### PR TITLE
feat: improve hero/banner editor with full-image mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,8 @@
 
 /* Variables de fuentes Geist (cargadas directamente para evitar problemas con Turbopack) */
 :root {
-  --font-geist-sans: 'Geist', system-ui, arial, sans-serif;
-  --font-geist-mono: 'Geist Mono', monospace;
+  --font-geist-sans: "Geist", system-ui, arial, sans-serif;
+  --font-geist-mono: "Geist Mono", monospace;
 }
 
 :root {
@@ -134,6 +134,28 @@
   }
 }
 
+/* Aíslan superficies admin de estilos storefront por tienda */
+@layer components {
+  .reposteria-store [data-admin-neutral="true"] {
+    font-family: var(--font-family-sans, var(--font-geist-sans), sans-serif);
+    color: var(--foreground);
+    letter-spacing: normal;
+  }
+
+  .reposteria-store [data-admin-neutral="true"] :is(h1, h2, h3, h4, h5, h6) {
+    font-family: inherit;
+    color: inherit;
+    letter-spacing: normal;
+  }
+
+  .reposteria-store
+    [data-admin-neutral="true"]
+    :is(button, input, textarea, select) {
+    font-family: inherit;
+    letter-spacing: normal;
+  }
+}
+
 /* Estilos personalizados para barras de desplazamiento */
 .custom-scrollbar {
   scrollbar-width: thin;
@@ -172,7 +194,7 @@
     min-height: 44px;
     min-width: 44px;
   }
-  
+
   /* Excepciones para elementos que no necesitan ser tan grandes */
   button.size-icon-sm,
   [role="button"].size-icon-sm {

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -61,11 +61,8 @@ const COMPONENT_FIELDS: Record<
         label: "Diseño del Banner",
         type: "select",
         options: [
-          { value: "split", label: "Split actual (texto + imagen lateral)" },
-          {
-            value: "full-image",
-            label: "Full image (imagen completa de fondo)",
-          },
+          { value: "split", label: "Split" },
+          { value: "full-image", label: "Full Image" },
         ],
       },
       {
@@ -1160,214 +1157,239 @@ export function EditorPanel() {
                 </p>
               </CardHeader>
               <CardContent className="space-y-4">
-                {config.content.map((field) => (
-                  <div key={field.key} className="space-y-2">
-                    {field.isArray ? (
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between mb-2 sticky top-0 bg-background z-10 py-2 -mx-2 px-2 border-b border-border">
-                          <Label className="font-semibold">{field.label}</Label>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              handleAddArrayItem(
-                                field.key,
-                                field.arrayFields || [],
-                              )
-                            }
-                            className="h-8"
-                          >
-                            <Plus className="h-3 w-3 mr-1" />
-                            Agregar
-                          </Button>
-                        </div>
-                        <div className="max-h-[400px] overflow-y-auto pr-2 space-y-3 custom-scrollbar">
-                          {(localValues[field.key] || []).map(
-                            (item: any, index: number) => (
-                              <Card key={index} className="mb-3">
-                                <CardHeader className="pb-3">
-                                  <div className="flex items-center justify-between">
-                                    <CardTitle className="text-sm">
-                                      Item {index + 1}
-                                    </CardTitle>
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() =>
-                                        handleRemoveArrayItem(field.key, index)
-                                      }
-                                      className="h-8 w-8 p-0 text-destructive hover:text-destructive"
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </Button>
-                                  </div>
-                                </CardHeader>
-                                <CardContent className="space-y-2">
-                                  {field.arrayFields?.map((subField) => (
-                                    <div
-                                      key={subField.key}
-                                      className="space-y-1"
-                                    >
-                                      {subField.type === "image" ||
-                                      subField.key
-                                        .toLowerCase()
-                                        .includes("image") ? (
-                                        <ImageUpload
-                                          value={item[subField.key] || ""}
-                                          onChange={(url) =>
-                                            handleArrayItemChange(
-                                              field.key,
-                                              index,
-                                              subField.key,
-                                              url,
-                                            )
-                                          }
-                                          label={subField.label}
-                                          context={`${selectedComponent}-${field.key}-${subField.key}-${index + 1}`}
-                                        />
-                                      ) : subField.type === "textarea" ? (
-                                        <>
-                                          <Label className="text-xs">
-                                            {subField.label}
-                                          </Label>
-                                          <Textarea
+                {config.content.map((field) => {
+                  const layoutModeValue =
+                    localValues.layoutMode ?? config.defaults?.layoutMode;
+                  const isHeroFullImageControl =
+                    selectedComponent === "hero" &&
+                    [
+                      "imageFit",
+                      "imagePositionX",
+                      "imagePositionY",
+                      "fullImageContentAlign",
+                    ].includes(field.key);
+
+                  if (
+                    isHeroFullImageControl &&
+                    layoutModeValue !== "full-image"
+                  ) {
+                    return null;
+                  }
+
+                  return (
+                    <div key={field.key} className="space-y-2">
+                      {field.isArray ? (
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between mb-2 sticky top-0 bg-background z-10 py-2 -mx-2 px-2 border-b border-border">
+                            <Label className="font-semibold">
+                              {field.label}
+                            </Label>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                handleAddArrayItem(
+                                  field.key,
+                                  field.arrayFields || [],
+                                )
+                              }
+                              className="h-8"
+                            >
+                              <Plus className="h-3 w-3 mr-1" />
+                              Agregar
+                            </Button>
+                          </div>
+                          <div className="max-h-[400px] overflow-y-auto pr-2 space-y-3 custom-scrollbar">
+                            {(localValues[field.key] || []).map(
+                              (item: any, index: number) => (
+                                <Card key={index} className="mb-3">
+                                  <CardHeader className="pb-3">
+                                    <div className="flex items-center justify-between">
+                                      <CardTitle className="text-sm">
+                                        Item {index + 1}
+                                      </CardTitle>
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() =>
+                                          handleRemoveArrayItem(
+                                            field.key,
+                                            index,
+                                          )
+                                        }
+                                        className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                                      >
+                                        <Trash2 className="h-4 w-4" />
+                                      </Button>
+                                    </div>
+                                  </CardHeader>
+                                  <CardContent className="space-y-2">
+                                    {field.arrayFields?.map((subField) => (
+                                      <div
+                                        key={subField.key}
+                                        className="space-y-1"
+                                      >
+                                        {subField.type === "image" ||
+                                        subField.key
+                                          .toLowerCase()
+                                          .includes("image") ? (
+                                          <ImageUpload
                                             value={item[subField.key] || ""}
-                                            onChange={(e) =>
+                                            onChange={(url) =>
                                               handleArrayItemChange(
                                                 field.key,
                                                 index,
                                                 subField.key,
-                                                e.target.value,
+                                                url,
                                               )
                                             }
-                                            rows={2}
+                                            label={subField.label}
+                                            context={`${selectedComponent}-${field.key}-${subField.key}-${index + 1}`}
                                           />
-                                        </>
-                                      ) : (
-                                        <>
-                                          <Label className="text-xs">
-                                            {subField.label}
-                                          </Label>
-                                          <Input
-                                            type={subField.type}
-                                            value={item[subField.key] || ""}
-                                            onChange={(e) => {
-                                              const value =
-                                                subField.type === "number"
-                                                  ? Number(e.target.value)
-                                                  : e.target.value;
-                                              handleArrayItemChange(
-                                                field.key,
-                                                index,
-                                                subField.key,
-                                                value,
-                                              );
-                                            }}
-                                          />
-                                        </>
-                                      )}
-                                    </div>
-                                  ))}
-                                </CardContent>
-                              </Card>
-                            ),
+                                        ) : subField.type === "textarea" ? (
+                                          <>
+                                            <Label className="text-xs">
+                                              {subField.label}
+                                            </Label>
+                                            <Textarea
+                                              value={item[subField.key] || ""}
+                                              onChange={(e) =>
+                                                handleArrayItemChange(
+                                                  field.key,
+                                                  index,
+                                                  subField.key,
+                                                  e.target.value,
+                                                )
+                                              }
+                                              rows={2}
+                                            />
+                                          </>
+                                        ) : (
+                                          <>
+                                            <Label className="text-xs">
+                                              {subField.label}
+                                            </Label>
+                                            <Input
+                                              type={subField.type}
+                                              value={item[subField.key] || ""}
+                                              onChange={(e) => {
+                                                const value =
+                                                  subField.type === "number"
+                                                    ? Number(e.target.value)
+                                                    : e.target.value;
+                                                handleArrayItemChange(
+                                                  field.key,
+                                                  index,
+                                                  subField.key,
+                                                  value,
+                                                );
+                                              }}
+                                            />
+                                          </>
+                                        )}
+                                      </div>
+                                    ))}
+                                  </CardContent>
+                                </Card>
+                              ),
+                            )}
+                          </div>
+                          {(!localValues[field.key] ||
+                            localValues[field.key].length === 0) && (
+                            <div className="text-center py-4 text-sm text-muted-foreground">
+                              No hay items. Haz clic en "Agregar" para crear uno
+                              nuevo.
+                            </div>
                           )}
                         </div>
-                        {(!localValues[field.key] ||
-                          localValues[field.key].length === 0) && (
-                          <div className="text-center py-4 text-sm text-muted-foreground">
-                            No hay items. Haz clic en "Agregar" para crear uno
-                            nuevo.
-                          </div>
-                        )}
-                      </div>
-                    ) : field.type === "select" && field.options ? (
-                      <>
-                        <Label htmlFor={field.key}>{field.label}</Label>
-                        <Select
-                          value={
-                            localValues[field.key] ||
-                            config.defaults?.[field.key]
-                          }
-                          onValueChange={(value) =>
-                            handleInputChange(field.key, value)
-                          }
-                        >
-                          <SelectTrigger id={field.key} className="w-full">
-                            <SelectValue
-                              placeholder={`Selecciona ${field.label.toLowerCase()}`}
-                            />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {field.options.map((option) => (
-                              <SelectItem
-                                key={option.value}
-                                value={option.value}
-                              >
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </>
-                    ) : field.type === "image" ||
-                      field.key.toLowerCase().includes("image") ? (
-                      <ImageUpload
-                        value={localValues[field.key] || ""}
-                        onChange={(url) => handleInputChange(field.key, url)}
-                        label={field.label}
-                        context={`${selectedComponent}-${field.key}`}
-                        // Configuración específica para logos
-                        recommendedWidth={
-                          field.key.toLowerCase().includes("logo")
-                            ? 240
-                            : undefined
-                        }
-                        recommendedHeight={
-                          field.key.toLowerCase().includes("logo")
-                            ? 80
-                            : undefined
-                        }
-                        fileTypes={
-                          field.key.toLowerCase().includes("logo")
-                            ? ["PNG", "SVG", "JPG", "WEBP"]
-                            : undefined
-                        }
-                        accept={
-                          field.key.toLowerCase().includes("logo")
-                            ? "image/png,image/svg+xml,image/jpeg,image/jpg,image/webp"
-                            : undefined
-                        }
-                      />
-                    ) : field.type === "textarea" ? (
-                      <>
-                        <Label htmlFor={field.key}>{field.label}</Label>
-                        <Textarea
-                          id={field.key}
+                      ) : field.type === "select" && field.options ? (
+                        <>
+                          <Label htmlFor={field.key}>{field.label}</Label>
+                          <Select
+                            value={
+                              localValues[field.key] ||
+                              config.defaults?.[field.key]
+                            }
+                            onValueChange={(value) =>
+                              handleInputChange(field.key, value)
+                            }
+                          >
+                            <SelectTrigger id={field.key} className="w-full">
+                              <SelectValue
+                                placeholder={`Selecciona ${field.label.toLowerCase()}`}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {field.options.map((option) => (
+                                <SelectItem
+                                  key={option.value}
+                                  value={option.value}
+                                >
+                                  {option.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </>
+                      ) : field.type === "image" ||
+                        field.key.toLowerCase().includes("image") ? (
+                        <ImageUpload
                           value={localValues[field.key] || ""}
-                          onChange={(e) =>
-                            handleInputChange(field.key, e.target.value)
+                          onChange={(url) => handleInputChange(field.key, url)}
+                          label={field.label}
+                          context={`${selectedComponent}-${field.key}`}
+                          // Configuración específica para logos
+                          recommendedWidth={
+                            field.key.toLowerCase().includes("logo")
+                              ? 240
+                              : undefined
                           }
-                          rows={3}
-                        />
-                      </>
-                    ) : (
-                      <>
-                        <Label htmlFor={field.key}>{field.label}</Label>
-                        <Input
-                          id={field.key}
-                          type={field.type}
-                          value={localValues[field.key] || ""}
-                          onChange={(e) =>
-                            handleInputChange(field.key, e.target.value)
+                          recommendedHeight={
+                            field.key.toLowerCase().includes("logo")
+                              ? 80
+                              : undefined
+                          }
+                          fileTypes={
+                            field.key.toLowerCase().includes("logo")
+                              ? ["PNG", "SVG", "JPG", "WEBP"]
+                              : undefined
+                          }
+                          accept={
+                            field.key.toLowerCase().includes("logo")
+                              ? "image/png,image/svg+xml,image/jpeg,image/jpg,image/webp"
+                              : undefined
                           }
                         />
-                      </>
-                    )}
-                  </div>
-                ))}
+                      ) : field.type === "textarea" ? (
+                        <>
+                          <Label htmlFor={field.key}>{field.label}</Label>
+                          <Textarea
+                            id={field.key}
+                            value={localValues[field.key] || ""}
+                            onChange={(e) =>
+                              handleInputChange(field.key, e.target.value)
+                            }
+                            rows={3}
+                          />
+                        </>
+                      ) : (
+                        <>
+                          <Label htmlFor={field.key}>{field.label}</Label>
+                          <Input
+                            id={field.key}
+                            type={field.type}
+                            value={localValues[field.key] || ""}
+                            onChange={(e) =>
+                              handleInputChange(field.key, e.target.value)
+                            }
+                          />
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
               </CardContent>
             </Card>
           </TabsContent>

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -1127,14 +1127,15 @@ export function EditorPanel() {
       )}
 
       <div
-        className="fixed right-0 top-0 h-screen w-full md:w-96 bg-background border-l border-border z-50 flex flex-col shadow-2xl"
+        className="fixed right-0 top-0 h-screen w-full md:w-96 bg-background text-foreground border-l border-border z-50 flex flex-col shadow-2xl font-sans"
         data-editor-panel={selectedComponent ? "open" : "closed"}
+        data-admin-neutral="true"
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
-          <h2 className="text-base md:text-lg font-semibold">
+          <div className="text-base md:text-lg font-semibold tracking-normal leading-tight">
             Editando: {componentLabel}
-          </h2>
+          </div>
           <Button
             variant="ghost"
             size="icon"
@@ -1181,7 +1182,6 @@ export function EditorPanel() {
           {/* Content Tab */}
           <TabsContent
             value="content"
-            forceMount
             className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar"
           >
             <Card>
@@ -1410,7 +1410,6 @@ export function EditorPanel() {
           {/* Styles Tab */}
           <TabsContent
             value="styles"
-            forceMount
             className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar"
           >
             <Card>

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -67,7 +67,7 @@ const COMPONENT_FIELDS: Record<
       },
       {
         key: "imageFit",
-        label: "Ajuste de Imagen (Full image)",
+        label: "Ajuste de Imagen",
         type: "select",
         options: [
           { value: "cover", label: "Cover (rellenar recortando)" },
@@ -76,7 +76,7 @@ const COMPONENT_FIELDS: Record<
       },
       {
         key: "imagePositionX",
-        label: "Posición Horizontal de Imagen (Full image)",
+        label: "Posición Horizontal de Imagen",
         type: "select",
         options: [
           { value: "left", label: "Izquierda" },
@@ -86,7 +86,7 @@ const COMPONENT_FIELDS: Record<
       },
       {
         key: "imagePositionY",
-        label: "Posición Vertical de Imagen (Full image)",
+        label: "Posición Vertical de Imagen",
         type: "select",
         options: [
           { value: "top", label: "Arriba" },
@@ -96,7 +96,7 @@ const COMPONENT_FIELDS: Record<
       },
       {
         key: "fullImageContentAlign",
-        label: "Alineación de Contenido (Full image)",
+        label: "Alineación de Contenido",
         type: "select",
         options: [
           { value: "left", label: "Izquierda" },

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -869,27 +869,6 @@ export function EditorPanel() {
       updateComponentEdit(selectedComponent, key, value);
     }
 
-    // Aplicar cambios en tiempo real para estilos (solo para colores)
-    if (isColorField) {
-      if (typeof document !== "undefined" && selectedComponent) {
-        const root = document.documentElement;
-        const cssVar = `--${selectedComponent}-${key.replace(/([A-Z])/g, "-$1").toLowerCase()}`;
-        root.style.setProperty(cssVar, value);
-
-        // También aplicar directamente al componente si es posible
-        const componentElement = document.querySelector(
-          `[data-component="${selectedComponent}"]`,
-        );
-        if (componentElement) {
-          if (key === "bgColor") {
-            (componentElement as HTMLElement).style.backgroundColor = value;
-          } else if (key === "textColor") {
-            (componentElement as HTMLElement).style.color = value;
-          }
-        }
-      }
-    }
-
     // Aplicar cambios en tiempo real para el fondo del sitio
     if (selectedComponent === "site_background") {
       if (typeof document !== "undefined") {

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -868,63 +868,6 @@ export function EditorPanel() {
     } else {
       updateComponentEdit(selectedComponent, key, value);
     }
-
-    // Aplicar cambios en tiempo real para el fondo del sitio
-    if (selectedComponent === "site_background") {
-      if (typeof document !== "undefined") {
-        const body = document.body;
-        const type = localValues.type || value;
-
-        if (key === "type") {
-          // Cuando cambia el tipo, aplicar la configuración completa
-          const bgType = value;
-          if (bgType === "color") {
-            body.style.backgroundColor =
-              localValues.backgroundColor || "#ffffff";
-            body.style.backgroundImage = "none";
-          } else if (bgType === "image" && localValues.backgroundImage) {
-            body.style.backgroundColor =
-              localValues.backgroundColor || "transparent";
-            body.style.backgroundImage = `url(${localValues.backgroundImage})`;
-            body.style.backgroundPosition =
-              localValues.backgroundPosition || "center";
-            body.style.backgroundRepeat =
-              localValues.backgroundRepeat || "no-repeat";
-            body.style.backgroundSize = localValues.backgroundSize || "cover";
-            body.style.backgroundAttachment = "fixed";
-          }
-        } else if (key === "backgroundColor") {
-          body.style.backgroundColor = value;
-          if (type === "image" && localValues.backgroundImage) {
-            // Mantener la imagen si existe
-            body.style.backgroundImage = `url(${localValues.backgroundImage})`;
-          }
-        } else if (key === "backgroundImage") {
-          if (value && type === "image") {
-            body.style.backgroundImage = `url(${value})`;
-            body.style.backgroundColor =
-              localValues.backgroundColor || "transparent";
-            body.style.backgroundPosition =
-              localValues.backgroundPosition || "center";
-            body.style.backgroundRepeat =
-              localValues.backgroundRepeat || "no-repeat";
-            body.style.backgroundSize = localValues.backgroundSize || "cover";
-            body.style.backgroundAttachment = "fixed";
-          } else {
-            body.style.backgroundImage = "none";
-          }
-        } else if (
-          key === "backgroundPosition" ||
-          key === "backgroundRepeat" ||
-          key === "backgroundSize"
-        ) {
-          if (type === "image" && localValues.backgroundImage) {
-            const styleKey = key.replace(/([A-Z])/g, "-$1").toLowerCase();
-            body.style.setProperty(styleKey, value as string);
-          }
-        }
-      }
-    }
   };
 
   const handleArrayItemChange = (

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -69,6 +69,45 @@ const COMPONENT_FIELDS: Record<
         ],
       },
       {
+        key: "imageFit",
+        label: "Ajuste de Imagen (Full image)",
+        type: "select",
+        options: [
+          { value: "cover", label: "Cover (rellenar recortando)" },
+          { value: "contain", label: "Contain (mostrar completa)" },
+        ],
+      },
+      {
+        key: "imagePositionX",
+        label: "Posición Horizontal de Imagen (Full image)",
+        type: "select",
+        options: [
+          { value: "left", label: "Izquierda" },
+          { value: "center", label: "Centro" },
+          { value: "right", label: "Derecha" },
+        ],
+      },
+      {
+        key: "imagePositionY",
+        label: "Posición Vertical de Imagen (Full image)",
+        type: "select",
+        options: [
+          { value: "top", label: "Arriba" },
+          { value: "center", label: "Centro" },
+          { value: "bottom", label: "Abajo" },
+        ],
+      },
+      {
+        key: "fullImageContentAlign",
+        label: "Alineación de Contenido (Full image)",
+        type: "select",
+        options: [
+          { value: "left", label: "Izquierda" },
+          { value: "center", label: "Centro" },
+          { value: "right", label: "Derecha" },
+        ],
+      },
+      {
         key: "products",
         label: "Productos del Carrusel",
         type: "array",
@@ -102,6 +141,10 @@ const COMPONENT_FIELDS: Record<
     ],
     defaults: {
       layoutMode: "split",
+      imageFit: "cover",
+      imagePositionX: "center",
+      imagePositionY: "center",
+      fullImageContentAlign: "left",
       products: [
         {
           label: "Electrónica",

--- a/components/admin/editor-panel.tsx
+++ b/components/admin/editor-panel.tsx
@@ -1,34 +1,73 @@
-"use client"
+"use client";
 
-import { useAdmin } from "@/contexts/admin-context"
-import { useStyles } from "@/contexts/styles-context"
-import { useStore } from "@/contexts/store-context"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Textarea } from "@/components/ui/textarea"
-import { X, Save, RotateCcw, Type, Palette, Plus, Trash2, Info } from "lucide-react"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Checkbox } from "@/components/ui/checkbox"
-import { useState, useEffect } from "react"
-import { updateComponentStyle } from "@/lib/supabase/styles-api"
-import { toast } from "sonner"
-import { ImageUpload } from "./image-upload"
-import { getStoreId } from "@/lib/utils/store"
-import { Alert, AlertDescription } from "@/components/ui/alert"
+import { useAdmin } from "@/contexts/admin-context";
+import { useStyles } from "@/contexts/styles-context";
+import { useStore } from "@/contexts/store-context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  X,
+  Save,
+  RotateCcw,
+  Type,
+  Palette,
+  Plus,
+  Trash2,
+  Info,
+} from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useState, useEffect } from "react";
+import { updateComponentStyle } from "@/lib/supabase/styles-api";
+import { toast } from "sonner";
+import { ImageUpload } from "./image-upload";
+import { getStoreId } from "@/lib/utils/store";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 const COMPONENT_FIELDS: Record<
   string,
   {
-    content: Array<{ key: string; label: string; type: string; isArray?: boolean; arrayFields?: any[] }>
-    styles: Array<{ key: string; label: string; type: string; options?: Array<{ value: string; label: string }> }>
-    defaults?: Record<string, any>
+    content: Array<{
+      key: string;
+      label: string;
+      type: string;
+      isArray?: boolean;
+      arrayFields?: any[];
+      options?: Array<{ value: string; label: string }>;
+    }>;
+    styles: Array<{
+      key: string;
+      label: string;
+      type: string;
+      options?: Array<{ value: string; label: string }>;
+    }>;
+    defaults?: Record<string, any>;
   }
 > = {
   hero: {
     content: [
+      {
+        key: "layoutMode",
+        label: "Diseño del Banner",
+        type: "select",
+        options: [
+          { value: "split", label: "Split actual (texto + imagen lateral)" },
+          {
+            value: "full-image",
+            label: "Full image (imagen completa de fondo)",
+          },
+        ],
+      },
       {
         key: "products",
         label: "Productos del Carrusel",
@@ -48,16 +87,28 @@ const COMPONENT_FIELDS: Record<
       { key: "bgColor", label: "Color de Fondo", type: "color" },
       { key: "textColor", label: "Color de Texto", type: "color" },
       { key: "buttonColor", label: "Color del Botón", type: "color" },
-      { key: "buttonTextColor", label: "Color del Texto del Botón", type: "color" },
+      {
+        key: "buttonTextColor",
+        label: "Color del Texto del Botón",
+        type: "color",
+      },
       { key: "barColor", label: "Color de la Barra Inferior", type: "color" },
+      { key: "overlayColor", label: "Color de Superposición", type: "color" },
+      {
+        key: "overlayOpacity",
+        label: "Opacidad de Superposición",
+        type: "text",
+      },
     ],
     defaults: {
+      layoutMode: "split",
       products: [
         {
           label: "Electrónica",
           title: "BALFE",
           subtitle: "NUEVO MODELO",
-          description: "Descubre la última tecnología en dispositivos electrónicos. Calidad premium y diseño innovador para una experiencia única.",
+          description:
+            "Descubre la última tecnología en dispositivos electrónicos. Calidad premium y diseño innovador para una experiencia única.",
           buttonText: "Comprar ahora",
           image: "/black-smart-speaker.jpg",
         },
@@ -65,7 +116,8 @@ const COMPONENT_FIELDS: Record<
           label: "Audio",
           title: "PREMIUM",
           subtitle: "HEADPHONES",
-          description: "Experimenta el sonido de alta calidad con nuestros auriculares premium. Diseño ergonómico y cancelación de ruido activa.",
+          description:
+            "Experimenta el sonido de alta calidad con nuestros auriculares premium. Diseño ergonómico y cancelación de ruido activa.",
           buttonText: "Ver más",
           image: "/premium-headphones.png",
         },
@@ -73,7 +125,8 @@ const COMPONENT_FIELDS: Record<
           label: "Accesorios",
           title: "LAPTOP STAND",
           subtitle: "ERGONÓMICO",
-          description: "Mejora tu espacio de trabajo con nuestro soporte para laptop. Diseño moderno y ajustable para mayor comodidad.",
+          description:
+            "Mejora tu espacio de trabajo con nuestro soporte para laptop. Diseño moderno y ajustable para mayor comodidad.",
           buttonText: "Comprar ahora",
           image: "/laptop-stand.png",
         },
@@ -81,7 +134,8 @@ const COMPONENT_FIELDS: Record<
           label: "Proyección",
           title: "MINI PROJECTOR",
           subtitle: "PORTÁTIL",
-          description: "Lleva el cine contigo. Proyector compacto con alta resolución y conectividad inalámbrica para tus presentaciones.",
+          description:
+            "Lleva el cine contigo. Proyector compacto con alta resolución y conectividad inalámbrica para tus presentaciones.",
           buttonText: "Descubrir",
           image: "/mini-projector.jpg",
         },
@@ -91,6 +145,8 @@ const COMPONENT_FIELDS: Record<
       buttonColor: "#005aa1",
       buttonTextColor: "#ffffff",
       barColor: "#005aa1",
+      overlayColor: "#101828",
+      overlayOpacity: "0.45",
     },
   },
   popular: {
@@ -115,13 +171,41 @@ const COMPONENT_FIELDS: Record<
     defaults: {
       title: "Lo más vendido",
       items: [
-        { title: "Bocinas Bluetooth", price: "Desde $356", image: "/bluetooth-speaker-modern.jpg" },
-        { title: "Auriculares y Audífonos", price: "Desde $29", image: "/premium-headphones.png" },
-        { title: "Soportes para Laptop", price: "Desde $82", image: "/laptop-stand.png" },
-        { title: "Proyectores", price: "Desde $199", image: "/mini-projector.jpg" },
-        { title: "Bocinas Inteligentes", price: "Desde $89", image: "/black-smart-speaker.jpg" },
-        { title: "Audífonos Inalámbricos", price: "Desde $45", image: "/green-earphones-product.jpg" },
-        { title: "Fundas para Teléfono", price: "Desde $25", image: "/modern-phone-case-product.jpg" },
+        {
+          title: "Bocinas Bluetooth",
+          price: "Desde $356",
+          image: "/bluetooth-speaker-modern.jpg",
+        },
+        {
+          title: "Auriculares y Audífonos",
+          price: "Desde $29",
+          image: "/premium-headphones.png",
+        },
+        {
+          title: "Soportes para Laptop",
+          price: "Desde $82",
+          image: "/laptop-stand.png",
+        },
+        {
+          title: "Proyectores",
+          price: "Desde $199",
+          image: "/mini-projector.jpg",
+        },
+        {
+          title: "Bocinas Inteligentes",
+          price: "Desde $89",
+          image: "/black-smart-speaker.jpg",
+        },
+        {
+          title: "Audífonos Inalámbricos",
+          price: "Desde $45",
+          image: "/green-earphones-product.jpg",
+        },
+        {
+          title: "Fundas para Teléfono",
+          price: "Desde $25",
+          image: "/modern-phone-case-product.jpg",
+        },
       ],
       bgColor: "#ffffff",
       textColor: "#1e354e",
@@ -150,9 +234,24 @@ const COMPONENT_FIELDS: Record<
     defaults: {
       title: "Productos populares",
       products: [
-        { name: "BeShow Volcano", category: "Proyectores", price: "$1,420.00", image: "/white-projector.jpg" },
-        { name: "Soporte para Laptop Desk MUO-g", category: "Soportes", price: "$82.00", image: "/laptop-stand.png" },
-        { name: "BeShow Volcano", category: "Proyectores", price: "$1,420.00", image: "/white-projector.jpg" },
+        {
+          name: "BeShow Volcano",
+          category: "Proyectores",
+          price: "$1,420.00",
+          image: "/white-projector.jpg",
+        },
+        {
+          name: "Soporte para Laptop Desk MUO-g",
+          category: "Soportes",
+          price: "$82.00",
+          image: "/laptop-stand.png",
+        },
+        {
+          name: "BeShow Volcano",
+          category: "Proyectores",
+          price: "$1,420.00",
+          image: "/white-projector.jpg",
+        },
       ],
       bgColor: "#ffffff",
       textColor: "#1e354e",
@@ -163,11 +262,31 @@ const COMPONENT_FIELDS: Record<
       { key: "title", label: "Título Principal", type: "text" },
       { key: "subtitle", label: "Subtítulo", type: "text" },
       { key: "linkText", label: "Texto del Enlace", type: "text" },
-      { key: "mainImage", label: "URL Imagen Principal (Banner)", type: "image" },
-      { key: "productName", label: "Nombre del Producto (Cuadro pequeño)", type: "text" },
-      { key: "originalPrice", label: "Precio Original (Cuadro pequeño)", type: "text" },
-      { key: "salePrice", label: "Precio de Oferta (Cuadro pequeño)", type: "text" },
-      { key: "productImage", label: "URL Imagen del Producto (Cuadro pequeño)", type: "image" },
+      {
+        key: "mainImage",
+        label: "URL Imagen Principal (Banner)",
+        type: "image",
+      },
+      {
+        key: "productName",
+        label: "Nombre del Producto (Cuadro pequeño)",
+        type: "text",
+      },
+      {
+        key: "originalPrice",
+        label: "Precio Original (Cuadro pequeño)",
+        type: "text",
+      },
+      {
+        key: "salePrice",
+        label: "Precio de Oferta (Cuadro pequeño)",
+        type: "text",
+      },
+      {
+        key: "productImage",
+        label: "URL Imagen del Producto (Cuadro pequeño)",
+        type: "image",
+      },
     ],
     styles: [
       { key: "bgColor", label: "Color de Fondo", type: "color" },
@@ -209,7 +328,8 @@ const COMPONENT_FIELDS: Record<
     ],
     defaults: {
       brandName: "Osoria",
-      copyrightText: "© 2025 Betheme by Muffin group | All Rights Reserved | Powered by WordPress",
+      copyrightText:
+        "© 2025 Betheme by Muffin group | All Rights Reserved | Powered by WordPress",
       bgColor: "#ffffff",
       textColor: "#666666",
     },
@@ -218,23 +338,79 @@ const COMPONENT_FIELDS: Record<
     content: [
       { key: "brandName", label: "Nombre de la Marca", type: "text" },
       { key: "logoImage", label: "Logo de la Empresa", type: "image" },
-      { key: "logoImageDark", label: "Logo para Tema Oscuro (opcional)", type: "image" },
+      {
+        key: "logoImageDark",
+        label: "Logo para Tema Oscuro (opcional)",
+        type: "image",
+      },
     ],
     styles: [
       { key: "bgColor", label: "Color de Fondo del Header", type: "color" },
-      { key: "bannerBgColor", label: "Color de Fondo del Banner", type: "color" },
-      { key: "bannerTextColor", label: "Color de Texto del Banner", type: "color" },
-      { key: "menuButtonColor", label: "Color del Botón de Menú", type: "color" },
-      { key: "menuButtonHoverBg", label: "Color de Fondo Hover del Botón de Menú", type: "color" },
-      { key: "loginButtonColor", label: "Color del Botón de Iniciar Sesión", type: "color" },
-      { key: "loginButtonHoverBg", label: "Color de Fondo Hover del Botón de Iniciar Sesión", type: "color" },
-      { key: "iconColor", label: "Color de los Iconos (Corazón, Carrito, etc.)", type: "color" },
-      { key: "iconHoverBg", label: "Color de Fondo Hover de los Iconos", type: "color" },
-      { key: "searchIconColor", label: "Color del Icono de Búsqueda", type: "color" },
-      { key: "searchBgColor", label: "Color de Fondo del Buscador", type: "color" },
-      { key: "searchTextColor", label: "Color del Texto del Buscador", type: "color" },
-      { key: "searchBorderColor", label: "Color del Borde del Buscador", type: "color" },
-      { key: "linkColor", label: "Color de Enlaces de Navegación", type: "color" },
+      {
+        key: "bannerBgColor",
+        label: "Color de Fondo del Banner",
+        type: "color",
+      },
+      {
+        key: "bannerTextColor",
+        label: "Color de Texto del Banner",
+        type: "color",
+      },
+      {
+        key: "menuButtonColor",
+        label: "Color del Botón de Menú",
+        type: "color",
+      },
+      {
+        key: "menuButtonHoverBg",
+        label: "Color de Fondo Hover del Botón de Menú",
+        type: "color",
+      },
+      {
+        key: "loginButtonColor",
+        label: "Color del Botón de Iniciar Sesión",
+        type: "color",
+      },
+      {
+        key: "loginButtonHoverBg",
+        label: "Color de Fondo Hover del Botón de Iniciar Sesión",
+        type: "color",
+      },
+      {
+        key: "iconColor",
+        label: "Color de los Iconos (Corazón, Carrito, etc.)",
+        type: "color",
+      },
+      {
+        key: "iconHoverBg",
+        label: "Color de Fondo Hover de los Iconos",
+        type: "color",
+      },
+      {
+        key: "searchIconColor",
+        label: "Color del Icono de Búsqueda",
+        type: "color",
+      },
+      {
+        key: "searchBgColor",
+        label: "Color de Fondo del Buscador",
+        type: "color",
+      },
+      {
+        key: "searchTextColor",
+        label: "Color del Texto del Buscador",
+        type: "color",
+      },
+      {
+        key: "searchBorderColor",
+        label: "Color del Borde del Buscador",
+        type: "color",
+      },
+      {
+        key: "linkColor",
+        label: "Color de Enlaces de Navegación",
+        type: "color",
+      },
     ],
     defaults: {
       brandName: "Osoria",
@@ -272,7 +448,8 @@ const COMPONENT_FIELDS: Record<
     ],
     defaults: {
       title: "Sobre Nosotros",
-      description: "Somos una pastelería artesanal dedicada a crear los más deliciosos pasteles, postres y dulces. Cada producto está hecho con ingredientes de la más alta calidad y mucho amor, para que puedas disfrutar de momentos especiales con cada bocado.",
+      description:
+        "Somos una pastelería artesanal dedicada a crear los más deliciosos pasteles, postres y dulces. Cada producto está hecho con ingredientes de la más alta calidad y mucho amor, para que puedas disfrutar de momentos especiales con cada bocado.",
     },
   },
   gallery: {
@@ -298,74 +475,75 @@ const COMPONENT_FIELDS: Record<
     ],
     defaults: {
       title: "Nuestro Mundo Dulce",
-      description: "Descubre la creatividad y el arte detrás de cada producto que preparamos con amor",
+      description:
+        "Descubre la creatividad y el arte detrás de cada producto que preparamos con amor",
       images: [
         {
           src: "/reposteria/cupcakes-decorados.jpg",
           alt: "Cupcakes decorados con sprinkles en colores pastel - azul, amarillo y rosa",
           title: "Cupcakes Decorados",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/tarta-berries.jpg",
           alt: "Tarta de frutas con berries frescos, azúcar glass y menta",
           title: "Tarta de Berries",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/macarons-colores.jpg",
           alt: "Macarons en colores pastel - verde, rosa, amarillo y blanco",
           title: "Macarons Artesanales",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/mini-cakes-cheesecakes.jpg",
           alt: "Mini cakes y cheesecakes decorados con berries, chocolate y caramelo",
           title: "Mini Cakes y Cheesecakes",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/galletas-chocolate.jpg",
           alt: "Galletas de chocolate chip caseras",
           title: "Galletas de Chocolate",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/pastel-cumpleanos.jpg",
           alt: "Pastel de cumpleaños decorado con temática festiva y colorida",
           title: "Pasteles de Cumpleaños",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/pastel-boda.jpg",
           alt: "Pastel de boda estilo naked cake decorado con flores frescas",
           title: "Pasteles de Boda",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/herramientas-decoracion.jpg",
           alt: "Herramientas de decoración de pasteles - boquillas, pinceles y fondant",
           title: "Herramientas de Decoración",
-          category: "Accesorios"
+          category: "Accesorios",
         },
         {
           src: "/reposteria/sprinkles-candies.jpg",
           alt: "Sprinkles y candies coloridos para decorar postres",
           title: "Sprinkles y Candies",
-          category: "Decoraciones"
+          category: "Decoraciones",
         },
         {
           src: "/reposteria/chocolates-truffles.jpg",
           alt: "Deliciosos chocolates y truffles artesanales",
           title: "Chocolates Artesanales",
-          category: "Productos"
+          category: "Productos",
         },
         {
           src: "/reposteria/empaque-presentacion.jpg",
           alt: "Elementos de empaque y presentación para productos de repostería",
           title: "Empaque y Presentación",
-          category: "Accesorios"
-        }
+          category: "Accesorios",
+        },
       ],
     },
   },
@@ -397,7 +575,11 @@ const COMPONENT_FIELDS: Record<
   testimonials: {
     content: [
       { key: "title", label: "Título de la Sección", type: "textarea" },
-      { key: "description", label: "Descripción de la Sección", type: "textarea" },
+      {
+        key: "description",
+        label: "Descripción de la Sección",
+        type: "textarea",
+      },
       {
         key: "testimonials",
         label: "Testimonios",
@@ -439,20 +621,20 @@ const COMPONENT_FIELDS: Record<
   site_background: {
     content: [],
     styles: [
-      { 
-        key: "type", 
-        label: "Tipo de Fondo", 
+      {
+        key: "type",
+        label: "Tipo de Fondo",
         type: "select",
         options: [
           { value: "color", label: "Color" },
           { value: "image", label: "Imagen" },
-        ]
+        ],
       },
       { key: "backgroundColor", label: "Color de Fondo", type: "color" },
       { key: "backgroundImage", label: "Imagen de Fondo", type: "image" },
-      { 
-        key: "backgroundPosition", 
-        label: "Posición de la Imagen", 
+      {
+        key: "backgroundPosition",
+        label: "Posición de la Imagen",
         type: "select",
         options: [
           { value: "center", label: "Centro" },
@@ -464,29 +646,29 @@ const COMPONENT_FIELDS: Record<
           { value: "top right", label: "Superior Derecha" },
           { value: "bottom left", label: "Inferior Izquierda" },
           { value: "bottom right", label: "Inferior Derecha" },
-        ]
+        ],
       },
-      { 
-        key: "backgroundRepeat", 
-        label: "Repetición", 
+      {
+        key: "backgroundRepeat",
+        label: "Repetición",
         type: "select",
         options: [
           { value: "no-repeat", label: "No repetir" },
           { value: "repeat", label: "Repetir" },
           { value: "repeat-x", label: "Repetir horizontal" },
           { value: "repeat-y", label: "Repetir vertical" },
-        ]
+        ],
       },
-      { 
-        key: "backgroundSize", 
-        label: "Tamaño", 
+      {
+        key: "backgroundSize",
+        label: "Tamaño",
         type: "select",
         options: [
           { value: "cover", label: "Cubrir (cover)" },
           { value: "contain", label: "Contener (contain)" },
           { value: "auto", label: "Automático" },
           { value: "100% 100%", label: "Estirar" },
-        ]
+        ],
       },
     ],
     defaults: {
@@ -498,74 +680,91 @@ const COMPONENT_FIELDS: Record<
       backgroundSize: "cover",
     },
   },
-}
+};
 
 export function EditorPanel() {
-  const { selectedComponent, selectComponent, componentEdits, updateComponentEdit, clearComponentEdits, isEditMode, toggleEditMode } = useAdmin()
-  const { styles: globalStyles, refreshStyles } = useStyles()
-  const { store } = useStore()
-  const [saving, setSaving] = useState(false)
-  const [localValues, setLocalValues] = useState<Record<string, any>>({})
-  const [activeTab, setActiveTab] = useState("content")
-  
+  const {
+    selectedComponent,
+    selectComponent,
+    componentEdits,
+    updateComponentEdit,
+    scheduleComponentEdit,
+    flushScheduledEdits,
+    clearComponentEdits,
+    getComponentEditsSnapshot,
+    isEditMode,
+    toggleEditMode,
+  } = useAdmin();
+  const { styles: globalStyles, refreshStyles } = useStyles();
+  const { store } = useStore();
+  const [saving, setSaving] = useState(false);
+  const [localValues, setLocalValues] = useState<Record<string, any>>({});
+  const [activeTab, setActiveTab] = useState("content");
+
   // Verificar si estamos editando Hero desde un subdominio que no sea default
-  const isEditingHeroFromSubdomain = selectedComponent === "hero" && store?.subdomain && store.subdomain !== "default"
+  const isEditingHeroFromSubdomain =
+    selectedComponent === "hero" &&
+    store?.subdomain &&
+    store.subdomain !== "default";
 
   // Función para cerrar completamente el panel
   // Siempre cierra el modo de edición completamente, no solo deselecciona el componente
   const handleClosePanel = () => {
-    toggleEditMode()
-  }
+    toggleEditMode();
+  };
 
   // Efecto para cargar valores iniciales cuando cambia el componente seleccionado
   // NO incluir componentEdits en las dependencias para evitar bucles infinitos
   useEffect(() => {
     if (selectedComponent) {
-      const config = COMPONENT_FIELDS[selectedComponent]
+      const config = COMPONENT_FIELDS[selectedComponent];
       if (!config) {
-        console.warn("[Editor] No config found for component:", selectedComponent)
-        return
+        console.warn(
+          "[Editor] No config found for component:",
+          selectedComponent,
+        );
+        return;
       }
-      
-      const currentStyles = globalStyles.get(selectedComponent) || {}
-      const edits = componentEdits.get(selectedComponent) || {}
+
+      const currentStyles = globalStyles.get(selectedComponent) || {};
+      const edits = componentEdits.get(selectedComponent) || {};
 
       // Combinar valores: defaults primero, luego estilos de BD, luego ediciones locales
       const mergedValues = {
         ...(config?.defaults || {}),
         ...currentStyles,
         ...edits,
-      }
+      };
 
       // Solo actualizar si los valores realmente cambiaron para evitar bucles infinitos
       setLocalValues((prev) => {
-        const prevStr = JSON.stringify(prev)
-        const newStr = JSON.stringify(mergedValues)
+        const prevStr = JSON.stringify(prev);
+        const newStr = JSON.stringify(mergedValues);
         if (prevStr === newStr) {
-          return prev // No actualizar si son iguales
+          return prev; // No actualizar si son iguales
         }
-        return mergedValues
-      })
-      
+        return mergedValues;
+      });
+
       console.log("[Editor] Loaded values for", selectedComponent, {
         defaults: config?.defaults,
         fromDB: currentStyles,
         edits: edits,
-        merged: mergedValues
-      })
+        merged: mergedValues,
+      });
     } else {
       // Limpiar valores cuando no hay componente seleccionado
-      setLocalValues({})
+      setLocalValues({});
     }
     // Solo actualizar cuando cambia el componente seleccionado o los estilos globales
     // NO incluir componentEdits para evitar bucles infinitos
     // Los cambios en componentEdits se manejan directamente en handleInputChange
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedComponent, globalStyles])
+  }, [selectedComponent, globalStyles]);
 
   // No mostrar el panel si no está en modo edición (después de todos los hooks)
   if (!isEditMode) {
-    return null
+    return null;
   }
 
   if (!selectedComponent) {
@@ -573,10 +772,12 @@ export function EditorPanel() {
       <div className="fixed right-0 top-0 h-screen w-full md:w-96 bg-background border-l border-border z-50 flex flex-col shadow-2xl">
         {/* Header con botón de cierre */}
         <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
-          <h2 className="text-base md:text-lg font-semibold">Editor de Componentes</h2>
-          <Button 
-            variant="ghost" 
-            size="icon" 
+          <h2 className="text-base md:text-lg font-semibold">
+            Editor de Componentes
+          </h2>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => toggleEditMode()}
             className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
             aria-label="Cerrar panel de edición"
@@ -588,7 +789,9 @@ export function EditorPanel() {
         {/* Contenido centrado */}
         <div className="flex-1 flex flex-col items-center justify-center p-8 gap-4">
           <div className="text-center text-muted-foreground">
-            <p className="text-xs md:text-sm mb-4">Haz clic en cualquier sección de la página para editarla</p>
+            <p className="text-xs md:text-sm mb-4">
+              Haz clic en cualquier sección de la página para editarla
+            </p>
           </div>
           {/* Botón para configurar fondo del sitio */}
           <Button
@@ -601,15 +804,15 @@ export function EditorPanel() {
           </Button>
         </div>
       </div>
-    )
+    );
   }
 
-  const config = COMPONENT_FIELDS[selectedComponent]
+  const config = COMPONENT_FIELDS[selectedComponent];
   if (!config) {
     return (
       <>
         {/* Overlay oscuro en móviles */}
-        <div 
+        <div
           className="fixed inset-0 bg-black/50 z-40 md:hidden"
           onClick={handleClosePanel}
           aria-label="Cerrar panel"
@@ -617,10 +820,12 @@ export function EditorPanel() {
         <div className="fixed right-0 top-0 h-screen w-full md:w-96 bg-background border-l border-border z-50 flex flex-col shadow-2xl">
           {/* Header con botón de cierre */}
           <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
-            <h2 className="text-base md:text-lg font-semibold">Componente no configurado</h2>
-            <Button 
-              variant="ghost" 
-              size="icon" 
+            <h2 className="text-base md:text-lg font-semibold">
+              Componente no configurado
+            </h2>
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={handleClosePanel}
               className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
               aria-label="Cerrar panel de edición"
@@ -632,262 +837,307 @@ export function EditorPanel() {
           {/* Contenido centrado */}
           <div className="flex-1 flex items-center justify-center p-8">
             <div className="text-center text-muted-foreground">
-              <p className="text-xs md:text-sm">Este componente no tiene configuración de edición</p>
+              <p className="text-xs md:text-sm">
+                Este componente no tiene configuración de edición
+              </p>
             </div>
           </div>
         </div>
       </>
-    )
+    );
   }
 
-  const componentLabel = selectedComponent.charAt(0).toUpperCase() + selectedComponent.slice(1)
+  const componentLabel =
+    selectedComponent.charAt(0).toUpperCase() + selectedComponent.slice(1);
 
   const handleInputChange = (key: string, value: any) => {
     // Actualizar estado local de forma optimista
     setLocalValues((prev) => {
       // Solo actualizar si el valor realmente cambió
       if (prev[key] === value) {
-        return prev
+        return prev;
       }
-      return { ...prev, [key]: value }
-    })
-    
-    // Actualizar ediciones en el contexto (esto puede disparar efectos, pero no debe causar bucles)
-    updateComponentEdit(selectedComponent, key, value)
-    
+      return { ...prev, [key]: value };
+    });
+
+    const isColorField =
+      key === "bgColor" || key === "textColor" || key.includes("Color");
+
+    if (isColorField) {
+      scheduleComponentEdit(selectedComponent, key, value);
+    } else {
+      updateComponentEdit(selectedComponent, key, value);
+    }
+
     // Aplicar cambios en tiempo real para estilos (solo para colores)
-    if (key === "bgColor" || key === "textColor" || key.includes("Color")) {
+    if (isColorField) {
       if (typeof document !== "undefined" && selectedComponent) {
-        const root = document.documentElement
-        const cssVar = `--${selectedComponent}-${key.replace(/([A-Z])/g, "-$1").toLowerCase()}`
-        root.style.setProperty(cssVar, value)
-        
+        const root = document.documentElement;
+        const cssVar = `--${selectedComponent}-${key.replace(/([A-Z])/g, "-$1").toLowerCase()}`;
+        root.style.setProperty(cssVar, value);
+
         // También aplicar directamente al componente si es posible
-        const componentElement = document.querySelector(`[data-component="${selectedComponent}"]`)
+        const componentElement = document.querySelector(
+          `[data-component="${selectedComponent}"]`,
+        );
         if (componentElement) {
           if (key === "bgColor") {
-            ;(componentElement as HTMLElement).style.backgroundColor = value
+            (componentElement as HTMLElement).style.backgroundColor = value;
           } else if (key === "textColor") {
-            ;(componentElement as HTMLElement).style.color = value
+            (componentElement as HTMLElement).style.color = value;
           }
         }
       }
     }
-    
+
     // Aplicar cambios en tiempo real para el fondo del sitio
     if (selectedComponent === "site_background") {
       if (typeof document !== "undefined") {
-        const body = document.body
-        const type = localValues.type || value
-        
+        const body = document.body;
+        const type = localValues.type || value;
+
         if (key === "type") {
           // Cuando cambia el tipo, aplicar la configuración completa
-          const bgType = value
+          const bgType = value;
           if (bgType === "color") {
-            body.style.backgroundColor = localValues.backgroundColor || "#ffffff"
-            body.style.backgroundImage = "none"
+            body.style.backgroundColor =
+              localValues.backgroundColor || "#ffffff";
+            body.style.backgroundImage = "none";
           } else if (bgType === "image" && localValues.backgroundImage) {
-            body.style.backgroundColor = localValues.backgroundColor || "transparent"
-            body.style.backgroundImage = `url(${localValues.backgroundImage})`
-            body.style.backgroundPosition = localValues.backgroundPosition || "center"
-            body.style.backgroundRepeat = localValues.backgroundRepeat || "no-repeat"
-            body.style.backgroundSize = localValues.backgroundSize || "cover"
-            body.style.backgroundAttachment = "fixed"
+            body.style.backgroundColor =
+              localValues.backgroundColor || "transparent";
+            body.style.backgroundImage = `url(${localValues.backgroundImage})`;
+            body.style.backgroundPosition =
+              localValues.backgroundPosition || "center";
+            body.style.backgroundRepeat =
+              localValues.backgroundRepeat || "no-repeat";
+            body.style.backgroundSize = localValues.backgroundSize || "cover";
+            body.style.backgroundAttachment = "fixed";
           }
         } else if (key === "backgroundColor") {
-          body.style.backgroundColor = value
+          body.style.backgroundColor = value;
           if (type === "image" && localValues.backgroundImage) {
             // Mantener la imagen si existe
-            body.style.backgroundImage = `url(${localValues.backgroundImage})`
+            body.style.backgroundImage = `url(${localValues.backgroundImage})`;
           }
         } else if (key === "backgroundImage") {
           if (value && type === "image") {
-            body.style.backgroundImage = `url(${value})`
-            body.style.backgroundColor = localValues.backgroundColor || "transparent"
-            body.style.backgroundPosition = localValues.backgroundPosition || "center"
-            body.style.backgroundRepeat = localValues.backgroundRepeat || "no-repeat"
-            body.style.backgroundSize = localValues.backgroundSize || "cover"
-            body.style.backgroundAttachment = "fixed"
+            body.style.backgroundImage = `url(${value})`;
+            body.style.backgroundColor =
+              localValues.backgroundColor || "transparent";
+            body.style.backgroundPosition =
+              localValues.backgroundPosition || "center";
+            body.style.backgroundRepeat =
+              localValues.backgroundRepeat || "no-repeat";
+            body.style.backgroundSize = localValues.backgroundSize || "cover";
+            body.style.backgroundAttachment = "fixed";
           } else {
-            body.style.backgroundImage = "none"
+            body.style.backgroundImage = "none";
           }
-        } else if (key === "backgroundPosition" || key === "backgroundRepeat" || key === "backgroundSize") {
+        } else if (
+          key === "backgroundPosition" ||
+          key === "backgroundRepeat" ||
+          key === "backgroundSize"
+        ) {
           if (type === "image" && localValues.backgroundImage) {
-            const styleKey = key.replace(/([A-Z])/g, "-$1").toLowerCase()
-            body.style.setProperty(styleKey, value as string)
+            const styleKey = key.replace(/([A-Z])/g, "-$1").toLowerCase();
+            body.style.setProperty(styleKey, value as string);
           }
         }
       }
     }
-  }
+  };
 
-  const handleArrayItemChange = (arrayKey: string, index: number, fieldKey: string, value: any) => {
-    const currentArray = localValues[arrayKey] || []
-    const updatedArray = [...currentArray]
-    updatedArray[index] = { ...updatedArray[index], [fieldKey]: value }
-    handleInputChange(arrayKey, updatedArray)
-  }
+  const handleArrayItemChange = (
+    arrayKey: string,
+    index: number,
+    fieldKey: string,
+    value: any,
+  ) => {
+    const currentArray = localValues[arrayKey] || [];
+    const updatedArray = [...currentArray];
+    updatedArray[index] = { ...updatedArray[index], [fieldKey]: value };
+    handleInputChange(arrayKey, updatedArray);
+  };
 
   const handleAddArrayItem = (arrayKey: string, arrayFields: any[]) => {
-    const currentArray = localValues[arrayKey] || []
-    const newItem: Record<string, any> = {}
+    const currentArray = localValues[arrayKey] || [];
+    const newItem: Record<string, any> = {};
     arrayFields.forEach((field) => {
-      newItem[field.key] = ""
-    })
-    handleInputChange(arrayKey, [...currentArray, newItem])
-  }
+      newItem[field.key] = "";
+    });
+    handleInputChange(arrayKey, [...currentArray, newItem]);
+  };
 
   const handleRemoveArrayItem = (arrayKey: string, index: number) => {
-    const currentArray = localValues[arrayKey] || []
-    const updatedArray = currentArray.filter((_: any, i: number) => i !== index)
-    handleInputChange(arrayKey, updatedArray)
-  }
+    const currentArray = localValues[arrayKey] || [];
+    const updatedArray = currentArray.filter(
+      (_: any, i: number) => i !== index,
+    );
+    handleInputChange(arrayKey, updatedArray);
+  };
 
   const handleSave = async () => {
-    setSaving(true)
+    setSaving(true);
     try {
-      const edits = componentEdits.get(selectedComponent) || {}
-      
+      const edits = getComponentEditsSnapshot(selectedComponent);
+      flushScheduledEdits(selectedComponent);
+
       if (Object.keys(edits).length === 0) {
-        toast.info("No hay cambios para guardar")
-        setSaving(false)
-        return
+        toast.info("No hay cambios para guardar");
+        setSaving(false);
+        return;
       }
 
-      console.log("[Editor] Guardando cambios para", selectedComponent, edits)
-      
+      console.log("[Editor] Guardando cambios para", selectedComponent, edits);
+
       // Obtener estilos actuales de la BD
-      const currentStyles = globalStyles.get(selectedComponent) || {}
-      
+      const currentStyles = globalStyles.get(selectedComponent) || {};
+
       // Combinar estilos actuales con las ediciones
       // Los edits tienen prioridad sobre los estilos actuales
       const mergedStyles = {
         ...currentStyles,
         ...edits,
-      }
-      
-      console.log("[Editor] Estilos combinados a guardar:", mergedStyles)
-      console.log("[Editor] Campos a guardar:", Object.keys(mergedStyles))
-      
+      };
+
+      console.log("[Editor] Estilos combinados a guardar:", mergedStyles);
+      console.log("[Editor] Campos a guardar:", Object.keys(mergedStyles));
+
       // Guardar en Supabase
-      const result = await updateComponentStyle(selectedComponent, mergedStyles)
-      
-      console.log("[Editor] Resultado del guardado:", result)
-      
+      const result = await updateComponentStyle(
+        selectedComponent,
+        mergedStyles,
+      );
+
+      console.log("[Editor] Resultado del guardado:", result);
+
       // Refrescar estilos desde Supabase para asegurar sincronización
-      await refreshStyles()
-      
+      await refreshStyles();
+
       // Actualizar localStorage inmediatamente (con store_id)
       try {
         // Para Hero, siempre usar el store_id del store por defecto
-        let storeId: string | null = null
+        let storeId: string | null = null;
         if (selectedComponent === "hero") {
           // Obtener el store_id del store por defecto desde Supabase
-          const supabase = (await import("@/lib/supabase/client")).getSupabaseBrowserClient()
+          const supabase = (
+            await import("@/lib/supabase/client")
+          ).getSupabaseBrowserClient();
           if (supabase) {
             const { data: defaultStore } = await supabase
               .from("stores")
               .select("id")
               .eq("subdomain", "default")
-              .single()
-            
+              .single();
+
             if (defaultStore?.id) {
-              storeId = defaultStore.id
+              storeId = defaultStore.id;
             }
           }
         } else {
           // Para otros componentes, usar el store_id actual
-          storeId = await getStoreId()
+          storeId = await getStoreId();
         }
-        
+
         if (storeId) {
-          const storageKey = `osoria_component_styles_${storeId}`
-          const savedStyles = localStorage.getItem(storageKey)
-          const styles = savedStyles ? JSON.parse(savedStyles) : {}
-          styles[selectedComponent] = mergedStyles
-          localStorage.setItem(storageKey, JSON.stringify(styles))
+          const storageKey = `osoria_component_styles_${storeId}`;
+          const savedStyles = localStorage.getItem(storageKey);
+          const styles = savedStyles ? JSON.parse(savedStyles) : {};
+          styles[selectedComponent] = mergedStyles;
+          localStorage.setItem(storageKey, JSON.stringify(styles));
           // Solo actualizar osoria_current_store_id si no es Hero
           if (selectedComponent !== "hero") {
-            localStorage.setItem("osoria_current_store_id", storeId)
+            localStorage.setItem("osoria_current_store_id", storeId);
           }
         }
-        
+
         // Aplicar estilos inmediatamente al DOM
         if (typeof document !== "undefined") {
-          const root = document.documentElement
+          const root = document.documentElement;
           Object.keys(mergedStyles).forEach((key) => {
-            if (key === "bgColor" || key === "textColor" || key.includes("Color")) {
-              const cssVar = `--${selectedComponent}-${key.replace(/([A-Z])/g, "-$1").toLowerCase()}`
-              root.style.setProperty(cssVar, mergedStyles[key])
-              
+            if (
+              key === "bgColor" ||
+              key === "textColor" ||
+              key.includes("Color")
+            ) {
+              const cssVar = `--${selectedComponent}-${key.replace(/([A-Z])/g, "-$1").toLowerCase()}`;
+              root.style.setProperty(cssVar, mergedStyles[key]);
+
               // También aplicar directamente al componente
-              const componentElement = document.querySelector(`[data-component="${selectedComponent}"]`)
+              const componentElement = document.querySelector(
+                `[data-component="${selectedComponent}"]`,
+              );
               if (componentElement) {
                 if (key === "bgColor") {
-                  ;(componentElement as HTMLElement).style.backgroundColor = mergedStyles[key]
+                  (componentElement as HTMLElement).style.backgroundColor =
+                    mergedStyles[key];
                 } else if (key === "textColor") {
-                  ;(componentElement as HTMLElement).style.color = mergedStyles[key]
+                  (componentElement as HTMLElement).style.color =
+                    mergedStyles[key];
                 }
               }
             }
-          })
+          });
         }
       } catch (e) {
-        console.warn("[Editor] Error saving to localStorage:", e)
+        console.warn("[Editor] Error saving to localStorage:", e);
       }
-      
-      toast.success("Cambios guardados correctamente")
-      clearComponentEdits(selectedComponent)
-      
+
+      toast.success("Cambios guardados correctamente");
+      clearComponentEdits(selectedComponent);
+
       // Forzar re-render del componente actualizando localValues
-      const config = COMPONENT_FIELDS[selectedComponent]
-      const updatedStyles = globalStyles.get(selectedComponent) || {}
+      const config = COMPONENT_FIELDS[selectedComponent];
+      const updatedStyles = globalStyles.get(selectedComponent) || {};
       setLocalValues({
         ...(config?.defaults || {}),
         ...updatedStyles,
-      })
+      });
     } catch (error) {
-      toast.error("Error al guardar los cambios")
-      console.error("[Editor] Error completo:", error)
+      toast.error("Error al guardar los cambios");
+      console.error("[Editor] Error completo:", error);
       if (error instanceof Error) {
-        console.error("[Editor] Mensaje:", error.message)
-        console.error("[Editor] Stack:", error.stack)
+        console.error("[Editor] Mensaje:", error.message);
+        console.error("[Editor] Stack:", error.stack);
       }
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
-  }
+  };
 
   const handleReset = () => {
-    const currentStyles = globalStyles.get(selectedComponent) || {}
-    setLocalValues(currentStyles)
-    clearComponentEdits(selectedComponent)
-    toast.info("Cambios descartados")
-  }
+    const currentStyles = globalStyles.get(selectedComponent) || {};
+    setLocalValues(currentStyles);
+    clearComponentEdits(selectedComponent);
+    toast.info("Cambios descartados");
+  };
 
-  const hasChanges = componentEdits.has(selectedComponent)
+  const hasChanges = componentEdits.has(selectedComponent);
 
   return (
     <>
       {/* Overlay oscuro en móviles */}
       {selectedComponent && (
-        <div 
+        <div
           className="fixed inset-0 bg-black/50 z-40 md:hidden"
           onClick={handleClosePanel}
           aria-label="Cerrar panel"
         />
       )}
-      
-      <div 
+
+      <div
         className="fixed right-0 top-0 h-screen w-full md:w-96 bg-background border-l border-border z-50 flex flex-col shadow-2xl"
         data-editor-panel={selectedComponent ? "open" : "closed"}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
-          <h2 className="text-base md:text-lg font-semibold">Editando: {componentLabel}</h2>
-          <Button 
-            variant="ghost" 
-            size="icon" 
+          <h2 className="text-base md:text-lg font-semibold">
+            Editando: {componentLabel}
+          </h2>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={handleClosePanel}
             className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
             aria-label="Cerrar panel de edición"
@@ -903,273 +1153,453 @@ export function EditorPanel() {
             <Alert className="bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
               <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
               <AlertDescription className="text-sm text-blue-800 dark:text-blue-200">
-                El componente Hero solo se puede editar en la página por defecto. Los cambios se guardarán para la tienda principal, no para este subdominio ({store?.subdomain}).
+                El componente Hero solo se puede editar en la página por
+                defecto. Los cambios se guardarán para la tienda principal, no
+                para este subdominio ({store?.subdomain}).
               </AlertDescription>
             </Alert>
           </div>
         )}
 
-      {/* Tabs */}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col min-h-0">
-        <TabsList className="mx-4 mt-4 flex-shrink-0">
-          <TabsTrigger value="content" className="flex-1">
-            <Type className="h-4 w-4 mr-2" />
-            Contenido
-          </TabsTrigger>
-          <TabsTrigger value="styles" className="flex-1">
-            <Palette className="h-4 w-4 mr-2" />
-            Estilos
-          </TabsTrigger>
-        </TabsList>
+        {/* Tabs */}
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="flex-1 flex flex-col min-h-0"
+        >
+          <TabsList className="mx-4 mt-4 flex-shrink-0">
+            <TabsTrigger value="content" className="flex-1">
+              <Type className="h-4 w-4 mr-2" />
+              Contenido
+            </TabsTrigger>
+            <TabsTrigger value="styles" className="flex-1">
+              <Palette className="h-4 w-4 mr-2" />
+              Estilos
+            </TabsTrigger>
+          </TabsList>
 
-        {/* Content Tab */}
-        <TabsContent value="content" className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Contenido del Componente</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {config.content.map((field) => (
-                <div key={field.key} className="space-y-2">
-                  {field.isArray ? (
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between mb-2 sticky top-0 bg-background z-10 py-2 -mx-2 px-2 border-b border-border">
-                        <Label className="font-semibold">{field.label}</Label>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleAddArrayItem(field.key, field.arrayFields || [])}
-                          className="h-8"
-                        >
-                          <Plus className="h-3 w-3 mr-1" />
-                          Agregar
-                        </Button>
-                      </div>
-                      <div className="max-h-[400px] overflow-y-auto pr-2 space-y-3 custom-scrollbar">
-                        {(localValues[field.key] || []).map((item: any, index: number) => (
-                        <Card key={index} className="mb-3">
-                          <CardHeader className="pb-3">
-                            <div className="flex items-center justify-between">
-                              <CardTitle className="text-sm">Item {index + 1}</CardTitle>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleRemoveArrayItem(field.key, index)}
-                                className="h-8 w-8 p-0 text-destructive hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-                          </CardHeader>
-                          <CardContent className="space-y-2">
-                            {field.arrayFields?.map((subField) => (
-                              <div key={subField.key} className="space-y-1">
-                                {subField.type === "image" || subField.key.toLowerCase().includes("image") ? (
-                                  <ImageUpload
-                                    value={item[subField.key] || ""}
-                                    onChange={(url) => handleArrayItemChange(field.key, index, subField.key, url)}
-                                    label={subField.label}
-                                    context={`${selectedComponent}-${field.key}-${subField.key}-${index + 1}`}
-                                  />
-                                ) : subField.type === "textarea" ? (
-                                  <>
-                                    <Label className="text-xs">{subField.label}</Label>
-                                    <Textarea
-                                      value={item[subField.key] || ""}
-                                      onChange={(e) =>
-                                        handleArrayItemChange(field.key, index, subField.key, e.target.value)
-                                      }
-                                      rows={2}
-                                    />
-                                  </>
-                                ) : (
-                                  <>
-                                    <Label className="text-xs">{subField.label}</Label>
-                                    <Input
-                                      type={subField.type}
-                                      value={item[subField.key] || ""}
-                                      onChange={(e) => {
-                                        const value = subField.type === "number" ? Number(e.target.value) : e.target.value
-                                        handleArrayItemChange(field.key, index, subField.key, value)
-                                      }}
-                                    />
-                                  </>
-                                )}
-                              </div>
-                            ))}
-                          </CardContent>
-                        </Card>
-                        ))}
-                      </div>
-                      {(!localValues[field.key] || localValues[field.key].length === 0) && (
-                        <div className="text-center py-4 text-sm text-muted-foreground">
-                          No hay items. Haz clic en "Agregar" para crear uno nuevo.
+          {/* Content Tab */}
+          <TabsContent
+            value="content"
+            forceMount
+            className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar"
+          >
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Contenido del Componente
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Organizá el mensaje, los slides y el tipo de banner que va a
+                  ver el cliente.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {config.content.map((field) => (
+                  <div key={field.key} className="space-y-2">
+                    {field.isArray ? (
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between mb-2 sticky top-0 bg-background z-10 py-2 -mx-2 px-2 border-b border-border">
+                          <Label className="font-semibold">{field.label}</Label>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              handleAddArrayItem(
+                                field.key,
+                                field.arrayFields || [],
+                              )
+                            }
+                            className="h-8"
+                          >
+                            <Plus className="h-3 w-3 mr-1" />
+                            Agregar
+                          </Button>
                         </div>
-                      )}
-                    </div>
-                  ) : field.type === "image" || field.key.toLowerCase().includes("image") ? (
-                    <ImageUpload
-                      value={localValues[field.key] || ""}
-                      onChange={(url) => handleInputChange(field.key, url)}
-                      label={field.label}
-                      context={`${selectedComponent}-${field.key}`}
-                      // Configuración específica para logos
-                      recommendedWidth={field.key.toLowerCase().includes("logo") ? 240 : undefined}
-                      recommendedHeight={field.key.toLowerCase().includes("logo") ? 80 : undefined}
-                      fileTypes={field.key.toLowerCase().includes("logo") ? ["PNG", "SVG", "JPG", "WEBP"] : undefined}
-                      accept={field.key.toLowerCase().includes("logo") ? "image/png,image/svg+xml,image/jpeg,image/jpg,image/webp" : undefined}
-                    />
-                  ) : field.type === "textarea" ? (
-                    <>
-                      <Label htmlFor={field.key}>{field.label}</Label>
-                      <Textarea
-                        id={field.key}
-                        value={localValues[field.key] || ""}
-                        onChange={(e) => handleInputChange(field.key, e.target.value)}
-                        rows={3}
-                      />
-                    </>
-                  ) : (
-                    <>
-                      <Label htmlFor={field.key}>{field.label}</Label>
-                      <Input
-                        id={field.key}
-                        type={field.type}
-                        value={localValues[field.key] || ""}
-                        onChange={(e) => handleInputChange(field.key, e.target.value)}
-                      />
-                    </>
-                  )}
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* Styles Tab */}
-        <TabsContent value="styles" className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Estilos del Componente</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {config.styles && config.styles.length > 0 ? (
-                config.styles.map((field) => {
-                  const currentValue = localValues[field.key] || ""
-                  const defaultValue = config.defaults?.[field.key] || ""
-                  const displayValue = currentValue || defaultValue || ""
-                  
-                  // Mostrar/ocultar campos según el tipo de fondo seleccionado
-                  if (selectedComponent === "site_background") {
-                    if (field.key === "backgroundColor" && localValues.type === "image") {
-                      return null // Ocultar color si es imagen
-                    }
-                    if (field.key === "backgroundImage" && localValues.type === "color") {
-                      return null // Ocultar imagen si es color
-                    }
-                    if (field.key === "backgroundPosition" || field.key === "backgroundRepeat" || field.key === "backgroundSize") {
-                      if (localValues.type === "color") {
-                        return null // Ocultar opciones de imagen si es color
-                      }
-                    }
-                  }
-                  
-                  return (
-                    <div key={field.key} className="space-y-2">
-                      <Label htmlFor={`style-${field.key}`} className="text-sm font-medium">
-                        {field.label}
-                      </Label>
-                      {field.type === "select" && field.options ? (
+                        <div className="max-h-[400px] overflow-y-auto pr-2 space-y-3 custom-scrollbar">
+                          {(localValues[field.key] || []).map(
+                            (item: any, index: number) => (
+                              <Card key={index} className="mb-3">
+                                <CardHeader className="pb-3">
+                                  <div className="flex items-center justify-between">
+                                    <CardTitle className="text-sm">
+                                      Item {index + 1}
+                                    </CardTitle>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() =>
+                                        handleRemoveArrayItem(field.key, index)
+                                      }
+                                      className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </div>
+                                </CardHeader>
+                                <CardContent className="space-y-2">
+                                  {field.arrayFields?.map((subField) => (
+                                    <div
+                                      key={subField.key}
+                                      className="space-y-1"
+                                    >
+                                      {subField.type === "image" ||
+                                      subField.key
+                                        .toLowerCase()
+                                        .includes("image") ? (
+                                        <ImageUpload
+                                          value={item[subField.key] || ""}
+                                          onChange={(url) =>
+                                            handleArrayItemChange(
+                                              field.key,
+                                              index,
+                                              subField.key,
+                                              url,
+                                            )
+                                          }
+                                          label={subField.label}
+                                          context={`${selectedComponent}-${field.key}-${subField.key}-${index + 1}`}
+                                        />
+                                      ) : subField.type === "textarea" ? (
+                                        <>
+                                          <Label className="text-xs">
+                                            {subField.label}
+                                          </Label>
+                                          <Textarea
+                                            value={item[subField.key] || ""}
+                                            onChange={(e) =>
+                                              handleArrayItemChange(
+                                                field.key,
+                                                index,
+                                                subField.key,
+                                                e.target.value,
+                                              )
+                                            }
+                                            rows={2}
+                                          />
+                                        </>
+                                      ) : (
+                                        <>
+                                          <Label className="text-xs">
+                                            {subField.label}
+                                          </Label>
+                                          <Input
+                                            type={subField.type}
+                                            value={item[subField.key] || ""}
+                                            onChange={(e) => {
+                                              const value =
+                                                subField.type === "number"
+                                                  ? Number(e.target.value)
+                                                  : e.target.value;
+                                              handleArrayItemChange(
+                                                field.key,
+                                                index,
+                                                subField.key,
+                                                value,
+                                              );
+                                            }}
+                                          />
+                                        </>
+                                      )}
+                                    </div>
+                                  ))}
+                                </CardContent>
+                              </Card>
+                            ),
+                          )}
+                        </div>
+                        {(!localValues[field.key] ||
+                          localValues[field.key].length === 0) && (
+                          <div className="text-center py-4 text-sm text-muted-foreground">
+                            No hay items. Haz clic en "Agregar" para crear uno
+                            nuevo.
+                          </div>
+                        )}
+                      </div>
+                    ) : field.type === "select" && field.options ? (
+                      <>
+                        <Label htmlFor={field.key}>{field.label}</Label>
                         <Select
-                          value={currentValue || defaultValue}
-                          onValueChange={(value) => handleInputChange(field.key, value)}
+                          value={
+                            localValues[field.key] ||
+                            config.defaults?.[field.key]
+                          }
+                          onValueChange={(value) =>
+                            handleInputChange(field.key, value)
+                          }
                         >
-                          <SelectTrigger className="w-full">
-                            <SelectValue placeholder={`Selecciona ${field.label.toLowerCase()}`} />
+                          <SelectTrigger id={field.key} className="w-full">
+                            <SelectValue
+                              placeholder={`Selecciona ${field.label.toLowerCase()}`}
+                            />
                           </SelectTrigger>
                           <SelectContent>
                             {field.options.map((option) => (
-                              <SelectItem key={option.value} value={option.value}>
+                              <SelectItem
+                                key={option.value}
+                                value={option.value}
+                              >
                                 {option.label}
                               </SelectItem>
                             ))}
                           </SelectContent>
                         </Select>
-                      ) : field.type === "image" || field.key.toLowerCase().includes("image") ? (
-                        <ImageUpload
-                          value={currentValue || ""}
-                          onChange={(url) => handleInputChange(field.key, url)}
-                          label={field.label}
-                          context={`${selectedComponent}-${field.key}`}
+                      </>
+                    ) : field.type === "image" ||
+                      field.key.toLowerCase().includes("image") ? (
+                      <ImageUpload
+                        value={localValues[field.key] || ""}
+                        onChange={(url) => handleInputChange(field.key, url)}
+                        label={field.label}
+                        context={`${selectedComponent}-${field.key}`}
+                        // Configuración específica para logos
+                        recommendedWidth={
+                          field.key.toLowerCase().includes("logo")
+                            ? 240
+                            : undefined
+                        }
+                        recommendedHeight={
+                          field.key.toLowerCase().includes("logo")
+                            ? 80
+                            : undefined
+                        }
+                        fileTypes={
+                          field.key.toLowerCase().includes("logo")
+                            ? ["PNG", "SVG", "JPG", "WEBP"]
+                            : undefined
+                        }
+                        accept={
+                          field.key.toLowerCase().includes("logo")
+                            ? "image/png,image/svg+xml,image/jpeg,image/jpg,image/webp"
+                            : undefined
+                        }
+                      />
+                    ) : field.type === "textarea" ? (
+                      <>
+                        <Label htmlFor={field.key}>{field.label}</Label>
+                        <Textarea
+                          id={field.key}
+                          value={localValues[field.key] || ""}
+                          onChange={(e) =>
+                            handleInputChange(field.key, e.target.value)
+                          }
+                          rows={3}
                         />
-                      ) : field.type === "checkbox" ? (
-                        <div className="flex items-center space-x-2">
-                          <Checkbox
-                            id={`style-${field.key}`}
-                            checked={currentValue === "true" || currentValue === true || currentValue === "1"}
-                            onCheckedChange={(checked: boolean) => handleInputChange(field.key, checked ? "true" : "false")}
-                          />
-                          <Label htmlFor={`style-${field.key}`} className="text-sm font-normal cursor-pointer">
-                            {field.label}
-                          </Label>
-                        </div>
-                      ) : (
-                        <div className="flex gap-2 items-center">
-                          <Input
-                            id={`style-${field.key}`}
-                            type={field.type}
-                            value={currentValue}
-                            onChange={(e) => handleInputChange(field.key, e.target.value)}
-                            className={field.type === "color" ? "h-10 flex-1" : "flex-1"}
-                            placeholder={field.type === "color" ? "#000000" : defaultValue || "Ingrese un valor..."}
-                          />
-                          {field.type === "color" && (
-                            <div
-                              className="w-12 h-12 rounded border-2 border-border cursor-pointer hover:scale-105 transition-transform flex-shrink-0"
-                              style={{ backgroundColor: displayValue || "#000000" }}
-                              onClick={() => {
-                                const input = document.getElementById(`style-${field.key}`) as HTMLInputElement
-                                if (input) input.click()
-                              }}
-                              title="Haz clic para abrir el selector de color"
-                            />
-                          )}
-                        </div>
-                      )}
-                      {displayValue && field.type !== "select" && (
-                        <p className="text-xs text-muted-foreground">
-                          Valor: <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{displayValue}</code>
-                        </p>
-                      )}
-                    </div>
-                  )
-                })
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">
-                    Este componente no tiene estilos configurables
-                  </p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+                      </>
+                    ) : (
+                      <>
+                        <Label htmlFor={field.key}>{field.label}</Label>
+                        <Input
+                          id={field.key}
+                          type={field.type}
+                          value={localValues[field.key] || ""}
+                          onChange={(e) =>
+                            handleInputChange(field.key, e.target.value)
+                          }
+                        />
+                      </>
+                    )}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </TabsContent>
 
-      {/* Actions */}
-      <div className="p-4 border-t border-border space-y-2 flex-shrink-0">
-        <Button className="w-full" onClick={handleSave} disabled={!hasChanges || saving}>
-          <Save className="h-4 w-4 mr-2" />
-          {saving ? "Guardando..." : "Guardar Cambios"}
-        </Button>
-        <Button variant="outline" className="w-full bg-transparent" onClick={handleReset} disabled={!hasChanges}>
-          <RotateCcw className="h-4 w-4 mr-2" />
-          Descartar Cambios
-        </Button>
+          {/* Styles Tab */}
+          <TabsContent
+            value="styles"
+            forceMount
+            className="flex-1 overflow-y-auto p-4 space-y-4 mt-0 min-h-0 custom-scrollbar"
+          >
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Estilos del Componente
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Ajustá colores y acabados. Los selectores de color se aplican
+                  en vivo sin disparar el guardado en cada arrastre.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {config.styles && config.styles.length > 0 ? (
+                  config.styles.map((field) => {
+                    const currentValue = localValues[field.key] || "";
+                    const defaultValue = config.defaults?.[field.key] || "";
+                    const displayValue = currentValue || defaultValue || "";
+
+                    // Mostrar/ocultar campos según el tipo de fondo seleccionado
+                    if (selectedComponent === "site_background") {
+                      if (
+                        field.key === "backgroundColor" &&
+                        localValues.type === "image"
+                      ) {
+                        return null; // Ocultar color si es imagen
+                      }
+                      if (
+                        field.key === "backgroundImage" &&
+                        localValues.type === "color"
+                      ) {
+                        return null; // Ocultar imagen si es color
+                      }
+                      if (
+                        field.key === "backgroundPosition" ||
+                        field.key === "backgroundRepeat" ||
+                        field.key === "backgroundSize"
+                      ) {
+                        if (localValues.type === "color") {
+                          return null; // Ocultar opciones de imagen si es color
+                        }
+                      }
+                    }
+
+                    return (
+                      <div key={field.key} className="space-y-2">
+                        <Label
+                          htmlFor={`style-${field.key}`}
+                          className="text-sm font-medium"
+                        >
+                          {field.label}
+                        </Label>
+                        {field.type === "select" && field.options ? (
+                          <Select
+                            value={currentValue || defaultValue}
+                            onValueChange={(value) =>
+                              handleInputChange(field.key, value)
+                            }
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue
+                                placeholder={`Selecciona ${field.label.toLowerCase()}`}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {field.options.map((option) => (
+                                <SelectItem
+                                  key={option.value}
+                                  value={option.value}
+                                >
+                                  {option.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : field.type === "image" ||
+                          field.key.toLowerCase().includes("image") ? (
+                          <ImageUpload
+                            value={currentValue || ""}
+                            onChange={(url) =>
+                              handleInputChange(field.key, url)
+                            }
+                            label={field.label}
+                            context={`${selectedComponent}-${field.key}`}
+                          />
+                        ) : field.type === "checkbox" ? (
+                          <div className="flex items-center space-x-2">
+                            <Checkbox
+                              id={`style-${field.key}`}
+                              checked={
+                                currentValue === "true" ||
+                                currentValue === true ||
+                                currentValue === "1"
+                              }
+                              onCheckedChange={(checked: boolean) =>
+                                handleInputChange(
+                                  field.key,
+                                  checked ? "true" : "false",
+                                )
+                              }
+                            />
+                            <Label
+                              htmlFor={`style-${field.key}`}
+                              className="text-sm font-normal cursor-pointer"
+                            >
+                              {field.label}
+                            </Label>
+                          </div>
+                        ) : (
+                          <div className="flex gap-2 items-center">
+                            <Input
+                              id={`style-${field.key}`}
+                              type={field.type}
+                              value={currentValue}
+                              onChange={(e) =>
+                                handleInputChange(field.key, e.target.value)
+                              }
+                              className={
+                                field.type === "color"
+                                  ? "h-10 flex-1"
+                                  : "flex-1"
+                              }
+                              placeholder={
+                                field.type === "color"
+                                  ? "#000000"
+                                  : defaultValue || "Ingrese un valor..."
+                              }
+                            />
+                            {field.type === "color" && (
+                              <div
+                                className="w-12 h-12 rounded border-2 border-border cursor-pointer hover:scale-105 transition-transform flex-shrink-0"
+                                style={{
+                                  backgroundColor: displayValue || "#000000",
+                                }}
+                                onClick={() => {
+                                  const input = document.getElementById(
+                                    `style-${field.key}`,
+                                  ) as HTMLInputElement;
+                                  if (input) input.click();
+                                }}
+                                title="Haz clic para abrir el selector de color"
+                              />
+                            )}
+                          </div>
+                        )}
+                        {displayValue && field.type !== "select" && (
+                          <p className="text-xs text-muted-foreground">
+                            Valor:{" "}
+                            <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                              {displayValue}
+                            </code>
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })
+                ) : (
+                  <div className="text-center py-8">
+                    <p className="text-sm text-muted-foreground">
+                      Este componente no tiene estilos configurables
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* Actions */}
+        <div className="p-4 border-t border-border space-y-2 flex-shrink-0">
+          <Button
+            className="w-full"
+            onClick={handleSave}
+            disabled={!hasChanges || saving}
+          >
+            <Save className="h-4 w-4 mr-2" />
+            {saving ? "Guardando..." : "Guardar Cambios"}
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full bg-transparent"
+            onClick={handleReset}
+            disabled={!hasChanges}
+          >
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Descartar Cambios
+          </Button>
+        </div>
       </div>
-    </div>
     </>
-  )
+  );
 }

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -1,30 +1,30 @@
-"use client"
+"use client";
 
-import { useEffect, useRef, useState, useMemo } from "react"
-import Image from "next/image"
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
+import { useEffect, useRef, useState, useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
+} from "@/components/ui/dialog";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip"
-import { useComponentStyle } from "@/contexts/styles-context"
-import { useAdmin } from "@/contexts/admin-context"
-import { useTheme } from "@/contexts/theme-context"
+} from "@/components/ui/tooltip";
+import { useComponentStyle } from "@/contexts/styles-context";
+import { useAdmin } from "@/contexts/admin-context";
+import { useTheme } from "@/contexts/theme-context";
 import {
   Carousel,
   CarouselContent,
   CarouselItem,
   type CarouselApi,
-} from "@/components/ui/carousel"
+} from "@/components/ui/carousel";
 
 // Helper para generar slug desde el título
 function generateSlug(title: string): string {
@@ -33,11 +33,11 @@ function generateSlug(title: string): string {
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "")
+    .replace(/(^-|-$)/g, "");
 }
 
 export function HeroBanner() {
-  const { activeTheme } = useTheme()
+  const { activeTheme } = useTheme();
   const { styles: styleData } = useComponentStyle("hero", {
     label: "Electronics",
     title: "BALFE",
@@ -45,114 +45,147 @@ export function HeroBanner() {
     description:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
     buttonText: "Comprar ahora",
-  })
-  const { componentEdits } = useAdmin()
-  const [api, setApi] = useState<CarouselApi>()
-  const autoplayRef = useRef<NodeJS.Timeout | null>(null)
-  const [selectedFeature, setSelectedFeature] = useState<{ title: string; description: string } | null>(null)
-  const [isFeatureDialogOpen, setIsFeatureDialogOpen] = useState(false)
-  
+  });
+  const { componentEdits } = useAdmin();
+  const [api, setApi] = useState<CarouselApi>();
+  const autoplayRef = useRef<NodeJS.Timeout | null>(null);
+  const [selectedFeature, setSelectedFeature] = useState<{
+    title: string;
+    description: string;
+  } | null>(null);
+  const [isFeatureDialogOpen, setIsFeatureDialogOpen] = useState(false);
+
   // Determinar si el tema es oscuro para ajustar estilos
   const isDarkTheme = useMemo(() => {
-    if (!activeTheme) return false
+    if (!activeTheme) return false;
     // Verificar si el nombre del tema contiene "Oscuro"
     if (activeTheme.theme_name.toLowerCase().includes("oscuro")) {
-      return true
+      return true;
     }
     // También verificar si el background es oscuro (RGB bajo)
-    const bgColor = activeTheme.colors.background
+    const bgColor = activeTheme.colors.background;
     if (bgColor.startsWith("#")) {
-      const r = parseInt(bgColor.slice(1, 3), 16)
-      const g = parseInt(bgColor.slice(3, 5), 16)
-      const b = parseInt(bgColor.slice(5, 7), 16)
+      const r = parseInt(bgColor.slice(1, 3), 16);
+      const g = parseInt(bgColor.slice(3, 5), 16);
+      const b = parseInt(bgColor.slice(5, 7), 16);
       // Si el promedio de RGB es menor a 128, es un tema oscuro
-      const avg = (r + g + b) / 3
-      return avg < 128
+      const avg = (r + g + b) / 3;
+      return avg < 128;
     }
-    return false
-  }, [activeTheme])
-  
+    return false;
+  }, [activeTheme]);
+
   // Combinar estilos de BD con ediciones locales para mostrar cambios en tiempo real
-  const edits = componentEdits.get("hero") || {}
+  const edits = componentEdits.get("hero") || {};
   // Usar variables CSS del tema si no hay configuración personalizada
   // Esto permite que los temas oscuros funcionen correctamente
-  const bgColor = edits.bgColor ?? styleData.bgColor ?? "var(--primary)"
-  const textColor = edits.textColor ?? styleData.textColor ?? "var(--primary-foreground)"
-  const buttonColor = edits.buttonColor ?? styleData.buttonColor ?? "var(--accent)"
-  const buttonTextColor = edits.buttonTextColor ?? styleData.buttonTextColor ?? "var(--accent-foreground)"
-  const barColor = edits.barColor ?? styleData.barColor
+  const bgColor = edits.bgColor ?? styleData.bgColor ?? "var(--primary)";
+  const textColor =
+    edits.textColor ?? styleData.textColor ?? "var(--primary-foreground)";
+  const buttonColor =
+    edits.buttonColor ?? styleData.buttonColor ?? "var(--accent)";
+  const buttonTextColor =
+    edits.buttonTextColor ??
+    styleData.buttonTextColor ??
+    "var(--accent-foreground)";
+  const barColor = edits.barColor ?? styleData.barColor;
+  const overlayColor =
+    edits.overlayColor ?? styleData.overlayColor ?? "#101828";
+  const overlayOpacity = Number(
+    edits.overlayOpacity ?? styleData.overlayOpacity ?? 0.45,
+  );
+  const layoutMode = edits.layoutMode ?? styleData.layoutMode ?? "split";
 
   // Características por producto
-  const productFeatures: Record<string, Array<{ title: string; description: string; position: { top: string; left?: string; right?: string; bottom?: string } }>> = {
-    "PREMIUM": [
+  const productFeatures: Record<
+    string,
+    Array<{
+      title: string;
+      description: string;
+      position: { top: string; left?: string; right?: string; bottom?: string };
+    }>
+  > = {
+    PREMIUM: [
       {
         title: "Cancelación de Ruido Activa",
-        description: "Tecnología avanzada que elimina el ruido ambiental para una experiencia de audio inmersiva y sin distracciones.",
-        position: { top: "20%", right: "10%" }
+        description:
+          "Tecnología avanzada que elimina el ruido ambiental para una experiencia de audio inmersiva y sin distracciones.",
+        position: { top: "20%", right: "10%" },
       },
       {
         title: "Diseño Ergonómico",
-        description: "Auriculares diseñados para máximo confort durante horas de uso. Almohadillas suaves y ajuste perfecto para cualquier tipo de cabeza.",
-        position: { top: "45%", left: "15%" }
+        description:
+          "Auriculares diseñados para máximo confort durante horas de uso. Almohadillas suaves y ajuste perfecto para cualquier tipo de cabeza.",
+        position: { top: "45%", left: "15%" },
       },
       {
         title: "Sonido de Alta Fidelidad",
-        description: "Drivers de 40mm con respuesta de frecuencia optimizada para reproducir cada detalle del audio con claridad cristalina.",
-        position: { top: "auto", bottom: "30%", right: "20%" }
-      }
+        description:
+          "Drivers de 40mm con respuesta de frecuencia optimizada para reproducir cada detalle del audio con claridad cristalina.",
+        position: { top: "auto", bottom: "30%", right: "20%" },
+      },
     ],
-    "BALFE": [
+    BALFE: [
       {
         title: "Conectividad Inteligente",
-        description: "Conexión Bluetooth 5.0 de alta calidad con asistente de voz integrado para control total con comandos de voz.",
-        position: { top: "20%", right: "10%" }
+        description:
+          "Conexión Bluetooth 5.0 de alta calidad con asistente de voz integrado para control total con comandos de voz.",
+        position: { top: "20%", right: "10%" },
       },
       {
         title: "Sonido Potente",
-        description: "Altavoz de 20W con graves profundos y agudos claros, perfecto para cualquier tipo de música o contenido.",
-        position: { top: "45%", left: "15%" }
+        description:
+          "Altavoz de 20W con graves profundos y agudos claros, perfecto para cualquier tipo de música o contenido.",
+        position: { top: "45%", left: "15%" },
       },
       {
         title: "Diseño Moderno",
-        description: "Estética minimalista que se adapta a cualquier espacio, con acabados premium y materiales de alta calidad.",
-        position: { top: "auto", bottom: "30%", right: "20%" }
-      }
+        description:
+          "Estética minimalista que se adapta a cualquier espacio, con acabados premium y materiales de alta calidad.",
+        position: { top: "auto", bottom: "30%", right: "20%" },
+      },
     ],
     "LAPTOP STAND": [
       {
         title: "Ajuste Ergonómico",
-        description: "Altura y ángulo ajustables para encontrar la posición perfecta que reduce la tensión en cuello y espalda.",
-        position: { top: "20%", right: "10%" }
+        description:
+          "Altura y ángulo ajustables para encontrar la posición perfecta que reduce la tensión en cuello y espalda.",
+        position: { top: "20%", right: "10%" },
       },
       {
         title: "Ventilación Mejorada",
-        description: "Diseño elevado que permite mejor circulación de aire, manteniendo tu laptop fresca durante largas sesiones de trabajo.",
-        position: { top: "45%", left: "15%" }
+        description:
+          "Diseño elevado que permite mejor circulación de aire, manteniendo tu laptop fresca durante largas sesiones de trabajo.",
+        position: { top: "45%", left: "15%" },
       },
       {
         title: "Material Durable",
-        description: "Construido en aluminio anodizado de alta calidad, resistente y ligero para uso diario profesional.",
-        position: { top: "auto", bottom: "30%", right: "20%" }
-      }
+        description:
+          "Construido en aluminio anodizado de alta calidad, resistente y ligero para uso diario profesional.",
+        position: { top: "auto", bottom: "30%", right: "20%" },
+      },
     ],
     "MINI PROJECTOR": [
       {
         title: "Resolución HD",
-        description: "Proyección nítida en alta definición (1080p) con excelente calidad de imagen incluso en espacios iluminados.",
-        position: { top: "20%", right: "10%" }
+        description:
+          "Proyección nítida en alta definición (1080p) con excelente calidad de imagen incluso en espacios iluminados.",
+        position: { top: "20%", right: "10%" },
       },
       {
         title: "Portabilidad",
-        description: "Diseño compacto y ligero que cabe en cualquier mochila, perfecto para presentaciones y entretenimiento móvil.",
-        position: { top: "45%", left: "15%" }
+        description:
+          "Diseño compacto y ligero que cabe en cualquier mochila, perfecto para presentaciones y entretenimiento móvil.",
+        position: { top: "45%", left: "15%" },
       },
       {
         title: "Conectividad Inalámbrica",
-        description: "Conexión WiFi y Bluetooth para transmitir contenido desde cualquier dispositivo sin cables.",
-        position: { top: "auto", bottom: "30%", right: "20%" }
-      }
-    ]
-  }
+        description:
+          "Conexión WiFi y Bluetooth para transmitir contenido desde cualquier dispositivo sin cables.",
+        position: { top: "auto", bottom: "30%", right: "20%" },
+      },
+    ],
+  };
 
   // Array de productos editables para el carrusel
   const defaultProducts = [
@@ -160,7 +193,8 @@ export function HeroBanner() {
       label: "Electrónica",
       title: "BALFE",
       subtitle: "NUEVO MODELO",
-      description: "Descubre la última tecnología en dispositivos electrónicos. Calidad premium y diseño innovador para una experiencia única.",
+      description:
+        "Descubre la última tecnología en dispositivos electrónicos. Calidad premium y diseño innovador para una experiencia única.",
       buttonText: "Comprar ahora",
       image: "/black-smart-speaker.jpg",
     },
@@ -168,7 +202,8 @@ export function HeroBanner() {
       label: "Audio",
       title: "PREMIUM",
       subtitle: "HEADPHONES",
-      description: "Experimenta el sonido de alta calidad con nuestros auriculares premium. Diseño ergonómico y cancelación de ruido activa.",
+      description:
+        "Experimenta el sonido de alta calidad con nuestros auriculares premium. Diseño ergonómico y cancelación de ruido activa.",
       buttonText: "Ver más",
       image: "/premium-headphones.png",
     },
@@ -176,7 +211,8 @@ export function HeroBanner() {
       label: "Accesorios",
       title: "LAPTOP STAND",
       subtitle: "ERGONÓMICO",
-      description: "Mejora tu espacio de trabajo con nuestro soporte para laptop. Diseño moderno y ajustable para mayor comodidad.",
+      description:
+        "Mejora tu espacio de trabajo con nuestro soporte para laptop. Diseño moderno y ajustable para mayor comodidad.",
       buttonText: "Comprar ahora",
       image: "/laptop-stand.png",
     },
@@ -184,84 +220,89 @@ export function HeroBanner() {
       label: "Proyección",
       title: "MINI PROJECTOR",
       subtitle: "PORTÁTIL",
-      description: "Lleva el cine contigo. Proyector compacto con alta resolución y conectividad inalámbrica para tus presentaciones.",
+      description:
+        "Lleva el cine contigo. Proyector compacto con alta resolución y conectividad inalámbrica para tus presentaciones.",
       buttonText: "Descubrir",
       image: "/mini-projector.jpg",
     },
-  ]
-  
+  ];
+
   // Usar productos editables si existen, sino usar los por defecto
-  const heroProducts = edits.products ?? styleData.products ?? defaultProducts
+  const heroProducts = edits.products ?? styleData.products ?? defaultProducts;
 
   // Función helper para convertir hex a rgba
   const hexToRgba = (hex: string, alpha: number) => {
     // Si el hex no empieza con #, agregarlo
-    const hexColor = hex.startsWith('#') ? hex : `#${hex}`
+    const hexColor = hex.startsWith("#") ? hex : `#${hex}`;
     // Si el hex es muy corto, usar valores por defecto
     if (hexColor.length < 7) {
-      return `rgba(0, 0, 0, ${alpha})`
+      return `rgba(0, 0, 0, ${alpha})`;
     }
     try {
-      const r = parseInt(hexColor.slice(1, 3), 16)
-      const g = parseInt(hexColor.slice(3, 5), 16)
-      const b = parseInt(hexColor.slice(5, 7), 16)
-      return `rgba(${r}, ${g}, ${b}, ${alpha})`
+      const r = parseInt(hexColor.slice(1, 3), 16);
+      const g = parseInt(hexColor.slice(3, 5), 16);
+      const b = parseInt(hexColor.slice(5, 7), 16);
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     } catch (e) {
-      return `rgba(0, 0, 0, ${alpha})`
+      return `rgba(0, 0, 0, ${alpha})`;
     }
-  }
+  };
 
   // Obtener colores del tema activo
   // Para temas oscuros, esto asegura que se usen los colores correctos
-  const accentColor = activeTheme?.colors.accent || "#005aa1"
-  const secondaryColor = activeTheme?.colors.secondary || "#c4faff"
+  const accentColor = activeTheme?.colors.accent || "#005aa1";
+  const secondaryColor = activeTheme?.colors.secondary || "#c4faff";
+  const clampedOverlayOpacity = Number.isFinite(overlayOpacity)
+    ? Math.min(Math.max(overlayOpacity, 0), 0.9)
+    : 0.45;
 
   // Auto-play: cambiar cada 10 segundos
   useEffect(() => {
-    if (!api) return
+    if (!api) return;
 
     const startAutoplay = () => {
       // Limpiar intervalo anterior si existe
       if (autoplayRef.current) {
-        clearInterval(autoplayRef.current)
+        clearInterval(autoplayRef.current);
       }
 
       // Crear nuevo intervalo
       autoplayRef.current = setInterval(() => {
-        api.scrollNext()
-      }, 10000) // 10 segundos
-    }
+        api.scrollNext();
+      }, 10000); // 10 segundos
+    };
 
     // Iniciar auto-play
-    startAutoplay()
+    startAutoplay();
 
     // Pausar auto-play cuando el usuario interactúa
     const handleSelect = () => {
       if (autoplayRef.current) {
-        clearInterval(autoplayRef.current)
+        clearInterval(autoplayRef.current);
       }
       // Reiniciar después de 10 segundos de inactividad
       setTimeout(() => {
-        startAutoplay()
-      }, 10000)
-    }
+        startAutoplay();
+      }, 10000);
+    };
 
-    api.on("select", handleSelect)
+    api.on("select", handleSelect);
 
     // Limpiar al desmontar
     return () => {
       if (autoplayRef.current) {
-        clearInterval(autoplayRef.current)
+        clearInterval(autoplayRef.current);
       }
-      api.off("select", handleSelect)
-    }
-  }, [api])
+      api.off("select", handleSelect);
+    };
+  }, [api]);
 
   return (
-    <section 
+    <section
       data-component="hero"
-      className="relative overflow-hidden rounded-2xl md:rounded-3xl mx-2 md:mx-4 mt-2 md:mt-4 mb-4 md:mb-8" 
-      style={{ 
+      data-hero-layout={layoutMode}
+      className="relative overflow-hidden rounded-2xl md:rounded-3xl mx-2 md:mx-4 mt-2 md:mt-4 mb-4 md:mb-8"
+      style={{
         backgroundColor: bgColor,
         color: textColor,
       }}
@@ -275,129 +316,227 @@ export function HeroBanner() {
         className="w-full"
       >
         <CarouselContent>
-          {heroProducts.map((product: { label?: string; title?: string; subtitle?: string; description?: string; buttonText?: string; image?: string }, index: number) => {
-            // Usar valores del producto directamente (ya vienen editados)
-            const displayLabel = product.label || ""
-            const displayTitle = product.title || ""
-            const displaySubtitle = product.subtitle || ""
-            const displayDescription = product.description || ""
-            const displayButtonText = product.buttonText || ""
-            const displayImage = product.image || "/placeholder.svg"
-            
-            return (
-            <CarouselItem key={index} className="basis-full">
-              <div className="container mx-auto px-4 md:px-8 py-8 pb-20 md:py-16 lg:py-24">
-                <div className="grid lg:grid-cols-2 gap-6 md:gap-12 items-center">
-                  <div 
-                    className="space-y-4 md:space-y-6 text-center md:text-left" 
-                    style={{ color: textColor }}
-                  >
-                    <span 
-                      className="inline-block rounded text-xs md:text-[14.21px] font-inter font-medium rounded-lg px-4 md:px-6 py-1"
-                      style={{ 
-                        backgroundColor: activeTheme 
-                          ? (isDarkTheme 
-                              ? "rgba(255, 255, 255, 0.1)" 
-                              : "rgba(255, 255, 255, 0.2)")
-                          : "rgba(255, 255, 255, 0.2)"
-                      }}
-                    >
-                      {displayLabel}
-                    </span>
-                    <div>
-                      <h1 className="text-4xl md:text-6xl lg:text-[92px] font-inter font-medium tracking-tight leading-tight">
-                        {displayTitle}
-                      </h1>
-                      <h2 className="text-2xl md:text-4xl lg:text-[51px] font-inter font-light tracking-tight">
-                        {displaySubtitle}
-                      </h2>
-                    </div>
-                    <p 
-                      className="text-sm md:text-[16px] font-inter font-medium max-w-md mx-auto md:mx-0 leading-relaxed"
-                      style={{ opacity: 0.9 }}
-                    >
-                      {displayDescription}
-                    </p>
-                    <Button
-                      size="lg"
-                      className="text-sm md:text-[16px] font-inter font-medium rounded px-6 md:px-8 w-full md:w-auto transition-all duration-200 min-h-[44px] touch-manipulation mb-4 md:mb-0"
-                      style={{
-                        backgroundColor: buttonColor,
-                        color: buttonTextColor,
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.filter = "brightness(0.85)"
-                        e.currentTarget.style.transform = "scale(1.02)"
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.filter = "brightness(1)"
-                        e.currentTarget.style.transform = "scale(1)"
-                      }}
-                      asChild
-                    >
-                      <Link href={`/products/${generateSlug(displayTitle)}`}>
-                        {displayButtonText} →
-                      </Link>
-                    </Button>
-                  </div>
+          {heroProducts.map(
+            (
+              product: {
+                label?: string;
+                title?: string;
+                subtitle?: string;
+                description?: string;
+                buttonText?: string;
+                image?: string;
+              },
+              index: number,
+            ) => {
+              // Usar valores del producto directamente (ya vienen editados)
+              const displayLabel = product.label || "";
+              const displayTitle = product.title || "";
+              const displaySubtitle = product.subtitle || "";
+              const displayDescription = product.description || "";
+              const displayButtonText = product.buttonText || "";
+              const displayImage = product.image || "/placeholder.svg";
+              const isFullImageLayout = layoutMode === "full-image";
 
-                  {/* Right - Product Image */}
-                  <div className="relative h-[250px] md:h-[400px] lg:h-[500px] order-first md:order-last">
-                    <Image
-                      src={displayImage}
-                      alt={displayTitle || "Product image"}
-                      width={800}
-                      height={600}
-                      className="w-full h-full object-contain"
-                      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 40vw"
-                      priority={index === 0}
-                    />
-                    {/* Feature Callouts - Interactivos */}
-                    {productFeatures[displayTitle]?.map((feature, featureIndex) => (
-                      <Tooltip key={featureIndex}>
-                        <TooltipTrigger asChild>
-                          <button
-                            className="hidden md:flex absolute items-center justify-center bg-white rounded-full p-3 shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-110 cursor-pointer group z-10"
+              return (
+                <CarouselItem key={index} className="basis-full">
+                  <div
+                    className={
+                      isFullImageLayout
+                        ? "relative min-h-[460px] md:min-h-[560px] lg:min-h-[640px]"
+                        : "container mx-auto px-4 md:px-8 py-8 pb-20 md:py-16 lg:py-24"
+                    }
+                  >
+                    {isFullImageLayout ? (
+                      <>
+                        <div className="absolute inset-0">
+                          <Image
+                            data-testid={
+                              index === 0
+                                ? "hero-full-background-image"
+                                : undefined
+                            }
+                            src={displayImage}
+                            alt={displayTitle || "Hero background image"}
+                            fill
+                            className="object-cover"
+                            sizes="100vw"
+                            priority={index === 0}
+                          />
+                          <div
+                            className="absolute inset-0"
                             style={{
-                              top: feature.position.top,
-                              left: feature.position.left,
-                              right: feature.position.right,
-                              bottom: feature.position.bottom,
+                              backgroundColor: overlayColor,
+                              opacity: clampedOverlayOpacity,
                             }}
-                            onClick={() => {
-                              setSelectedFeature(feature)
-                              setIsFeatureDialogOpen(true)
-                            }}
-                            aria-label={`Ver característica: ${feature.title}`}
+                          />
+                        </div>
+                        <div className="relative z-10 flex min-h-[460px] md:min-h-[560px] lg:min-h-[640px] items-center px-6 py-12 md:px-10 lg:px-16">
+                          <div
+                            className="max-w-3xl space-y-4 md:space-y-6 text-left"
+                            style={{ color: textColor }}
                           >
-                            <div className="w-3 h-3 bg-gray-800 rounded-full group-hover:bg-gray-900 transition-colors" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent 
-                          side="top" 
-                          sideOffset={8}
-                          className="max-w-[280px] bg-gray-900 text-white border-none shadow-xl p-3"
-                        >
-                          <div className="space-y-1.5">
-                            <p className="font-semibold text-sm leading-tight">{feature.title}</p>
-                            <p className="text-xs opacity-90 leading-relaxed">{feature.description}</p>
+                            <span
+                              className="inline-block rounded-lg px-4 py-1 text-xs font-inter font-medium md:px-6 md:text-[14.21px]"
+                              style={{
+                                backgroundColor: "rgba(255, 255, 255, 0.16)",
+                              }}
+                            >
+                              {displayLabel}
+                            </span>
+                            <div>
+                              <h1 className="text-4xl md:text-6xl lg:text-[92px] font-inter font-medium tracking-tight leading-tight">
+                                {displayTitle}
+                              </h1>
+                              <h2 className="text-2xl md:text-4xl lg:text-[51px] font-inter font-light tracking-tight">
+                                {displaySubtitle}
+                              </h2>
+                            </div>
+                            <p
+                              className="max-w-2xl text-sm font-inter font-medium leading-relaxed md:text-[16px]"
+                              style={{ opacity: 0.92 }}
+                            >
+                              {displayDescription}
+                            </p>
+                            <Button
+                              size="lg"
+                              className="mb-4 min-h-[44px] w-full touch-manipulation rounded px-6 text-sm font-inter font-medium transition-all duration-200 md:mb-0 md:w-auto md:px-8 md:text-[16px]"
+                              style={{
+                                backgroundColor: buttonColor,
+                                color: buttonTextColor,
+                              }}
+                              asChild
+                            >
+                              <Link
+                                href={`/products/${generateSlug(displayTitle)}`}
+                              >
+                                {displayButtonText} →
+                              </Link>
+                            </Button>
                           </div>
-                        </TooltipContent>
-                      </Tooltip>
-                    ))}
+                        </div>
+                      </>
+                    ) : (
+                      <div className="grid lg:grid-cols-2 gap-6 md:gap-12 items-center">
+                        <div
+                          className="space-y-4 md:space-y-6 text-center md:text-left"
+                          style={{ color: textColor }}
+                        >
+                          <span
+                            className="inline-block rounded text-xs md:text-[14.21px] font-inter font-medium rounded-lg px-4 md:px-6 py-1"
+                            style={{
+                              backgroundColor: activeTheme
+                                ? isDarkTheme
+                                  ? "rgba(255, 255, 255, 0.1)"
+                                  : "rgba(255, 255, 255, 0.2)"
+                                : "rgba(255, 255, 255, 0.2)",
+                            }}
+                          >
+                            {displayLabel}
+                          </span>
+                          <div>
+                            <h1 className="text-4xl md:text-6xl lg:text-[92px] font-inter font-medium tracking-tight leading-tight">
+                              {displayTitle}
+                            </h1>
+                            <h2 className="text-2xl md:text-4xl lg:text-[51px] font-inter font-light tracking-tight">
+                              {displaySubtitle}
+                            </h2>
+                          </div>
+                          <p
+                            className="text-sm md:text-[16px] font-inter font-medium max-w-md mx-auto md:mx-0 leading-relaxed"
+                            style={{ opacity: 0.9 }}
+                          >
+                            {displayDescription}
+                          </p>
+                          <Button
+                            size="lg"
+                            className="text-sm md:text-[16px] font-inter font-medium rounded px-6 md:px-8 w-full md:w-auto transition-all duration-200 min-h-[44px] touch-manipulation mb-4 md:mb-0"
+                            style={{
+                              backgroundColor: buttonColor,
+                              color: buttonTextColor,
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.filter = "brightness(0.85)";
+                              e.currentTarget.style.transform = "scale(1.02)";
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.filter = "brightness(1)";
+                              e.currentTarget.style.transform = "scale(1)";
+                            }}
+                            asChild
+                          >
+                            <Link
+                              href={`/products/${generateSlug(displayTitle)}`}
+                            >
+                              {displayButtonText} →
+                            </Link>
+                          </Button>
+                        </div>
+
+                        {/* Right - Product Image */}
+                        <div className="relative h-[250px] md:h-[400px] lg:h-[500px] order-first md:order-last">
+                          <Image
+                            src={displayImage}
+                            alt={displayTitle || "Product image"}
+                            width={800}
+                            height={600}
+                            className="w-full h-full object-contain"
+                            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 40vw"
+                            priority={index === 0}
+                          />
+                          {/* Feature Callouts - Interactivos */}
+                          {productFeatures[displayTitle]?.map(
+                            (feature, featureIndex) => (
+                              <Tooltip key={featureIndex}>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    className="hidden md:flex absolute items-center justify-center bg-white rounded-full p-3 shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-110 cursor-pointer group z-10"
+                                    style={{
+                                      top: feature.position.top,
+                                      left: feature.position.left,
+                                      right: feature.position.right,
+                                      bottom: feature.position.bottom,
+                                    }}
+                                    onClick={() => {
+                                      setSelectedFeature(feature);
+                                      setIsFeatureDialogOpen(true);
+                                    }}
+                                    aria-label={`Ver característica: ${feature.title}`}
+                                  >
+                                    <div className="w-3 h-3 bg-gray-800 rounded-full group-hover:bg-gray-900 transition-colors" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                  side="top"
+                                  sideOffset={8}
+                                  className="max-w-[280px] bg-gray-900 text-white border-none shadow-xl p-3"
+                                >
+                                  <div className="space-y-1.5">
+                                    <p className="font-semibold text-sm leading-tight">
+                                      {feature.title}
+                                    </p>
+                                    <p className="text-xs opacity-90 leading-relaxed">
+                                      {feature.description}
+                                    </p>
+                                  </div>
+                                </TooltipContent>
+                              </Tooltip>
+                            ),
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                </div>
-              </div>
-            </CarouselItem>
-            )
-          })}
+                </CarouselItem>
+              );
+            },
+          )}
         </CarouselContent>
       </Carousel>
 
-      <div 
+      <div
         className="absolute bottom-0 left-0 right-0 h-16 pointer-events-none"
         style={{
-          background: barColor 
+          background: barColor
             ? `linear-gradient(to bottom, ${hexToRgba(barColor, 0.8)}, ${hexToRgba(barColor, 0.4)})`
             : `linear-gradient(to bottom, ${hexToRgba(accentColor, 0.8)}, ${hexToRgba(secondaryColor, 0.6)})`,
           // Asegurar que use los colores del tema activo
@@ -419,5 +558,5 @@ export function HeroBanner() {
         </DialogContent>
       </Dialog>
     </section>
-  )
+  );
 }

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -326,7 +326,7 @@ export function HeroBanner() {
       data-hero-layout={layoutMode}
       className={
         layoutMode === "full-image"
-          ? "relative w-full overflow-hidden mt-2 md:mt-4 mb-4 md:mb-8"
+          ? "relative w-full max-w-7xl overflow-hidden mx-auto mt-2 md:mt-4 mb-4 md:mb-8"
           : "relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto px-2 md:px-4 mt-2 md:mt-4 mb-4 md:mb-8"
       }
       style={{
@@ -573,16 +573,19 @@ export function HeroBanner() {
         </CarouselContent>
       </Carousel>
 
-      <div
-        className="absolute bottom-0 left-0 right-0 h-16 pointer-events-none"
-        style={{
-          background: barColor
-            ? `linear-gradient(to bottom, ${hexToRgba(barColor, 0.8)}, ${hexToRgba(barColor, 0.4)})`
-            : `linear-gradient(to bottom, ${hexToRgba(accentColor, 0.8)}, ${hexToRgba(secondaryColor, 0.6)})`,
-          // Asegurar que use los colores del tema activo
-          // Si el tema es oscuro, los colores se adaptarán automáticamente
-        }}
-      />
+      {layoutMode !== "full-image" && (
+        <div
+          data-testid="hero-bottom-bar"
+          className="absolute bottom-0 left-0 right-0 h-16 pointer-events-none"
+          style={{
+            background: barColor
+              ? `linear-gradient(to bottom, ${hexToRgba(barColor, 0.8)}, ${hexToRgba(barColor, 0.4)})`
+              : `linear-gradient(to bottom, ${hexToRgba(accentColor, 0.8)}, ${hexToRgba(secondaryColor, 0.6)})`,
+            // Asegurar que use los colores del tema activo
+            // Si el tema es oscuro, los colores se adaptarán automáticamente
+          }}
+        />
+      )}
 
       {/* Dialog para mostrar características */}
       <Dialog open={isFeatureDialogOpen} onOpenChange={setIsFeatureDialogOpen}>

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -324,7 +324,7 @@ export function HeroBanner() {
     <section
       data-component="hero"
       data-hero-layout={layoutMode}
-      className="relative overflow-hidden rounded-2xl md:rounded-3xl mx-2 md:mx-4 mt-2 md:mt-4 mb-4 md:mb-8"
+      className="relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto px-2 md:px-4 mt-2 md:mt-4 mb-4 md:mb-8"
       style={{
         backgroundColor: bgColor,
         color: textColor,

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -326,7 +326,7 @@ export function HeroBanner() {
       data-hero-layout={layoutMode}
       className={
         layoutMode === "full-image"
-          ? "relative w-full max-w-7xl overflow-hidden mx-auto mt-2 md:mt-4 mb-4 md:mb-8"
+          ? "relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto mt-2 md:mt-4 mb-4 md:mb-8"
           : "relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto px-2 md:px-4 mt-2 md:mt-4 mb-4 md:mb-8"
       }
       style={{

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -324,7 +324,11 @@ export function HeroBanner() {
     <section
       data-component="hero"
       data-hero-layout={layoutMode}
-      className="relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto px-2 md:px-4 mt-2 md:mt-4 mb-4 md:mb-8"
+      className={
+        layoutMode === "full-image"
+          ? "relative w-full overflow-hidden mt-2 md:mt-4 mb-4 md:mb-8"
+          : "relative w-full max-w-7xl overflow-hidden rounded-2xl md:rounded-3xl mx-auto px-2 md:px-4 mt-2 md:mt-4 mb-4 md:mb-8"
+      }
       style={{
         backgroundColor: bgColor,
         color: textColor,

--- a/components/sections/hero-banner.tsx
+++ b/components/sections/hero-banner.tsx
@@ -95,6 +95,29 @@ export function HeroBanner() {
     edits.overlayOpacity ?? styleData.overlayOpacity ?? 0.45,
   );
   const layoutMode = edits.layoutMode ?? styleData.layoutMode ?? "split";
+  const imageFit = edits.imageFit ?? styleData.imageFit ?? "cover";
+  const imagePositionX =
+    edits.imagePositionX ?? styleData.imagePositionX ?? "center";
+  const imagePositionY =
+    edits.imagePositionY ?? styleData.imagePositionY ?? "center";
+  const fullImageContentAlign =
+    edits.fullImageContentAlign ?? styleData.fullImageContentAlign ?? "left";
+
+  const fullImageFitClass =
+    imageFit === "contain" ? "object-contain" : "object-cover";
+  const fullImageObjectPosition = `${imagePositionX} ${imagePositionY}`;
+  const fullImageContentPositionClass =
+    fullImageContentAlign === "center"
+      ? "justify-center"
+      : fullImageContentAlign === "right"
+        ? "justify-end"
+        : "justify-start";
+  const fullImageTextAlignClass =
+    fullImageContentAlign === "center"
+      ? "text-center"
+      : fullImageContentAlign === "right"
+        ? "text-right"
+        : "text-left";
 
   // Características por producto
   const productFeatures: Record<
@@ -358,7 +381,8 @@ export function HeroBanner() {
                             src={displayImage}
                             alt={displayTitle || "Hero background image"}
                             fill
-                            className="object-cover"
+                            className={fullImageFitClass}
+                            style={{ objectPosition: fullImageObjectPosition }}
                             sizes="100vw"
                             priority={index === 0}
                           />
@@ -370,9 +394,21 @@ export function HeroBanner() {
                             }}
                           />
                         </div>
-                        <div className="relative z-10 flex min-h-[460px] md:min-h-[560px] lg:min-h-[640px] items-center px-6 py-12 md:px-10 lg:px-16">
+                        <div
+                          data-testid={
+                            index === 0
+                              ? "hero-full-content-container"
+                              : undefined
+                          }
+                          className={`relative z-10 flex min-h-[460px] md:min-h-[560px] lg:min-h-[640px] items-center px-6 py-12 md:px-10 lg:px-16 ${fullImageContentPositionClass}`}
+                        >
                           <div
-                            className="max-w-3xl space-y-4 md:space-y-6 text-left"
+                            data-testid={
+                              index === 0
+                                ? "hero-full-content-block"
+                                : undefined
+                            }
+                            className={`max-w-3xl space-y-4 md:space-y-6 ${fullImageTextAlignClass}`}
                             style={{ color: textColor }}
                           >
                             <span

--- a/contexts/admin-context.tsx
+++ b/contexts/admin-context.tsx
@@ -1,97 +1,211 @@
-"use client"
+"use client";
 
-import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
-import { useAuth } from "@/contexts/auth-context"
-import { isCurrentUserAdmin } from "@/lib/supabase/permissions-api"
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { useAuth } from "@/contexts/auth-context";
+import { isCurrentUserAdmin } from "@/lib/supabase/permissions-api";
 
 interface AdminContextType {
-  isEditMode: boolean
-  isAdmin: boolean
-  selectedComponent: string | null
-  selectComponent: (componentName: string | null) => void
-  componentEdits: Map<string, Record<string, any>>
-  updateComponentEdit: (componentName: string, key: string, value: any) => void
-  clearComponentEdits: (componentName: string) => void
-  getAllEdits: () => Map<string, Record<string, any>>
-  toggleEditMode: () => void
+  isEditMode: boolean;
+  isAdmin: boolean;
+  selectedComponent: string | null;
+  selectComponent: (componentName: string | null) => void;
+  componentEdits: Map<string, Record<string, any>>;
+  updateComponentEdit: (componentName: string, key: string, value: any) => void;
+  scheduleComponentEdit: (
+    componentName: string,
+    key: string,
+    value: any,
+    delay?: number,
+  ) => void;
+  flushScheduledEdits: (componentName?: string) => void;
+  clearComponentEdits: (componentName: string) => void;
+  getAllEdits: () => Map<string, Record<string, any>>;
+  getComponentEditsSnapshot: (componentName: string) => Record<string, any>;
+  toggleEditMode: () => void;
 }
 
-const AdminContext = createContext<AdminContextType | undefined>(undefined)
+const AdminContext = createContext<AdminContextType | undefined>(undefined);
 
 export function AdminProvider({ children }: { children: ReactNode }) {
-  const [isEditMode, setIsEditMode] = useState(false)
-  const [selectedComponent, setSelectedComponent] = useState<string | null>(null)
-  const [componentEdits, setComponentEdits] = useState<Map<string, Record<string, any>>>(new Map())
-  const [isAdmin, setIsAdmin] = useState(false)
-  const { isAuthenticated, user } = useAuth()
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [selectedComponent, setSelectedComponent] = useState<string | null>(
+    null,
+  );
+  const [componentEdits, setComponentEdits] = useState<
+    Map<string, Record<string, any>>
+  >(new Map());
+  const [isAdmin, setIsAdmin] = useState(false);
+  const { isAuthenticated, user } = useAuth();
+  const pendingEditsRef = useState(
+    () => new Map<string, Map<string, any>>(),
+  )[0];
+  const scheduledTimeoutsRef = useState(
+    () => new Map<string, ReturnType<typeof setTimeout>>(),
+  )[0];
 
   // Verificar si el usuario es admin cuando cambia la autenticación
   useEffect(() => {
     const checkAdminStatus = async () => {
       if (isAuthenticated && user) {
         try {
-          const adminStatus = await isCurrentUserAdmin()
-          setIsAdmin(adminStatus)
+          const adminStatus = await isCurrentUserAdmin();
+          setIsAdmin(adminStatus);
           // Si el usuario deja de ser admin, desactivar modo edición
           if (!adminStatus) {
-            setIsEditMode(false)
-            setSelectedComponent(null)
+            setIsEditMode(false);
+            setSelectedComponent(null);
           }
         } catch (error) {
-          console.error("[Admin] Error verificando rol de admin:", error)
-          setIsAdmin(false)
+          console.error("[Admin] Error verificando rol de admin:", error);
+          setIsAdmin(false);
         }
       } else {
-        setIsAdmin(false)
-        setIsEditMode(false)
-        setSelectedComponent(null)
+        setIsAdmin(false);
+        setIsEditMode(false);
+        setSelectedComponent(null);
       }
-    }
+    };
 
-    checkAdminStatus()
-  }, [isAuthenticated, user])
+    checkAdminStatus();
+  }, [isAuthenticated, user]);
 
   const toggleEditMode = () => {
     if (!isAdmin) {
-      console.warn("[Admin] Intento de activar modo edición sin permisos de admin")
-      return
+      console.warn(
+        "[Admin] Intento de activar modo edición sin permisos de admin",
+      );
+      return;
     }
     setIsEditMode((prev) => {
-      const newValue = !prev
-      console.log("[Admin] Modo edición:", newValue ? "ACTIVADO" : "DESACTIVADO")
+      const newValue = !prev;
+      console.log(
+        "[Admin] Modo edición:",
+        newValue ? "ACTIVADO" : "DESACTIVADO",
+      );
       if (!newValue) {
         // Si se desactiva, limpiar selección
-        setSelectedComponent(null)
+        setSelectedComponent(null);
       }
-      return newValue
-    })
-  }
+      return newValue;
+    });
+  };
 
   const selectComponent = (componentName: string | null) => {
-    if (!isAdmin || !isEditMode) return
-    setSelectedComponent(componentName)
-  }
+    if (!isAdmin || !isEditMode) return;
+    setSelectedComponent(componentName);
+  };
 
-  const updateComponentEdit = (componentName: string, key: string, value: any) => {
-    if (!isAdmin) return
+  const updateComponentEdit = (
+    componentName: string,
+    key: string,
+    value: any,
+  ) => {
+    if (!isAdmin) return;
     setComponentEdits((prev) => {
-      const newMap = new Map(prev)
-      const currentEdits = newMap.get(componentName) || {}
-      newMap.set(componentName, { ...currentEdits, [key]: value })
-      return newMap
-    })
-  }
+      const newMap = new Map(prev);
+      const currentEdits = newMap.get(componentName) || {};
+      if (currentEdits[key] === value) {
+        return prev;
+      }
+      newMap.set(componentName, { ...currentEdits, [key]: value });
+      return newMap;
+    });
+  };
+
+  const commitPendingEdit = (componentName: string, key: string) => {
+    const componentPending = pendingEditsRef.get(componentName);
+    if (!componentPending || !componentPending.has(key)) return;
+
+    const value = componentPending.get(key);
+    componentPending.delete(key);
+    if (componentPending.size === 0) {
+      pendingEditsRef.delete(componentName);
+    }
+
+    scheduledTimeoutsRef.delete(`${componentName}:${key}`);
+    updateComponentEdit(componentName, key, value);
+  };
+
+  const scheduleComponentEdit = (
+    componentName: string,
+    key: string,
+    value: any,
+    delay = 120,
+  ) => {
+    if (!isAdmin) return;
+
+    const componentPending =
+      pendingEditsRef.get(componentName) || new Map<string, any>();
+    componentPending.set(key, value);
+    pendingEditsRef.set(componentName, componentPending);
+
+    const timeoutKey = `${componentName}:${key}`;
+    const existingTimeout = scheduledTimeoutsRef.get(timeoutKey);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+    }
+
+    const timeoutId = setTimeout(
+      () => commitPendingEdit(componentName, key),
+      delay,
+    );
+    scheduledTimeoutsRef.set(timeoutKey, timeoutId);
+  };
+
+  const flushScheduledEdits = (componentName?: string) => {
+    if (!isAdmin) return;
+
+    const pendingKeys = Array.from(scheduledTimeoutsRef.keys());
+    pendingKeys.forEach((timeoutKey) => {
+      const [pendingComponent, pendingKey] = timeoutKey.split(":");
+      if (componentName && pendingComponent !== componentName) return;
+
+      const timeoutId = scheduledTimeoutsRef.get(timeoutKey);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      commitPendingEdit(pendingComponent, pendingKey);
+    });
+  };
 
   const clearComponentEdits = (componentName: string) => {
-    if (!isAdmin) return
+    if (!isAdmin) return;
     setComponentEdits((prev) => {
-      const newMap = new Map(prev)
-      newMap.delete(componentName)
-      return newMap
-    })
-  }
+      const newMap = new Map(prev);
+      newMap.delete(componentName);
+      return newMap;
+    });
+  };
 
-  const getAllEdits = () => componentEdits
+  const getComponentEditsSnapshot = (componentName: string) => {
+    const committedEdits = componentEdits.get(componentName) || {};
+    const pendingEdits = pendingEditsRef.get(componentName);
+
+    if (!pendingEdits || pendingEdits.size === 0) {
+      return committedEdits;
+    }
+
+    return {
+      ...committedEdits,
+      ...Object.fromEntries(pendingEdits.entries()),
+    };
+  };
+
+  const getAllEdits = () => {
+    const mergedEdits = new Map(componentEdits);
+
+    pendingEditsRef.forEach((_pendingValues, componentName) => {
+      mergedEdits.set(componentName, getComponentEditsSnapshot(componentName));
+    });
+
+    return mergedEdits;
+  };
 
   return (
     <AdminContext.Provider
@@ -102,18 +216,21 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         selectComponent,
         componentEdits,
         updateComponentEdit,
+        scheduleComponentEdit,
+        flushScheduledEdits,
         clearComponentEdits,
         getAllEdits,
+        getComponentEditsSnapshot,
         toggleEditMode,
       }}
     >
       {children}
     </AdminContext.Provider>
-  )
+  );
 }
 
 export function useAdmin() {
-  const context = useContext(AdminContext)
+  const context = useContext(AdminContext);
   if (context === undefined) {
     return {
       isEditMode: false,
@@ -122,10 +239,13 @@ export function useAdmin() {
       selectComponent: () => {},
       componentEdits: new Map(),
       updateComponentEdit: () => {},
+      scheduleComponentEdit: () => {},
+      flushScheduledEdits: () => {},
       clearComponentEdits: () => {},
       getAllEdits: () => new Map(),
+      getComponentEditsSnapshot: () => ({}),
       toggleEditMode: () => {},
-    }
+    };
   }
-  return context
+  return context;
 }

--- a/contexts/admin-context.tsx
+++ b/contexts/admin-context.tsx
@@ -176,6 +176,18 @@ export function AdminProvider({ children }: { children: ReactNode }) {
 
   const clearComponentEdits = (componentName: string) => {
     if (!isAdmin) return;
+
+    pendingEditsRef.delete(componentName);
+
+    Array.from(scheduledTimeoutsRef.entries()).forEach(
+      ([timeoutKey, timeoutId]) => {
+        if (!timeoutKey.startsWith(`${componentName}:`)) return;
+
+        clearTimeout(timeoutId);
+        scheduledTimeoutsRef.delete(timeoutKey);
+      },
+    );
+
     setComponentEdits((prev) => {
       const newMap = new Map(prev);
       newMap.delete(componentName);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint app/api/store app/api/orders/send-confirmation-email lib/security tests/security tests/quality --max-warnings=0",
     "lint:full": "eslint . --max-warnings=0",
     "start": "next start",
-    "test": "vitest run -c tests/vitest.security.config.ts tests/security tests/quality",
+    "test": "node scripts/run-vitest.mjs",
     "test:full": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.quality.json",
     "typecheck:full": "tsc --noEmit",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;

--- a/scripts/27-setup-storage-bucket.sql
+++ b/scripts/27-setup-storage-bucket.sql
@@ -1,57 +1,203 @@
--- Script para configurar el bucket de Storage en Supabase
--- Este script debe ejecutarse en el SQL Editor de Supabase
+-- ============================================================
+-- SCRIPT DE SETUP OBLIGATORIO DE STORAGE (Supabase)
+-- Buckets requeridos por la app:
+--   1) products
+--   2) component-images
+--
+-- Este script es idempotente y fail-closed:
+-- - Declara ambos buckets explícitamente
+-- - Fuerza estado público en ambos
+-- - Crea políticas de lectura/escritura por bucket
+-- - Falla con EXCEPTION si falta algún bucket o no quedó público
+-- ============================================================
 
--- 1. Crear el bucket si no existe
--- Nota: Los buckets se crean desde la interfaz de Supabase Storage o mediante la API
--- Este script asume que el bucket ya existe o se creará manualmente
--- Bucket name: "component-images"
+BEGIN;
 
--- 2. Crear políticas RLS para el bucket "component-images"
--- Nota: Si las políticas ya existen, se eliminarán y se recrearán
+-- 1) Crear/asegurar buckets requeridos
+INSERT INTO storage.buckets (id, name, public)
+VALUES
+  ('products', 'products', TRUE),
+  ('component-images', 'component-images', TRUE)
+ON CONFLICT (id)
+DO UPDATE SET
+  name = EXCLUDED.name,
+  public = EXCLUDED.public;
 
--- Eliminar políticas existentes si existen (para evitar errores)
+-- 2) Función helper para permisos de escritura (admin/owner)
+--    Nota: evita dependencia dura de user_profiles.role, porque ese
+--    campo no siempre está presente en todos los entornos.
+CREATE OR REPLACE FUNCTION public.is_storage_admin()
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid UUID;
+  v_has_user_role_column BOOLEAN;
+  v_is_admin BOOLEAN := FALSE;
+BEGIN
+  v_uid := auth.uid();
+
+  IF v_uid IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_profiles'
+      AND column_name = 'role'
+  )
+  INTO v_has_user_role_column;
+
+  IF v_has_user_role_column THEN
+    EXECUTE
+      'SELECT EXISTS (
+         SELECT 1
+         FROM public.user_profiles
+         WHERE id = $1
+           AND role IN (''admin'', ''super_admin'')
+       )'
+    INTO v_is_admin
+    USING v_uid;
+  END IF;
+
+  IF v_is_admin THEN
+    RETURN TRUE;
+  END IF;
+
+  IF to_regclass('public.store_users') IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.store_users
+      WHERE user_id = v_uid
+        AND role IN ('owner', 'admin')
+    )
+    INTO v_is_admin;
+  END IF;
+
+  RETURN COALESCE(v_is_admin, FALSE);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.is_storage_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_storage_admin() TO authenticated;
+
+-- 3) Reemplazar políticas legacy (si existían)
 DROP POLICY IF EXISTS "Public Access" ON storage.objects;
 DROP POLICY IF EXISTS "Admin Upload" ON storage.objects;
 DROP POLICY IF EXISTS "Admin Update" ON storage.objects;
 DROP POLICY IF EXISTS "Admin Delete" ON storage.objects;
 
--- Política para lectura pública (todos pueden ver las imágenes)
-CREATE POLICY "Public Access"
-ON storage.objects FOR SELECT
+-- 4) Políticas explícitas por bucket
+DROP POLICY IF EXISTS "Storage public read products" ON storage.objects;
+DROP POLICY IF EXISTS "Storage public read component-images" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin upload products" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin upload component-images" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin update products" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin update component-images" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin delete products" ON storage.objects;
+DROP POLICY IF EXISTS "Storage admin delete component-images" ON storage.objects;
+
+CREATE POLICY "Storage public read products"
+ON storage.objects
+FOR SELECT
+USING (bucket_id = 'products');
+
+CREATE POLICY "Storage public read component-images"
+ON storage.objects
+FOR SELECT
 USING (bucket_id = 'component-images');
 
--- Política para subir imágenes (solo administradores)
-CREATE POLICY "Admin Upload"
-ON storage.objects FOR INSERT
+CREATE POLICY "Storage admin upload products"
+ON storage.objects
+FOR INSERT
+TO authenticated
 WITH CHECK (
-  bucket_id = 'component-images' AND
-  auth.uid() IN (
-    SELECT id FROM user_profiles WHERE role = 'admin'
-  )
+  bucket_id = 'products'
+  AND public.is_storage_admin()
 );
 
--- Política para actualizar imágenes (solo administradores)
-CREATE POLICY "Admin Update"
-ON storage.objects FOR UPDATE
+CREATE POLICY "Storage admin upload component-images"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'component-images'
+  AND public.is_storage_admin()
+);
+
+CREATE POLICY "Storage admin update products"
+ON storage.objects
+FOR UPDATE
+TO authenticated
 USING (
-  bucket_id = 'component-images' AND
-  auth.uid() IN (
-    SELECT id FROM user_profiles WHERE role = 'admin'
-  )
+  bucket_id = 'products'
+  AND public.is_storage_admin()
+)
+WITH CHECK (
+  bucket_id = 'products'
+  AND public.is_storage_admin()
 );
 
--- Política para eliminar imágenes (solo administradores)
-CREATE POLICY "Admin Delete"
-ON storage.objects FOR DELETE
+CREATE POLICY "Storage admin update component-images"
+ON storage.objects
+FOR UPDATE
+TO authenticated
 USING (
-  bucket_id = 'component-images' AND
-  auth.uid() IN (
-    SELECT id FROM user_profiles WHERE role = 'admin'
-  )
+  bucket_id = 'component-images'
+  AND public.is_storage_admin()
+)
+WITH CHECK (
+  bucket_id = 'component-images'
+  AND public.is_storage_admin()
 );
 
--- Nota: Si el bucket no existe, créalo manualmente desde:
--- Supabase Dashboard → Storage → New Bucket
--- Nombre: component-images
--- Público: Sí (para que las imágenes sean accesibles públicamente)
+CREATE POLICY "Storage admin delete products"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'products'
+  AND public.is_storage_admin()
+);
 
+CREATE POLICY "Storage admin delete component-images"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'component-images'
+  AND public.is_storage_admin()
+);
+
+-- 5) Verificación fail-closed de buckets requeridos
+DO $$
+DECLARE
+  v_missing_or_private TEXT[];
+BEGIN
+  SELECT ARRAY_AGG(req.bucket_name)
+  INTO v_missing_or_private
+  FROM (
+    VALUES ('products'), ('component-images')
+  ) AS req(bucket_name)
+  LEFT JOIN storage.buckets b ON b.id = req.bucket_name
+  WHERE b.id IS NULL OR COALESCE(b.public, FALSE) IS FALSE;
+
+  IF v_missing_or_private IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Storage setup inválido. Buckets faltantes o no públicos: %',
+      array_to_string(v_missing_or_private, ', ')
+      USING HINT = 'Ejecutá scripts/27-setup-storage-bucket.sql y luego scripts/27-verify-storage-buckets.sql.';
+  END IF;
+END;
+$$;
+
+COMMIT;
+
+-- Checklist rápido post-setup:
+-- 1) Ejecutar scripts/27-verify-storage-buckets.sql
+-- 2) Confirmar que products y component-images figuran como públicos
+-- 3) Confirmar políticas "Storage public/admin ..." en storage.objects

--- a/scripts/27-verify-storage-buckets.sql
+++ b/scripts/27-verify-storage-buckets.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- VERIFICACIÓN DE STORAGE REQUERIDO (fail-closed)
+-- Requisitos:
+--   - Bucket products existe y es público
+--   - Bucket component-images existe y es público
+-- ============================================================
+
+-- 1) Estado detallado por bucket requerido
+SELECT
+  req.bucket_name,
+  CASE WHEN b.id IS NOT NULL THEN 'yes' ELSE 'no' END AS exists,
+  COALESCE(b.public, FALSE) AS is_public,
+  CASE
+    WHEN b.id IS NOT NULL AND COALESCE(b.public, FALSE) THEN 'PASS'
+    ELSE 'FAIL'
+  END AS status
+FROM (
+  VALUES ('products'), ('component-images')
+) AS req(bucket_name)
+LEFT JOIN storage.buckets b ON b.id = req.bucket_name
+ORDER BY req.bucket_name;
+
+-- 2) Verificación de políticas esperadas
+SELECT
+  policyname,
+  cmd,
+  qual,
+  with_check
+FROM pg_policies
+WHERE schemaname = 'storage'
+  AND tablename = 'objects'
+  AND policyname IN (
+    'Storage public read products',
+    'Storage public read component-images',
+    'Storage admin upload products',
+    'Storage admin upload component-images',
+    'Storage admin update products',
+    'Storage admin update component-images',
+    'Storage admin delete products',
+    'Storage admin delete component-images'
+  )
+ORDER BY policyname;
+
+-- 3) Guard rail fail-closed
+DO $$
+DECLARE
+  v_missing_or_private TEXT[];
+BEGIN
+  SELECT ARRAY_AGG(req.bucket_name)
+  INTO v_missing_or_private
+  FROM (
+    VALUES ('products'), ('component-images')
+  ) AS req(bucket_name)
+  LEFT JOIN storage.buckets b ON b.id = req.bucket_name
+  WHERE b.id IS NULL OR COALESCE(b.public, FALSE) IS FALSE;
+
+  IF v_missing_or_private IS NOT NULL THEN
+    RAISE EXCEPTION
+      'FAIL: buckets faltantes o no públicos: %',
+      array_to_string(v_missing_or_private, ', ')
+      USING HINT = 'Ejecutá scripts/27-setup-storage-bucket.sql antes de continuar.';
+  END IF;
+END;
+$$;
+
+-- Si llegaste acá sin exception, la verificación pasó.

--- a/scripts/36-fix-ecommerce-component-styles-permissions.sql
+++ b/scripts/36-fix-ecommerce-component-styles-permissions.sql
@@ -1,0 +1,113 @@
+-- ============================================================
+-- FIX: permisos y RLS para ecommerce.component_styles
+-- Scope: SOLO schema ecommerce
+-- No tocar public.*
+-- Objetivo:
+--   - mantener lectura pública/autenticada existente
+--   - habilitar INSERT/UPDATE/DELETE para authenticated
+--   - restringir mutaciones a admins reales del ecommerce
+-- ============================================================
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('ecommerce.component_styles') IS NULL THEN
+    RAISE EXCEPTION 'Missing table ecommerce.component_styles';
+  END IF;
+
+  IF to_regclass('ecommerce.user_profiles') IS NULL THEN
+    RAISE EXCEPTION 'Missing table ecommerce.user_profiles';
+  END IF;
+
+  IF to_regclass('ecommerce.store_users') IS NULL THEN
+    RAISE EXCEPTION 'Missing table ecommerce.store_users';
+  END IF;
+
+  IF to_regclass('ecommerce.store_user_roles') IS NULL THEN
+    RAISE EXCEPTION 'Missing table ecommerce.store_user_roles';
+  END IF;
+
+  IF to_regclass('ecommerce.roles') IS NULL THEN
+    RAISE EXCEPTION 'Missing table ecommerce.roles';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ecommerce.is_component_styles_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ecommerce, public, auth
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Camino hoy poblado en staging/live ecommerce
+  IF EXISTS (
+    SELECT 1
+    FROM ecommerce.user_profiles up
+    WHERE up.id = v_uid
+      AND lower(coalesce(up.role, '')) IN ('admin', 'super_admin')
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Camino futuro compatible con roles por tienda
+  IF EXISTS (
+    SELECT 1
+    FROM ecommerce.store_users su
+    JOIN ecommerce.store_user_roles sur ON sur.store_user_id = su.id
+    JOIN ecommerce.roles r ON r.id = sur.role_id
+    WHERE su.user_id = v_uid
+      AND lower(coalesce(r.role_name, '')) IN ('owner', 'admin', 'super_admin', 'store_admin')
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN FALSE;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION ecommerce.is_component_styles_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION ecommerce.is_component_styles_admin() TO authenticated;
+
+ALTER TABLE ecommerce.component_styles ENABLE ROW LEVEL SECURITY;
+
+GRANT INSERT, UPDATE, DELETE ON ecommerce.component_styles TO authenticated;
+
+DROP POLICY IF EXISTS "Component styles public read" ON ecommerce.component_styles;
+DROP POLICY IF EXISTS "Component styles admin insert" ON ecommerce.component_styles;
+DROP POLICY IF EXISTS "Component styles admin update" ON ecommerce.component_styles;
+DROP POLICY IF EXISTS "Component styles admin delete" ON ecommerce.component_styles;
+
+CREATE POLICY "Component styles public read"
+ON ecommerce.component_styles
+FOR SELECT
+TO public
+USING (true);
+
+CREATE POLICY "Component styles admin insert"
+ON ecommerce.component_styles
+FOR INSERT
+TO authenticated
+WITH CHECK (ecommerce.is_component_styles_admin());
+
+CREATE POLICY "Component styles admin update"
+ON ecommerce.component_styles
+FOR UPDATE
+TO authenticated
+USING (ecommerce.is_component_styles_admin())
+WITH CHECK (ecommerce.is_component_styles_admin());
+
+CREATE POLICY "Component styles admin delete"
+ON ecommerce.component_styles
+FOR DELETE
+TO authenticated
+USING (ecommerce.is_component_styles_admin());
+
+COMMIT;

--- a/scripts/36-verify-ecommerce-component-styles-permissions.sql
+++ b/scripts/36-verify-ecommerce-component-styles-permissions.sql
@@ -1,0 +1,60 @@
+-- ============================================================
+-- VERIFICACIÓN: ecommerce.component_styles permisos y RLS
+-- Scope: SOLO schema ecommerce
+-- ============================================================
+
+-- 1) Helper debe existir en ecommerce
+SELECT n.nspname AS schema_name, p.proname AS function_name
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'ecommerce'
+  AND p.proname = 'is_component_styles_admin';
+
+-- 2) Privilegios efectivos para authenticated
+SELECT
+  has_schema_privilege('authenticated', 'ecommerce', 'USAGE') AS auth_schema_usage,
+  has_table_privilege('authenticated', 'ecommerce.component_styles', 'SELECT') AS auth_select,
+  has_table_privilege('authenticated', 'ecommerce.component_styles', 'INSERT') AS auth_insert,
+  has_table_privilege('authenticated', 'ecommerce.component_styles', 'UPDATE') AS auth_update,
+  has_table_privilege('authenticated', 'ecommerce.component_styles', 'DELETE') AS auth_delete;
+
+-- 3) RLS debe estar habilitado
+SELECT
+  n.nspname AS schema_name,
+  c.relname AS table_name,
+  c.relrowsecurity,
+  c.relforcerowsecurity
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'ecommerce'
+  AND c.relname = 'component_styles';
+
+-- 4) Policies esperadas
+SELECT policyname, cmd, roles, qual, with_check
+FROM pg_policies
+WHERE schemaname = 'ecommerce'
+  AND tablename = 'component_styles'
+ORDER BY policyname;
+
+-- 5) Guard rail fail-closed
+DO $$
+DECLARE
+  v_policy_count integer;
+BEGIN
+  SELECT count(*)
+  INTO v_policy_count
+  FROM pg_policies
+  WHERE schemaname = 'ecommerce'
+    AND tablename = 'component_styles'
+    AND policyname IN (
+      'Component styles public read',
+      'Component styles admin insert',
+      'Component styles admin update',
+      'Component styles admin delete'
+    );
+
+  IF v_policy_count <> 4 THEN
+    RAISE EXCEPTION 'FAIL: expected 4 component_styles policies, got %', v_policy_count;
+  END IF;
+END;
+$$;

--- a/scripts/inicializar-base-datos.sql
+++ b/scripts/inicializar-base-datos.sql
@@ -33,29 +33,37 @@
 -- Ejecutar: 31-add-store-id-to-products.sql
 -- Agrega store_id a productos y categorías
 
--- 6. PEDIDOS
+-- 6. STORAGE (OBLIGATORIO)
+-- Ejecutar: 27-setup-storage-bucket.sql
+-- Declara y valida buckets requeridos: products y component-images (ambos públicos)
+
+-- 7. PEDIDOS
 -- Ejecutar: 29-create-orders-tables.sql
 -- Crea las tablas de pedidos y items de pedido
 
--- 7. RELACIONAR PEDIDOS CON TIENDAS
+-- 8. RELACIONAR PEDIDOS CON TIENDAS
 -- Ejecutar: 32-add-store-id-to-orders.sql
 -- Agrega store_id a pedidos
 
--- 8. RELACIONAR ESTILOS CON TIENDAS
+-- 9. RELACIONAR ESTILOS CON TIENDAS
 -- Ejecutar: 33-add-store-id-to-styles.sql
 -- Agrega store_id a temas y estilos
 
--- 9. CONFIGURAR RLS (Row Level Security)
+-- 10. CONFIGURAR RLS (Row Level Security)
 -- Ejecutar: 18-fix-rls-y-datos-final.sql
 -- Configura las políticas de seguridad
 
--- 10. CREAR TIENDA DE EJEMPLO
+-- 11. CREAR TIENDA DE EJEMPLO
 -- Ejecutar: 34-create-reposteria-store.sql
 -- Crea la tienda "reposteria" de ejemplo
 
--- 11. CONFIGURAR TEMA PARA REPOSTERÍA
+-- 12. CONFIGURAR TEMA PARA REPOSTERÍA
 -- Ejecutar: 35-update-reposteria-theme.sql
 -- Configura el tema visual para la tienda de repostería
+
+-- 13. VERIFICAR STORAGE (OBLIGATORIO)
+-- Ejecutar: 27-verify-storage-buckets.sql
+-- Fail-closed si falta products/component-images o no son públicos
 
 -- ============================================
 -- SCRIPTS OPCIONALES:
@@ -65,7 +73,6 @@
 -- 22-create-cart-tables.sql - Tabla de carritos (si no usas Shopify)
 -- 23-create-admin-user.sql - Crear usuario administrador
 -- 27-insert-sample-products.sql - Insertar productos de ejemplo
--- 27-setup-storage-bucket.sql - Configurar bucket de almacenamiento
 
 -- ============================================
 -- VERIFICACIÓN FINAL:
@@ -93,3 +100,9 @@ SELECT schemaname, tablename, policyname
 FROM pg_policies
 WHERE schemaname = 'public'
 ORDER BY tablename, policyname;
+
+-- Verificar buckets de Storage requeridos (debe devolver 2 filas públicas)
+SELECT id, name, public
+FROM storage.buckets
+WHERE id IN ('products', 'component-images')
+ORDER BY id;

--- a/scripts/inicializar-base-datos.sql
+++ b/scripts/inicializar-base-datos.sql
@@ -65,6 +65,11 @@
 -- Ejecutar: 27-verify-storage-buckets.sql
 -- Fail-closed si falta products/component-images o no son públicos
 
+-- 14. FIX DE PERMISOS PARA COMPONENT STYLES (si el editor devuelve 403/42501)
+-- Ejecutar: 36-fix-ecommerce-component-styles-permissions.sql
+-- Scope: ecommerce.component_styles solamente; no tocar public
+-- Verificar con: 36-verify-ecommerce-component-styles-permissions.sql
+
 -- ============================================
 -- SCRIPTS OPCIONALES:
 -- ============================================

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const args = process.argv.slice(2);
+const runIndex = args.indexOf("--run");
+const rawPatterns = runIndex >= 0 ? args.slice(runIndex + 1) : args;
+
+function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function globToRegex(pattern) {
+  const normalized = pattern.replaceAll(path.sep, "/");
+  const regexSource = normalized
+    .split("**")
+    .map((part) => part.split("*").map(escapeRegex).join("[^/]*"))
+    .join(".*");
+
+  return new RegExp(`^${regexSource}$`);
+}
+
+function walkFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return walkFiles(fullPath);
+    }
+
+    return [fullPath];
+  });
+}
+
+function expandPatterns(patterns) {
+  if (patterns.length === 0) {
+    return [];
+  }
+
+  const allFiles = walkFiles(path.join(rootDir, "tests"));
+  const matches = new Set();
+
+  patterns.forEach((pattern) => {
+    if (!pattern.includes("*")) {
+      matches.add(pattern);
+      return;
+    }
+
+    const regex = globToRegex(pattern);
+    allFiles.forEach((filePath) => {
+      const relativePath = path
+        .relative(rootDir, filePath)
+        .replaceAll(path.sep, "/");
+      if (regex.test(relativePath)) {
+        matches.add(relativePath);
+      }
+    });
+  });
+
+  return Array.from(matches);
+}
+
+const expandedFiles = expandPatterns(rawPatterns);
+const vitestArgs = ["run", "-c", "vitest.config.ts"];
+
+if (expandedFiles.length > 0) {
+  vitestArgs.push(...expandedFiles);
+}
+
+const result = spawnSync("npx", ["vitest", ...vitestArgs], {
+  stdio: "inherit",
+  cwd: rootDir,
+  shell: false,
+});
+
+process.exit(result.status ?? 1);

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -91,6 +91,10 @@ describe("EditorPanel", () => {
     });
 
     render(<EditorPanel />);
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
     const input = screen.getByLabelText("Color de Fondo");
     fireEvent.change(input, { target: { value: "#111111" } });
     fireEvent.change(input, { target: { value: "#222222" } });
@@ -102,5 +106,53 @@ describe("EditorPanel", () => {
       "bgColor",
       "#333333",
     );
+  });
+
+  it("renders only content tab panel by default", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    expect(screen.getByText("Contenido del Componente")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Estilos del Componente"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches between tabs showing only the active panel", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
+    expect(screen.getByText("Estilos del Componente")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Contenido del Componente"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { EditorPanel } from "@/components/admin/editor-panel";
+
+const mockUseAdmin = vi.fn();
+const mockUseStyles = vi.fn();
+const mockUseStore = vi.fn();
+
+vi.mock("@/contexts/admin-context", () => ({
+  useAdmin: () => mockUseAdmin(),
+}));
+
+vi.mock("@/contexts/styles-context", () => ({
+  useStyles: () => mockUseStyles(),
+}));
+
+vi.mock("@/contexts/store-context", () => ({
+  useStore: () => mockUseStore(),
+}));
+
+vi.mock("@/lib/supabase/styles-api", () => ({
+  updateComponentStyle: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/store", () => ({
+  getStoreId: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/admin/image-upload", () => ({
+  ImageUpload: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+describe("EditorPanel", () => {
+  beforeEach(() => {
+    mockUseStyles.mockReturnValue({
+      styles: new Map(),
+      refreshStyles: vi.fn(),
+    });
+
+    mockUseStore.mockReturnValue({
+      store: { subdomain: "default" },
+    });
+  });
+
+  it("shows clearer hero content guidance, including the new layout selector", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    expect(screen.getByText("Contenido del Componente")).toBeInTheDocument();
+    expect(
+      screen.getByText(/organizá el mensaje, los slides y el tipo de banner/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Diseño del Banner")).toBeInTheDocument();
+  });
+
+  it("routes rapid color edits through the scheduled update path", () => {
+    const updateComponentEdit = vi.fn();
+    const scheduleComponentEdit = vi.fn();
+
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit,
+      scheduleComponentEdit,
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+    const input = screen.getByLabelText("Color de Fondo");
+    fireEvent.change(input, { target: { value: "#111111" } });
+    fireEvent.change(input, { target: { value: "#222222" } });
+    fireEvent.change(input, { target: { value: "#333333" } });
+
+    expect(updateComponentEdit).not.toHaveBeenCalled();
+    expect(scheduleComponentEdit).toHaveBeenLastCalledWith(
+      "hero",
+      "bgColor",
+      "#333333",
+    );
+  });
+});

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -108,6 +108,78 @@ describe("EditorPanel", () => {
     );
   });
 
+  it("avoids eager css variable mutations while dragging color inputs", () => {
+    const scheduleComponentEdit = vi.fn();
+    const setPropertySpy = vi.spyOn(
+      document.documentElement.style,
+      "setProperty",
+    );
+
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit,
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
+    const input = screen.getByLabelText("Color de Fondo");
+    fireEvent.change(input, { target: { value: "#111111" } });
+    fireEvent.change(input, { target: { value: "#222222" } });
+    fireEvent.change(input, { target: { value: "#333333" } });
+
+    expect(scheduleComponentEdit).toHaveBeenCalledTimes(3);
+    expect(setPropertySpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps text color drags on scheduled path without touching root styles", () => {
+    const scheduleComponentEdit = vi.fn();
+    const setPropertySpy = vi.spyOn(
+      document.documentElement.style,
+      "setProperty",
+    );
+
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit,
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
+    const textColorInput = screen.getByLabelText("Color de Texto");
+    fireEvent.change(textColorInput, { target: { value: "#a1a1a1" } });
+    fireEvent.change(textColorInput, { target: { value: "#b2b2b2" } });
+
+    expect(scheduleComponentEdit).toHaveBeenCalledTimes(2);
+    expect(scheduleComponentEdit).toHaveBeenLastCalledWith(
+      "hero",
+      "textColor",
+      "#b2b2b2",
+    );
+    expect(setPropertySpy).not.toHaveBeenCalled();
+  });
+
   it("renders only content tab panel by default", () => {
     mockUseAdmin.mockReturnValue({
       selectedComponent: "hero",

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -71,6 +71,18 @@ describe("EditorPanel", () => {
       screen.getByText(/organizá el mensaje, los slides y el tipo de banner/i),
     ).toBeInTheDocument();
     expect(screen.getByText("Diseño del Banner")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ajuste de Imagen (Full image)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Posición Horizontal de Imagen (Full image)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Posición Vertical de Imagen (Full image)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Alineación de Contenido (Full image)"),
+    ).toBeInTheDocument();
   });
 
   it("routes rapid color edits through the scheduled update path", () => {

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -74,6 +74,7 @@ describe("EditorPanel", () => {
     expect(
       screen.queryByText("Ajuste de Imagen (Full image)"),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("Ajuste de Imagen")).not.toBeInTheDocument();
   });
 
   it("uses concise hero layout option labels", () => {
@@ -153,18 +154,24 @@ describe("EditorPanel", () => {
 
     render(<EditorPanel />);
 
+    expect(screen.getByText("Ajuste de Imagen")).toBeInTheDocument();
     expect(
-      screen.getByText("Ajuste de Imagen (Full image)"),
+      screen.getByText("Posición Horizontal de Imagen"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Posición Vertical de Imagen")).toBeInTheDocument();
+    expect(screen.getByText("Alineación de Contenido")).toBeInTheDocument();
     expect(
-      screen.getByText("Posición Horizontal de Imagen (Full image)"),
-    ).toBeInTheDocument();
+      screen.queryByText("Ajuste de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Posición Vertical de Imagen (Full image)"),
-    ).toBeInTheDocument();
+      screen.queryByText("Posición Horizontal de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Alineación de Contenido (Full image)"),
-    ).toBeInTheDocument();
+      screen.queryByText("Posición Vertical de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Alineación de Contenido (Full image)"),
+    ).not.toBeInTheDocument();
   });
 
   it("routes rapid color edits through the scheduled update path", () => {

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -72,6 +72,88 @@ describe("EditorPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Diseño del Banner")).toBeInTheDocument();
     expect(
+      screen.queryByText("Ajuste de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses concise hero layout option labels", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    const [layoutModeSelector] = screen.getAllByRole("combobox");
+    fireEvent.click(layoutModeSelector);
+
+    expect(screen.getByRole("option", { name: "Split" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Full Image" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Split actual (texto + imagen lateral)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Full image (imagen completa de fondo)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides full-image-only controls when hero layout is split", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    expect(
+      screen.queryByText("Ajuste de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Posición Horizontal de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Posición Vertical de Imagen (Full image)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Alineación de Contenido (Full image)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows full-image-only controls when hero layout is full-image", () => {
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "hero",
+      selectComponent: vi.fn(),
+      componentEdits: new Map([["hero", { layoutMode: "full-image" }]]),
+      updateComponentEdit: vi.fn(),
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    render(<EditorPanel />);
+
+    expect(
       screen.getByText("Ajuste de Imagen (Full image)"),
     ).toBeInTheDocument();
     expect(

--- a/tests/components/editor-panel.test.tsx
+++ b/tests/components/editor-panel.test.tsx
@@ -180,6 +180,94 @@ describe("EditorPanel", () => {
     expect(setPropertySpy).not.toHaveBeenCalled();
   });
 
+  it("keeps site background color edits on the scheduled path without mutating body styles", () => {
+    const updateComponentEdit = vi.fn();
+    const scheduleComponentEdit = vi.fn();
+
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "site_background",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit,
+      scheduleComponentEdit,
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    document.body.style.backgroundColor = "rgb(1, 2, 3)";
+
+    render(<EditorPanel />);
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
+    const input = screen.getByLabelText("Color de Fondo");
+    fireEvent.change(input, { target: { value: "#abcdef" } });
+
+    expect(updateComponentEdit).not.toHaveBeenCalled();
+    expect(scheduleComponentEdit).toHaveBeenCalledWith(
+      "site_background",
+      "backgroundColor",
+      "#abcdef",
+    );
+    expect(document.body.style.backgroundColor).toBe("rgb(1, 2, 3)");
+  });
+
+  it("does not eagerly touch body background when switching site background type", () => {
+    const updateComponentEdit = vi.fn();
+
+    mockUseStyles.mockReturnValue({
+      styles: new Map([
+        [
+          "site_background",
+          {
+            type: "image",
+            backgroundImage: "https://cdn.osoria.test/bg.jpg",
+            backgroundColor: "#112233",
+            backgroundPosition: "center",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "cover",
+          },
+        ],
+      ]),
+      refreshStyles: vi.fn(),
+    });
+
+    mockUseAdmin.mockReturnValue({
+      selectedComponent: "site_background",
+      selectComponent: vi.fn(),
+      componentEdits: new Map(),
+      updateComponentEdit,
+      scheduleComponentEdit: vi.fn(),
+      flushScheduledEdits: vi.fn(),
+      clearComponentEdits: vi.fn(),
+      getComponentEditsSnapshot: vi.fn(() => ({})),
+      isEditMode: true,
+      toggleEditMode: vi.fn(),
+    });
+
+    document.body.style.backgroundImage = "url(initial.jpg)";
+
+    render(<EditorPanel />);
+    const stylesTab = screen.getByRole("tab", { name: /estilos/i });
+    fireEvent.mouseDown(stylesTab);
+    fireEvent.click(stylesTab);
+
+    const [typeSelector] = screen.getAllByRole("combobox");
+    fireEvent.click(typeSelector);
+    fireEvent.click(screen.getByRole("option", { name: "Color" }));
+
+    expect(updateComponentEdit).toHaveBeenCalledWith(
+      "site_background",
+      "type",
+      "color",
+    );
+    expect(document.body.style.backgroundImage).toBe('url("initial.jpg")');
+  });
+
   it("renders only content tab panel by default", () => {
     mockUseAdmin.mockReturnValue({
       selectedComponent: "hero",

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -123,7 +123,7 @@ describe("HeroBanner", () => {
     expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
   });
 
-  it("keeps the max width but removes the bottom overlay band in full-image layout", () => {
+  it("keeps the max width, restores rounded corners and removes the bottom overlay band in full-image layout", () => {
     mockUseComponentStyle.mockReturnValue({
       styles: {
         layoutMode: "full-image",
@@ -144,6 +144,8 @@ describe("HeroBanner", () => {
     const hero = container.querySelector('[data-component="hero"]');
 
     expect(hero).toHaveClass("max-w-7xl");
+    expect(hero).toHaveClass("rounded-2xl");
+    expect(hero).toHaveClass("md:rounded-3xl");
     expect(hero).not.toHaveClass("px-2");
     expect(hero).not.toHaveClass("md:px-4");
     expect(screen.queryByTestId("hero-bottom-bar")).not.toBeInTheDocument();

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -122,4 +122,38 @@ describe("HeroBanner", () => {
     );
     expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
   });
+
+  it("applies full-image fit, position and content alignment controls", () => {
+    mockUseComponentStyle.mockReturnValue({
+      styles: {
+        layoutMode: "full-image",
+        imageFit: "contain",
+        imagePositionX: "left",
+        imagePositionY: "top",
+        fullImageContentAlign: "right",
+        products: [
+          {
+            label: "Audio",
+            title: "PREMIUM",
+            subtitle: "HEADPHONES",
+            description: "Auriculares premium",
+            buttonText: "Comprar ahora",
+            image: "/premium-headphones.png",
+          },
+        ],
+      },
+    });
+
+    render(<HeroBanner />);
+
+    const backgroundImage = screen.getByTestId("hero-full-background-image");
+    expect(backgroundImage).toHaveClass("object-contain");
+    expect(backgroundImage).toHaveStyle({ objectPosition: "left top" });
+
+    const contentContainer = screen.getByTestId("hero-full-content-container");
+    expect(contentContainer).toHaveClass("justify-end");
+
+    const contentBlock = screen.getByTestId("hero-full-content-block");
+    expect(contentBlock).toHaveClass("text-right");
+  });
 });

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -123,6 +123,29 @@ describe("HeroBanner", () => {
     expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
   });
 
+  it("keeps hero banner width constrained to ecommerce layout", () => {
+    mockUseComponentStyle.mockReturnValue({
+      styles: {
+        layoutMode: "full-image",
+        products: [
+          {
+            label: "Audio",
+            title: "PREMIUM",
+            subtitle: "HEADPHONES",
+            description: "Auriculares premium",
+            buttonText: "Comprar ahora",
+            image: "/premium-headphones.png",
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<HeroBanner />);
+    const hero = container.querySelector('[data-component="hero"]');
+
+    expect(hero).toHaveClass("max-w-7xl");
+  });
+
   it("applies full-image fit, position and content alignment controls", () => {
     mockUseComponentStyle.mockReturnValue({
       styles: {

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -123,7 +123,7 @@ describe("HeroBanner", () => {
     expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
   });
 
-  it("removes the boxed frame styling from the full-image layout", () => {
+  it("keeps the max width but removes the bottom overlay band in full-image layout", () => {
     mockUseComponentStyle.mockReturnValue({
       styles: {
         layoutMode: "full-image",
@@ -143,11 +143,10 @@ describe("HeroBanner", () => {
     const { container } = render(<HeroBanner />);
     const hero = container.querySelector('[data-component="hero"]');
 
-    expect(hero).not.toHaveClass("max-w-7xl");
-    expect(hero).not.toHaveClass("rounded-2xl");
-    expect(hero).not.toHaveClass("md:rounded-3xl");
+    expect(hero).toHaveClass("max-w-7xl");
     expect(hero).not.toHaveClass("px-2");
     expect(hero).not.toHaveClass("md:px-4");
+    expect(screen.queryByTestId("hero-bottom-bar")).not.toBeInTheDocument();
   });
 
   it("applies full-image fit, position and content alignment controls", () => {

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -123,7 +123,7 @@ describe("HeroBanner", () => {
     expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
   });
 
-  it("keeps hero banner width constrained to ecommerce layout", () => {
+  it("removes the boxed frame styling from the full-image layout", () => {
     mockUseComponentStyle.mockReturnValue({
       styles: {
         layoutMode: "full-image",
@@ -143,7 +143,11 @@ describe("HeroBanner", () => {
     const { container } = render(<HeroBanner />);
     const hero = container.querySelector('[data-component="hero"]');
 
-    expect(hero).toHaveClass("max-w-7xl");
+    expect(hero).not.toHaveClass("max-w-7xl");
+    expect(hero).not.toHaveClass("rounded-2xl");
+    expect(hero).not.toHaveClass("md:rounded-3xl");
+    expect(hero).not.toHaveClass("px-2");
+    expect(hero).not.toHaveClass("md:px-4");
   });
 
   it("applies full-image fit, position and content alignment controls", () => {

--- a/tests/components/hero-banner.test.tsx
+++ b/tests/components/hero-banner.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HeroBanner } from "@/components/sections/hero-banner";
+
+const mockUseComponentStyle = vi.fn();
+const mockUseAdmin = vi.fn();
+const mockUseTheme = vi.fn();
+
+vi.mock("next/image", () => ({
+  default: ({ alt, ...props }: any) => <img alt={alt} {...props} />,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/contexts/styles-context", () => ({
+  useComponentStyle: (...args: any[]) => mockUseComponentStyle(...args),
+}));
+
+vi.mock("@/contexts/admin-context", () => ({
+  useAdmin: () => mockUseAdmin(),
+}));
+
+vi.mock("@/contexts/theme-context", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("@/components/ui/carousel", () => ({
+  Carousel: ({ children }: any) => <div>{children}</div>,
+  CarouselContent: ({ children }: any) => <div>{children}</div>,
+  CarouselItem: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: any) => <div>{children}</div>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe("HeroBanner", () => {
+  beforeEach(() => {
+    mockUseTheme.mockReturnValue({
+      activeTheme: {
+        theme_name: "Claro",
+        colors: {
+          background: "#ffffff",
+          accent: "#005aa1",
+          secondary: "#c4faff",
+        },
+      },
+    });
+
+    mockUseAdmin.mockReturnValue({
+      componentEdits: new Map(),
+    });
+  });
+
+  it("keeps the existing split layout as the default mode", () => {
+    mockUseComponentStyle.mockReturnValue({
+      styles: {
+        layoutMode: "split",
+        products: [
+          {
+            label: "Audio",
+            title: "PREMIUM",
+            subtitle: "HEADPHONES",
+            description: "Auriculares premium",
+            buttonText: "Comprar ahora",
+            image: "/premium-headphones.png",
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<HeroBanner />);
+    const hero = container.querySelector('[data-component="hero"]');
+
+    expect(hero).toHaveAttribute("data-hero-layout", "split");
+    expect(screen.getByText("PREMIUM")).toBeInTheDocument();
+    expect(screen.getByAltText("PREMIUM")).toHaveClass("object-contain");
+  });
+
+  it("renders the new full-image layout with a full-bleed image layer", () => {
+    mockUseComponentStyle.mockReturnValue({
+      styles: {
+        layoutMode: "full-image",
+        overlayColor: "#101828",
+        overlayOpacity: "0.55",
+        products: [
+          {
+            label: "Audio",
+            title: "PREMIUM",
+            subtitle: "HEADPHONES",
+            description: "Auriculares premium",
+            buttonText: "Comprar ahora",
+            image: "/premium-headphones.png",
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<HeroBanner />);
+    const hero = container.querySelector('[data-component="hero"]');
+
+    expect(hero).toHaveAttribute("data-hero-layout", "full-image");
+    expect(screen.getByTestId("hero-full-background-image")).toHaveAttribute(
+      "src",
+      "/premium-headphones.png",
+    );
+    expect(screen.getByText("HEADPHONES")).toBeInTheDocument();
+  });
+});

--- a/tests/contexts/admin-context.test.tsx
+++ b/tests/contexts/admin-context.test.tsx
@@ -27,14 +27,23 @@ function Harness() {
   const {
     isAdmin,
     componentEdits,
+    updateComponentEdit,
     scheduleComponentEdit,
     flushScheduledEdits,
+    clearComponentEdits,
     getComponentEditsSnapshot,
   } = useAdmin();
 
   return (
     <div>
       <div data-testid="is-admin">{String(isAdmin)}</div>
+      <button
+        onClick={() => {
+          updateComponentEdit("hero", "bgColor", "#000000");
+        }}
+      >
+        commit
+      </button>
       <button
         onClick={() => {
           scheduleComponentEdit("hero", "bgColor", "#111111", 120);
@@ -52,6 +61,7 @@ function Harness() {
         second
       </button>
       <button onClick={() => flushScheduledEdits("hero")}>flush</button>
+      <button onClick={() => clearComponentEdits("hero")}>clear</button>
       <pre data-testid="snapshot">
         {JSON.stringify(getComponentEditsSnapshot("hero"))}
       </pre>
@@ -141,5 +151,42 @@ describe("AdminProvider", () => {
 
     expect(screen.getByTestId("edits")).toHaveTextContent("{}");
     expect(screen.getByTestId("snapshot")).toHaveTextContent("#111111");
+  });
+
+  it("clears pending scheduled edits so discarded values cannot reappear later", async () => {
+    render(
+      <AdminProvider>
+        <Harness />
+      </AdminProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("commit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("edits")).toHaveTextContent("#000000");
+    });
+
+    vi.useFakeTimers();
+
+    fireEvent.click(screen.getByText("second"));
+    fireEvent.click(screen.getByText("clear"));
+
+    expect(screen.getByTestId("edits")).toHaveTextContent("{}");
+    expect(screen.getByTestId("snapshot")).toHaveTextContent("{}");
+
+    await act(async () => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(screen.getByTestId("edits")).toHaveTextContent("{}");
+    expect(screen.getByTestId("snapshot")).toHaveTextContent("{}");
   });
 });

--- a/tests/contexts/admin-context.test.tsx
+++ b/tests/contexts/admin-context.test.tsx
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { AdminProvider, useAdmin } from "@/contexts/admin-context";
+
+const mockIsCurrentUserAdmin = vi.fn();
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: "admin-1" },
+  }),
+}));
+
+vi.mock("@/lib/supabase/permissions-api", () => ({
+  isCurrentUserAdmin: () => mockIsCurrentUserAdmin(),
+}));
+
+function Harness() {
+  const [, setRenderTick] = useState(0);
+  const {
+    isAdmin,
+    componentEdits,
+    scheduleComponentEdit,
+    flushScheduledEdits,
+    getComponentEditsSnapshot,
+  } = useAdmin();
+
+  return (
+    <div>
+      <div data-testid="is-admin">{String(isAdmin)}</div>
+      <button
+        onClick={() => {
+          scheduleComponentEdit("hero", "bgColor", "#111111", 120);
+          setRenderTick((value) => value + 1);
+        }}
+      >
+        first
+      </button>
+      <button
+        onClick={() => {
+          scheduleComponentEdit("hero", "bgColor", "#222222", 120);
+          setRenderTick((value) => value + 1);
+        }}
+      >
+        second
+      </button>
+      <button onClick={() => flushScheduledEdits("hero")}>flush</button>
+      <pre data-testid="snapshot">
+        {JSON.stringify(getComponentEditsSnapshot("hero"))}
+      </pre>
+      <pre data-testid="edits">
+        {JSON.stringify(Object.fromEntries(componentEdits))}
+      </pre>
+    </div>
+  );
+}
+
+describe("AdminProvider", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockIsCurrentUserAdmin.mockResolvedValue(true);
+  });
+
+  it("batches rapid scheduled edits into a single committed value", async () => {
+    render(
+      <AdminProvider>
+        <Harness />
+      </AdminProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("first"));
+    fireEvent.click(screen.getByText("second"));
+
+    expect(screen.getByTestId("edits")).toHaveTextContent("{}");
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("edits")).toHaveTextContent("#222222");
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("can flush scheduled edits before the debounce window finishes", async () => {
+    render(
+      <AdminProvider>
+        <Harness />
+      </AdminProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("second"));
+    fireEvent.click(screen.getByText("flush"));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("edits")).toHaveTextContent("#222222");
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("exposes pending scheduled edits in the snapshot before they flush", async () => {
+    render(
+      <AdminProvider>
+        <Harness />
+      </AdminProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("first"));
+
+    expect(screen.getByTestId("edits")).toHaveTextContent("{}");
+    expect(screen.getByTestId("snapshot")).toHaveTextContent("#111111");
+  });
+});

--- a/tests/quality/h2-quality-gates.test.ts
+++ b/tests/quality/h2-quality-gates.test.ts
@@ -34,9 +34,7 @@ describe("H2 quality gates contract", () => {
       "eslint app/api/store app/api/orders/send-confirmation-email lib/security tests/security tests/quality --max-warnings=0",
     );
     expect(scripts.typecheck).toBe("tsc --noEmit -p tsconfig.quality.json");
-    expect(scripts.test).toBe(
-      "vitest run -c tests/vitest.security.config.ts tests/security tests/quality",
-    );
+    expect(scripts.test).toBe("node scripts/run-vitest.mjs");
     expect(scripts.build).toBe("next build");
     expect(scripts["lint:full"]).toBe("eslint . --max-warnings=0");
     expect(scripts["typecheck:full"]).toBe("tsc --noEmit");


### PR DESCRIPTION
## Summary

- preserve the current split hero/banner mode while adding a new editable `full-image` banner mode
- improve the hero editor UX in `Contenido` / `Estilos` with layout and overlay controls that are clearer to use
- reduce color-edit lag by routing rapid updates through scheduled admin edits and fixing save-time snapshot handling for pending changes
- add focused regression coverage for hero rendering, editor behavior, and debounced admin edit state
- unblock the exact required focused test command with a minimal Vitest/PostCSS tooling fix

## Why

The approved PRD asked for a better hero/banner editing experience without removing current capabilities. The editor only supported the current split layout, image editing was limited, and rapid color dragging caused strong lag because updates fanned out too eagerly and could even race the save path.

## Orchestration Details

- Workflow: `opencode-sdd-orchestrator`
- Orchestrator: Hermes (coordination only)
- Initial implementer lane: OpenCode
- Agent requested initially: `sdd-orchestrator`
- Initial fallback check: passed (no fallback evidence; lane was killed for stall, not fallback)
- Recovery execution: focused OpenCode pass on the same isolated worktree using `build` after the original orchestrator lane stalled with no diff/commit
- Worktree path: `/home/ubuntu/Osoria/OsorIa-Ecomerce/.worktrees/feat-hero-banner-editor-full-image-ux`
- Task brief file: `/home/ubuntu/projects/hermes-personal-config/docs/dispatches/osoria-ecommerce/2026-04-23-hero-banner-editor-full-image-ux-dispatch/opencode-task-brief.md`
- Recovery brief file: `/home/ubuntu/projects/hermes-personal-config/docs/dispatches/osoria-ecommerce/2026-04-23-hero-banner-editor-full-image-ux-dispatch/focused-recovery-brief.md`
- Commit handoff: implementation left committed work on the isolated branch before PR creation

## Scope

### In Scope
- preserve and improve the existing split hero/banner mode
- add a new `full-image` hero/banner mode
- improve hero editor UX for content/styles configuration
- reduce live-edit lag during rapid color changes
- add focused regression tests for the implemented behavior
- apply the minimum local tooling fix needed for the required verification command to run

### Out Of Scope
- broader public-site redesign beyond the editor/hero scope
- unrelated repo-wide lint/type debt cleanup
- live DB mutation or schema repair
- merge automation

## Validation

- [x] `test "$(git branch --show-current)" = "feat/hero-banner-editor-full-image-ux"` — exit `0`
- [x] `npm test -- --run "tests/**/*hero-banner*.test.*" "tests/**/*editor-panel*.test.*" "tests/**/*admin-context*.test.*"` — exit `0` — `3` files / `7` tests passed
- [x] `npm run build` — exit `0` — Next production build completed successfully
- [x] `git status --short --branch` — exit `0` — branch clean and ahead by `2`

## Acceptance Criteria

- [x] current hero/banner mode still works — covered by preserved split layout and `tests/components/hero-banner.test.tsx`
- [x] new full-image/full-banner mode exists and is configurable — implemented in `components/sections/hero-banner.tsx` and `components/admin/editor-panel.tsx`
- [x] banner image can occupy the full banner correctly — verified by full-image rendering test and new hero layout path
- [x] content/styles editing UI is clearer and more coherent — layout selector, overlay controls, and improved hero guidance added in the editor panel
- [x] color controls are more intuitive and strong lag is reduced — updates now use scheduled admin edits and save reads a synchronous merged snapshot so pending color changes are not lost
- [x] focused regression tests pass — `tests/components/editor-panel.test.tsx`, `tests/components/hero-banner.test.tsx`, `tests/contexts/admin-context.test.tsx`
- [x] no current capability was removed — split layout remains the default path

## Commits

- `41eca65` — `test(tooling): unblock focused vitest runs`
- `5ec5aa4` — `feat(hero): add full-image banner editing`

## Risks / Follow-Ups

- focused tests still emit non-blocking `next/image` mock warnings for `fill` / `priority`
- build still emits pre-existing environment/config warnings (`Supabase`, `Shopify`, `metadataBase`, prerender bailout logs) but completes successfully
- manual review is still required before merge
