### PR TITLE
chore(gitignore): ignore local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local agent/tooling files
+.atl/
+opencode.json


### PR DESCRIPTION
## Summary
- Ignore local agent infrastructure under `.atl/`.
- Ignore the local `opencode.json` tooling file.
- Keep future feature branches focused on product code instead of workstation artifacts.

## Changes
| File | Change |
|------|--------|
| `.gitignore` | Added local-only ignore rules for `.atl/` and `opencode.json`. |

## Test Plan
- [x] Verified only `.gitignore` changed in this branch
- [x] Confirmed the ignore rules match current local artifacts we want to keep out of PRs