### PR TITLE
feat: complete purchasable combo parity

### DIFF
--- a/app/admin/products/combos/page.tsx
+++ b/app/admin/products/combos/page.tsx
@@ -17,7 +17,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge"
 import { createCombo, listCombos, updateCombo } from "@/lib/supabase/combos-api"
 import { getItemById, getItems } from "@/lib/supabase/products-api"
+import { uploadImage, deleteImage } from "@/lib/supabase/storage-api"
+import { cleanupDeferredUploadedImage, resolveDeferredImageUpload } from "@/lib/products/deferred-image-upload"
 import { formatPrice } from "@/lib/shopify/utils"
+import { DeferredImageUpload } from "../components/deferred-image-upload"
 import type { ComboCatalogDetails, ComboDiscountType } from "@/lib/combos/types"
 import type { StoreItemWithDetails } from "@/lib/types/products"
 
@@ -63,6 +66,7 @@ export default function AdminCombosPage() {
   const [combos, setCombos] = useState<ComboCatalogDetails[]>([])
   const [products, setProducts] = useState<StoreItemWithDetails[]>([])
   const [form, setForm] = useState<ComboFormState>(emptyForm)
+  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLoadingData, setIsLoadingData] = useState(true)
 
@@ -116,6 +120,7 @@ export default function AdminCombosPage() {
   }
 
   const startEdit = (combo: ComboCatalogDetails) => {
+    setSelectedImageFile(null)
     setForm({
       id: combo.id,
       name: combo.name,
@@ -133,7 +138,10 @@ export default function AdminCombosPage() {
     })
   }
 
-  const resetForm = () => setForm(emptyForm)
+  const resetForm = () => {
+    setSelectedImageFile(null)
+    setForm(emptyForm)
+  }
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
@@ -157,12 +165,21 @@ export default function AdminCombosPage() {
     }
 
     setIsSubmitting(true)
+    let uploadedImageUrl: string | undefined
     try {
+      const imageResult = await resolveDeferredImageUpload({
+        file: selectedImageFile,
+        imageUrl: form.image_url,
+        context: "product-images",
+        uploadImage,
+      })
+      uploadedImageUrl = imageResult.uploadedUrl
+
       const payload = {
         name: form.name,
         slug: form.slug || undefined,
         description: form.description || undefined,
-        image_url: form.image_url || undefined,
+        image_url: imageResult.imageUrl,
         is_active: form.is_active,
         discount_type: form.discount_type,
         discount_value: Number(form.discount_value || 0),
@@ -171,6 +188,7 @@ export default function AdminCombosPage() {
       const result = form.id ? await updateCombo(form.id, payload) : await createCombo(payload)
 
       if (!result.success) {
+        await cleanupDeferredUploadedImage(uploadedImageUrl, deleteImage)
         toast.error(result.error || "No se pudo guardar el combo")
         return
       }
@@ -179,6 +197,7 @@ export default function AdminCombosPage() {
       resetForm()
       await loadData()
     } catch (error: any) {
+      await cleanupDeferredUploadedImage(uploadedImageUrl, deleteImage)
       console.error("[Admin Combos] Error guardando combo:", error)
       toast.error(error.message || "Error al guardar el combo")
     } finally {
@@ -262,10 +281,15 @@ export default function AdminCombosPage() {
                 <Label htmlFor="description">Descripción</Label>
                 <Textarea id="description" value={form.description} onChange={(event) => setForm({ ...form, description: event.target.value })} rows={3} />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="image_url">Imagen URL</Label>
-                <Input id="image_url" value={form.image_url} onChange={(event) => setForm({ ...form, image_url: event.target.value })} />
-              </div>
+              <DeferredImageUpload
+                imageUrl={form.image_url}
+                selectedFile={selectedImageFile}
+                onImageUrlChange={(imageUrl) => setForm({ ...form, image_url: imageUrl })}
+                onFileChange={setSelectedImageFile}
+                onValidationError={(message) => toast.error(message)}
+                label="Imagen del combo"
+                maxSizeMB={1}
+              />
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-2">
                   <Label>Tipo descuento</Label>

--- a/app/admin/products/combos/page.tsx
+++ b/app/admin/products/combos/page.tsx
@@ -16,13 +16,13 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { createCombo, listCombos, updateCombo } from "@/lib/supabase/combos-api"
-import { getItemById, getItems } from "@/lib/supabase/products-api"
+import { getCategories, getItemById, getItems } from "@/lib/supabase/products-api"
 import { uploadImage, deleteImage } from "@/lib/supabase/storage-api"
 import { cleanupDeferredUploadedImage, resolveDeferredImageUpload } from "@/lib/products/deferred-image-upload"
 import { formatPrice } from "@/lib/shopify/utils"
 import { DeferredImageUpload } from "../components/deferred-image-upload"
 import type { ComboCatalogDetails, ComboDiscountType } from "@/lib/combos/types"
-import type { StoreItemWithDetails } from "@/lib/types/products"
+import type { ItemCategory, StoreItemWithDetails } from "@/lib/types/products"
 
 type ComponentDraft = {
   product_id: string
@@ -34,6 +34,7 @@ type ComboFormState = {
   id?: string
   name: string
   slug: string
+  category_id: string
   description: string
   image_url: string
   is_active: boolean
@@ -45,6 +46,7 @@ type ComboFormState = {
 const emptyForm: ComboFormState = {
   name: "",
   slug: "",
+  category_id: "",
   description: "",
   image_url: "",
   is_active: true,
@@ -65,6 +67,7 @@ export default function AdminCombosPage() {
   const router = useRouter()
   const [combos, setCombos] = useState<ComboCatalogDetails[]>([])
   const [products, setProducts] = useState<StoreItemWithDetails[]>([])
+  const [categories, setCategories] = useState<ItemCategory[]>([])
   const [form, setForm] = useState<ComboFormState>(emptyForm)
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -78,9 +81,10 @@ export default function AdminCombosPage() {
     if (!isAdmin) return
     setIsLoadingData(true)
     try {
-      const [comboRows, productRows] = await Promise.all([
+      const [comboRows, productRows, categoryRows] = await Promise.all([
         listCombos({ includeInactive: true }),
         getItems({ limit: 100, item_kind: "products", is_active: true, is_available_for_sale: true }),
+        getCategories(false),
       ])
 
       const productsWithVariants = await Promise.all(
@@ -89,6 +93,7 @@ export default function AdminCombosPage() {
 
       setCombos(comboRows)
       setProducts(productsWithVariants)
+      setCategories(categoryRows)
     } catch (error) {
       console.error("[Admin Combos] Error cargando combos:", error)
       toast.error("Error al cargar combos")
@@ -125,6 +130,7 @@ export default function AdminCombosPage() {
       id: combo.id,
       name: combo.name,
       slug: combo.slug || "",
+      category_id: combo.categoryId || "",
       description: combo.description || "",
       image_url: combo.imageUrl || "",
       is_active: combo.isActive,
@@ -178,6 +184,7 @@ export default function AdminCombosPage() {
       const payload = {
         name: form.name,
         slug: form.slug || undefined,
+        category_id: form.category_id || null,
         description: form.description || undefined,
         image_url: imageResult.imageUrl,
         is_active: form.is_active,
@@ -276,6 +283,19 @@ export default function AdminCombosPage() {
               <div className="space-y-2">
                 <Label htmlFor="slug">Slug</Label>
                 <Input id="slug" value={form.slug} onChange={(event) => setForm({ ...form, slug: event.target.value })} placeholder="combo-cafe-premium" />
+                <p className="text-xs text-muted-foreground">Se normaliza al guardar; por ejemplo, “combo test” queda como “combo-test”.</p>
+              </div>
+              <div className="space-y-2">
+                <Label>Categoría</Label>
+                <Select value={form.category_id || "__none"} onValueChange={(value) => setForm({ ...form, category_id: value === "__none" ? "" : value })}>
+                  <SelectTrigger><SelectValue placeholder="Selecciona una categoría" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none">Sin categoría</SelectItem>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.id}>{category.category_name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="description">Descripción</Label>

--- a/app/admin/products/components/deferred-image-upload.tsx
+++ b/app/admin/products/components/deferred-image-upload.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useMemo } from "react"
+import { ImageIcon, Upload, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface DeferredImageUploadProps {
+  imageUrl: string
+  selectedFile: File | null
+  onImageUrlChange: (url: string) => void
+  onFileChange: (file: File | null) => void
+  onValidationError?: (message: string) => void
+  label?: string
+  maxSizeMB?: number
+  accept?: string
+}
+
+export function DeferredImageUpload({
+  imageUrl,
+  selectedFile,
+  onImageUrlChange,
+  onFileChange,
+  onValidationError,
+  label = "Imagen",
+  maxSizeMB = 1,
+  accept = "image/jpeg,image/jpg,image/png,image/webp,image/gif",
+}: DeferredImageUploadProps) {
+  const previewUrl = useMemo(() => {
+    if (!selectedFile) return imageUrl.trim()
+    return URL.createObjectURL(selectedFile)
+  }, [imageUrl, selectedFile])
+
+  useEffect(() => {
+    if (!selectedFile || !previewUrl.startsWith("blob:")) return undefined
+    return () => URL.revokeObjectURL(previewUrl)
+  }, [previewUrl, selectedFile])
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (!file.type.startsWith("image/")) {
+      onFileChange(null)
+      event.target.value = ""
+      onValidationError?.("Por favor selecciona un archivo de imagen válido")
+      return
+    }
+
+    const maxSize = maxSizeMB * 1024 * 1024
+    if (file.size > maxSize) {
+      onFileChange(null)
+      event.target.value = ""
+      onValidationError?.(`El archivo supera el máximo de ${maxSizeMB}MB`)
+      return
+    }
+
+    onFileChange(file)
+  }
+
+  const clearImage = () => {
+    onFileChange(null)
+    onImageUrlChange("")
+  }
+
+  return (
+    <div className="space-y-3">
+      <Label>{label}</Label>
+      <div className="relative aspect-square overflow-hidden rounded-lg border border-dashed bg-muted">
+        {previewUrl ? (
+          <Image src={previewUrl} alt="Vista previa de imagen del combo" fill className="object-cover" unoptimized />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+            <ImageIcon className="h-8 w-8" />
+            <span className="text-xs">Sin imagen seleccionada</span>
+          </div>
+        )}
+        {(previewUrl || selectedFile) && (
+          <Button
+            type="button"
+            variant="destructive"
+            size="icon"
+            className="absolute right-2 top-2 h-8 w-8"
+            onClick={clearImage}
+            aria-label="Quitar imagen del combo"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="combo-image-file" className="text-sm font-medium">Seleccionar archivo</Label>
+        <div className="flex items-center gap-2">
+          <Input
+            id="combo-image-file"
+            type="file"
+            accept={accept}
+            onChange={handleFileSelect}
+            className="cursor-pointer"
+          />
+          <Upload className="h-4 w-4 text-muted-foreground" />
+        </div>
+        {selectedFile && (
+          <p className="text-xs text-muted-foreground">
+            Se subirá al guardar: {selectedFile.name}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="combo-image-url" className="text-sm font-medium">O pegar URL existente</Label>
+        <Input
+          id="combo-image-url"
+          value={imageUrl}
+          onChange={(event) => {
+            onFileChange(null)
+            onImageUrlChange(event.target.value)
+          }}
+          placeholder="https://..."
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Vista previa inmediata. El archivo se sube recién al guardar el combo; máximo {maxSizeMB}MB.
+      </p>
+    </div>
+  )
+}

--- a/app/shop/components/product-card/index.tsx
+++ b/app/shop/components/product-card/index.tsx
@@ -14,8 +14,14 @@ export const ProductCard = ({ product }: { product: Product }) => {
   const hasNoOptions = product.options.length === 0;
   const hasOneOptionWithOneValue = product.options.length === 1 && product.options[0].values.length === 1;
   const justHasColorOption = product.options.length === 1 && product.options[0].name.toLowerCase() === 'color';
+  const formattedPrice = formatPrice(
+    product.priceRange.minVariantPrice.amount,
+    product.priceRange.minVariantPrice.currencyCode,
+  );
+  const isCombo = product.productKind === 'combo';
 
   const renderInCardAddToCart = hasNoOptions || hasOneOptionWithOneValue || justHasColorOption;
+  const showVariantSelector = renderInCardAddToCart && !isCombo;
 
   return (
     <div className="relative w-full aspect-[3/4] md:aspect-square bg-muted group overflow-hidden">
@@ -23,14 +29,14 @@ export const ProductCard = ({ product }: { product: Product }) => {
       <div className="absolute top-3 right-3 z-20 pointer-events-auto">
         <WishlistButton product={product} />
       </div>
-      {product.productKind === 'combo' && (
+      {isCombo && (
         <Badge className="absolute left-3 top-3 z-20 bg-primary text-primary-foreground">Combo</Badge>
       )}
       
       <Link
         href={`/products/${product.handle}`}
         className="block size-full focus-visible:outline-none"
-        aria-label={`View details for ${product.title}, price ${product.priceRange.minVariantPrice}`}
+        aria-label={`View details for ${product.title}, price ${formattedPrice}`}
         prefetch
       >
         <Suspense fallback={null}>
@@ -55,7 +61,7 @@ export const ProductCard = ({ product }: { product: Product }) => {
         <div className="flex absolute inset-x-3 bottom-3 flex-col gap-8 px-2 py-3 rounded-md transition-all duration-300 pointer-events-none bg-popover md:opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 md:translate-y-1/3 group-hover:translate-y-0 group-focus-visible:translate-y-0 group-hover:pointer-events-auto group-focus-visible:pointer-events-auto max-md:pointer-events-auto">
           <div className="grid grid-cols-2 gap-x-4 gap-y-8 items-end">
             <p className="text-lg font-semibold text-pretty">{product.title}</p>
-            {product.productKind === 'combo' && (
+            {isCombo && (
               <Badge variant="outline" className="w-fit">Combo</Badge>
             )}
             <div className="flex gap-2 items-center place-self-end text-lg font-semibold">
@@ -66,12 +72,18 @@ export const ProductCard = ({ product }: { product: Product }) => {
                 </span>
               )}
             </div>
-            {renderInCardAddToCart ? (
+            {showVariantSelector ? (
               <Suspense fallback={null}>
                 <div className="self-center">
                   <VariantSelector product={product} />
                 </div>
               </Suspense>
+            ) : isCombo ? (
+              <Button className="col-start-1" size="sm" variant="outline" asChild>
+                <Link href={`/products/${product.handle}`}>
+                  Ver detalle
+                </Link>
+              </Button>
             ) : (
               <></>
             )}

--- a/components/cart/add-to-cart.tsx
+++ b/components/cart/add-to-cart.tsx
@@ -107,9 +107,13 @@ export function AddToCartButton({
           const { getProductStock, getVariantStock } = await import('@/lib/supabase/products-api');
           
           let stock: number | null = null;
-          
+
+          if (isCombo) {
+            const { getComboStock } = await import('@/lib/supabase/combos-api');
+            stock = await getComboStock(productId);
+          }
           // Si es una variante real, obtener stock de la variante
-          if (isRealVariant) {
+          else if (isRealVariant) {
             stock = await getVariantStock(variantId);
           } else {
             // Es el producto base o variante por defecto, obtener stock del producto

--- a/lib/combos/types.ts
+++ b/lib/combos/types.ts
@@ -52,6 +52,7 @@ export interface ComboCatalogDetails {
   id: string
   name: string
   slug?: string | null
+  categoryId?: string | null
   description?: string | null
   imageUrl?: string | null
   isActive: boolean

--- a/lib/products/deferred-image-upload.ts
+++ b/lib/products/deferred-image-upload.ts
@@ -1,0 +1,51 @@
+import type { UploadImageResult } from '@/lib/supabase/storage-api'
+
+export type DeferredImageUploadFn = (file: File, context: string) => Promise<UploadImageResult>
+export type DeferredImageCleanupFn = (url: string) => Promise<{ success: boolean; error?: string }>
+
+export interface ResolveDeferredImageInput {
+  file?: File | null
+  imageUrl?: string | null
+  context?: string
+  uploadImage: DeferredImageUploadFn
+}
+
+export interface ResolveDeferredImageResult {
+  imageUrl?: string
+  uploadedUrl?: string
+}
+
+export async function resolveDeferredImageUpload({
+  file,
+  imageUrl,
+  context = 'product-images',
+  uploadImage,
+}: ResolveDeferredImageInput): Promise<ResolveDeferredImageResult> {
+  if (!file) {
+    const trimmedUrl = imageUrl?.trim()
+    return { imageUrl: trimmedUrl || undefined }
+  }
+
+  const uploadResult = await uploadImage(file, context)
+  if (!uploadResult.success || !uploadResult.url) {
+    throw new Error(uploadResult.error || 'No se pudo subir la imagen del combo')
+  }
+
+  return {
+    imageUrl: uploadResult.url,
+    uploadedUrl: uploadResult.url,
+  }
+}
+
+export async function cleanupDeferredUploadedImage(
+  uploadedUrl: string | undefined,
+  cleanupImage: DeferredImageCleanupFn,
+): Promise<void> {
+  if (!uploadedUrl) return
+
+  try {
+    await cleanupImage(uploadedUrl)
+  } catch (error) {
+    console.warn('[DeferredImageUpload] No se pudo limpiar la imagen subida después de fallar el guardado:', error)
+  }
+}

--- a/lib/products/index.ts
+++ b/lib/products/index.ts
@@ -3,16 +3,12 @@
  * Funciones para obtener productos y categorías de la base de datos
  */
 
-import { cacheLife, cacheTag } from 'next/cache';
-import { TAGS } from '@/lib/constants';
 import {
   getItems,
   getItemBySlug,
   getCategories,
-  getCategoryById,
   getFeaturedItems,
   searchItems,
-  getItemsByCategory,
   type GetItemsParams,
 } from '@/lib/supabase/products-api';
 import {
@@ -201,5 +197,3 @@ export async function searchProducts(searchTerm: string, limit: number = 20): Pr
     return [];
   }
 }
-
-

--- a/lib/supabase/combos-api.ts
+++ b/lib/supabase/combos-api.ts
@@ -15,6 +15,7 @@ export interface CreateComboData {
   store_id?: string
   name: string
   slug?: string
+  category_id?: string | null
   description?: string
   image_url?: string
   is_active?: boolean
@@ -46,13 +47,51 @@ function getClient(supabaseOverride?: any) {
   return supabaseOverride ?? getSupabaseEcommerce()
 }
 
-function generateSlug(name: string) {
-  return name
+export function normalizeComboSlug(value: string) {
+  return value
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+function generateSlug(name: string) {
+  return normalizeComboSlug(name)
+}
+
+function comboCategoryId(combo: any): string | null {
+  const categoryId = combo?.category_id ?? combo?.metadata?.category_id
+  return typeof categoryId === 'string' && categoryId.trim() ? categoryId.trim() : null
+}
+
+async function fetchComboMetadata(supabase: any, comboId: string): Promise<Record<string, any>> {
+  const result = await withTimeout(
+    supabase.from(ECOMMERCE_TABLES.productCombos).select('metadata').eq('id', comboId).single(),
+    15000,
+    'fetchComboMetadata',
+  ) as { data: any | null; error: any }
+
+  if (result.error) return {}
+  return result.data?.metadata && typeof result.data.metadata === 'object' ? result.data.metadata : {}
+}
+
+function candidateSlugs(slug: string) {
+  const candidates = new Set<string>()
+  if (slug) candidates.add(slug)
+  try {
+    const decoded = decodeURIComponent(slug)
+    if (decoded) {
+      candidates.add(decoded)
+      const normalizedDecoded = normalizeComboSlug(decoded)
+      if (normalizedDecoded) candidates.add(normalizedDecoded)
+    }
+  } catch {
+    // Keep original candidate only.
+  }
+  const normalized = normalizeComboSlug(slug)
+  if (normalized) candidates.add(normalized)
+  return Array.from(candidates)
 }
 
 async function resolveStoreId(supabase: any, explicitStoreId?: string | null): Promise<string | null> {
@@ -231,6 +270,7 @@ export async function hydrateCombos(
       id: combo.id,
       name: combo.name,
       slug: combo.slug,
+      categoryId: comboCategoryId(combo),
       description: combo.description,
       imageUrl: combo.image_url,
       isActive: combo.is_active !== false,
@@ -247,6 +287,7 @@ export async function hydrateCombos(
 
 export async function listCombos(params: {
   store_id?: string | null
+  category_id?: string | null
   includeInactive?: boolean
   supabaseOverride?: any
 } = {}): Promise<ComboCatalogDetails[]> {
@@ -257,7 +298,9 @@ export async function listCombos(params: {
   if (!storeId) return []
 
   const combos = await fetchCombos(supabase, undefined, storeId, params.includeInactive)
-  return hydrateCombos(combos, supabase)
+  const hydrated = await hydrateCombos(combos, supabase)
+  if (!params.category_id) return hydrated
+  return hydrated.filter((combo) => combo.categoryId === params.category_id)
 }
 
 export async function getComboById(
@@ -289,14 +332,23 @@ export async function getComboBySlug(
     supabase
       .from(ECOMMERCE_TABLES.productCombos)
       .select('*')
-      .eq('slug', slug)
+      .in('slug', candidateSlugs(slug))
       .eq('store_id', resolvedStoreId)
+      .limit(1)
       .maybeSingle(),
     15000,
     'getComboBySlug',
   ) as { data: any | null; error: any }
 
-  if (result.error || !result.data) return null
+  if (result.error) return null
+  if (!result.data) {
+    const normalizedCandidates = new Set(candidateSlugs(slug).map((candidate) => normalizeComboSlug(candidate)).filter(Boolean))
+    const combos = await fetchCombos(supabase, undefined, resolvedStoreId, includeInactive)
+    const matchedCombo = combos.find((combo) => normalizedCandidates.has(normalizeComboSlug(combo.slug || '')))
+    if (!matchedCombo) return null
+    const [combo] = await hydrateCombos([matchedCombo], supabase)
+    return combo || null
+  }
   if (!includeInactive && result.data.is_active === false) return null
 
   const [combo] = await hydrateCombos([result.data], supabase)
@@ -314,7 +366,7 @@ export function comboToStoreItem(combo: ComboCatalogDetails): StoreItemWithDetai
     item_name: combo.name,
     item_description: combo.description || undefined,
     item_description_html: combo.description ? `<p>${combo.description}</p>` : undefined,
-    category_id: undefined,
+    category_id: combo.categoryId || undefined,
     base_price: finalPrice,
     compare_at_price: componentSubtotal > finalPrice ? componentSubtotal : undefined,
     currency_code: combo.pricing.currencyCode,
@@ -324,12 +376,13 @@ export function comboToStoreItem(combo: ComboCatalogDetails): StoreItemWithDetai
     track_inventory: true,
     inventory_quantity: combo.availability.derivedStock ?? 999999,
     low_stock_threshold: 1,
-    item_slug: combo.slug || combo.id,
+    item_slug: normalizeComboSlug(combo.slug || combo.name || combo.id) || combo.id,
     seo_title: combo.name,
     seo_description: combo.description || undefined,
     metadata: {
       item_kind: 'combo',
       combo_id: combo.id,
+      category_id: combo.categoryId || null,
       combo_discount_type: combo.pricing.discountType,
       combo_discount_value: combo.pricing.discountValue,
     },
@@ -506,7 +559,7 @@ export async function createCombo(data: CreateComboData): Promise<ComboMutationR
     return { success: false, error: componentValidation.error }
   }
 
-  const slug = data.slug?.trim() || generateSlug(data.name)
+  const slug = normalizeComboSlug(data.slug?.trim() || data.name)
   const result = await withTimeout(
     supabase
       .from(ECOMMERCE_TABLES.productCombos)
@@ -519,6 +572,9 @@ export async function createCombo(data: CreateComboData): Promise<ComboMutationR
         is_active: data.is_active ?? true,
         discount_type: data.discount_type,
         discount_value: Number(data.discount_value || 0),
+        metadata: {
+          category_id: data.category_id || null,
+        },
       })
       .select()
       .single(),
@@ -559,12 +615,22 @@ export async function updateCombo(comboId: string, data: UpdateComboData): Promi
 
   const updateData: Record<string, unknown> = {}
   if (data.name !== undefined) updateData.name = data.name.trim()
-  if (data.slug !== undefined) updateData.slug = data.slug.trim() || (data.name ? generateSlug(data.name) : undefined)
+  if (data.slug !== undefined || data.name !== undefined) {
+    const nextSlug = data.slug?.trim() || (data.name ? data.name : '')
+    if (nextSlug) updateData.slug = normalizeComboSlug(nextSlug)
+  }
   if (data.description !== undefined) updateData.description = data.description?.trim() || null
   if (data.image_url !== undefined) updateData.image_url = data.image_url?.trim() || null
   if (data.is_active !== undefined) updateData.is_active = data.is_active
   if (data.discount_type !== undefined) updateData.discount_type = data.discount_type
   if (data.discount_value !== undefined) updateData.discount_value = Number(data.discount_value || 0)
+  if (data.category_id !== undefined) {
+    const currentMetadata = await fetchComboMetadata(supabase, comboId)
+    updateData.metadata = {
+      ...currentMetadata,
+      category_id: data.category_id || null,
+    }
+  }
 
   let replacementRows: any[] | null = null
   let existingComponentRows: any[] = []

--- a/lib/supabase/combos-api.ts
+++ b/lib/supabase/combos-api.ts
@@ -590,16 +590,7 @@ export async function updateCombo(comboId: string, data: UpdateComboData): Promi
     existingComponentRows = existingResult.data || []
   }
 
-  if (Object.keys(updateData).length > 0) {
-    const result = await withTimeout(
-      supabase.from(ECOMMERCE_TABLES.productCombos).update(updateData).eq('id', comboId),
-      20000,
-      'updateCombo',
-    ) as { error: any }
-
-    if (result.error) return { success: false, error: result.error.message || 'Error al actualizar el combo' }
-  }
-
+  let componentsWereReplaced = false
   if (replacementRows) {
     const deleteResult = await withTimeout(
       supabase.from(ECOMMERCE_TABLES.productComboComponents).delete().eq('combo_id', comboId),
@@ -620,6 +611,28 @@ export async function updateCombo(comboId: string, data: UpdateComboData): Promi
     if (insertResult.error) {
       await restoreComboComponents(supabase, existingComponentRows).catch(() => undefined)
       return { success: false, error: insertResult.error.message || 'Error al guardar componentes del combo' }
+    }
+
+    componentsWereReplaced = true
+  }
+
+  if (Object.keys(updateData).length > 0) {
+    const result = await withTimeout(
+      supabase.from(ECOMMERCE_TABLES.productCombos).update(updateData).eq('id', comboId),
+      20000,
+      'updateCombo',
+    ) as { error: any }
+
+    if (result.error) {
+      if (componentsWereReplaced) {
+        await withTimeout(
+          supabase.from(ECOMMERCE_TABLES.productComboComponents).delete().eq('combo_id', comboId),
+          20000,
+          'rollbackComboComponentsAfterUpdateFailure',
+        ).catch(() => undefined)
+        await restoreComboComponents(supabase, existingComponentRows).catch(() => undefined)
+      }
+      return { success: false, error: result.error.message || 'Error al actualizar el combo' }
     }
   }
 

--- a/lib/supabase/products-api.ts
+++ b/lib/supabase/products-api.ts
@@ -333,9 +333,10 @@ export async function getItems(params: GetItemsParams = {}): Promise<GetItemsRes
       }))
     }
 
-    if (shouldFetchCombos && !category_id && is_featured === undefined) {
+    if (shouldFetchCombos && is_featured === undefined) {
       const combos = await listCombos({
         store_id: currentStoreId,
+        category_id,
         includeInactive: is_active === false,
       })
       const comboItems = combos

--- a/tests/components/shop-product-card.test.tsx
+++ b/tests/components/shop-product-card.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProductCard } from '@/app/shop/components/product-card';
+import type { Product } from '@/lib/shopify/types';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, prefetch: _prefetch, ...props }: { href: string; children: React.ReactNode; prefetch?: boolean }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/cart/add-to-cart', () => ({
+  AddToCart: () => <button type="button">Agregar al carrito</button>,
+  AddToCartButton: () => <button type="button">Agregar al carrito</button>,
+}));
+
+vi.mock('@/app/shop/components/product-card/product-image', () => ({
+  ProductImage: () => <div data-testid="product-image" />,
+}));
+
+vi.mock('@/app/shop/components/variant-selector', () => ({
+  VariantSelector: () => <div data-testid="variant-selector" />,
+}));
+
+vi.mock('@/components/wishlist/wishlist-button', () => ({
+  WishlistButton: () => <button type="button" aria-label="Agregar a favoritos" />,
+}));
+
+const comboProduct: Product = {
+  id: 'combo-1',
+  title: 'Combo Café',
+  handle: 'combo-cafe',
+  productKind: 'combo',
+  description: 'Café + mug',
+  descriptionHtml: '<p>Café + mug</p>',
+  featuredImage: {
+    url: '/combo.jpg',
+    altText: 'Combo Café',
+    height: 600,
+    width: 600,
+  },
+  currencyCode: 'COP',
+  priceRange: {
+    minVariantPrice: { amount: '72000', currencyCode: 'COP' },
+    maxVariantPrice: { amount: '72000', currencyCode: 'COP' },
+  },
+  compareAtPrice: { amount: '80000', currencyCode: 'COP' },
+  seo: {
+    title: 'Combo Café',
+    description: 'Café + mug',
+  },
+  options: [],
+  tags: ['combo'],
+  variants: [
+    {
+      id: 'combo-1',
+      title: 'Combo',
+      availableForSale: true,
+      price: { amount: '72000', currencyCode: 'COP' },
+      selectedOptions: [],
+    },
+  ],
+  images: [],
+  availableForSale: true,
+};
+
+describe('shop ProductCard combo behavior', () => {
+  it('keeps a visible combo detail link while preserving card add-to-cart parity', () => {
+    render(<ProductCard product={comboProduct} />);
+
+    const detailLink = screen.getByRole('link', { name: /ver detalle/i });
+    expect(detailLink).toHaveAttribute('href', '/products/combo-cafe');
+    expect(screen.getByRole('button', { name: /agregar al carrito/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('variant-selector')).not.toBeInTheDocument();
+  });
+});

--- a/tests/orders/order-flow.contract.test.ts
+++ b/tests/orders/order-flow.contract.test.ts
@@ -545,6 +545,95 @@ describe("orders-api live order contract", () => {
     expect(state.inserts.orders).toBeUndefined();
   });
 
+  it("rejects stale cart combo items when the combo becomes inactive before checkout", async () => {
+    const state = new MockSupabaseState({
+      "product_combos:select": [
+        {
+          data: [
+            {
+              id: "combo-inactive",
+              name: "Combo Inactivo",
+              slug: "combo-inactivo",
+              is_active: false,
+              discount_type: "percentage",
+              discount_value: 0,
+              currency_code: "COP",
+            },
+          ],
+          error: null,
+        },
+      ],
+      "product_combo_components:select": [
+        {
+          data: [
+            {
+              combo_id: "combo-inactive",
+              product_id: "store-item-1",
+              variant_id: null,
+              quantity: 1,
+            },
+            {
+              combo_id: "combo-inactive",
+              product_id: "store-item-2",
+              variant_id: null,
+              quantity: 1,
+            },
+          ],
+          error: null,
+        },
+      ],
+      "store_items:select": [
+        {
+          data: [
+            {
+              id: "store-item-1",
+              item_name: "Café 250g",
+              base_price: 30000,
+              currency_code: "COP",
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+            {
+              id: "store-item-2",
+              item_name: "Mug",
+              base_price: 20000,
+              currency_code: "COP",
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    getSupabaseEcommerceMock.mockReturnValue({ from: state.from });
+
+    await expect(
+      createOrder({
+        ...baseOrderData,
+        items: [
+          {
+            product_name: "Combo Inactivo",
+            unit_price: 50000,
+            quantity: 1,
+            total_price: 50000,
+            metadata: {
+              item_kind: "combo",
+              combo_id: "combo-inactive",
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("No hay suficiente stock disponible");
+
+    expect(state.inserts.orders).toBeUndefined();
+  });
+
   it("decrements product and variant inventory on writable base tables", async () => {
     const state = new MockSupabaseState({
       "store_items:select": [

--- a/tests/products/combo-domain.test.ts
+++ b/tests/products/combo-domain.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { hydrateCombos } from '@/lib/supabase/combos-api'
+import { getSupabaseEcommerce } from '@/lib/supabase/client'
+import { hydrateCombos, updateCombo } from '@/lib/supabase/combos-api'
 import {
   calculateComboPricing,
   deriveComboAvailability,
 } from '@/lib/combos'
+import { resolveDeferredImageUpload } from '@/lib/products/deferred-image-upload'
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseEcommerce: vi.fn(),
+}))
+
+const getSupabaseEcommerceMock = vi.mocked(getSupabaseEcommerce)
 
 type ScriptedResponse = { data?: unknown; error?: unknown }
 
@@ -35,7 +43,67 @@ function createComboHydrationSupabase(script: Record<string, ScriptedResponse[]>
   }
 }
 
+interface MutationOperation {
+  table: string
+  operation: string
+  payload?: unknown
+}
+
+function createComboMutationSupabase(
+  script: Record<string, ScriptedResponse[]>,
+  operations: MutationOperation[],
+) {
+  return {
+    from(table: string) {
+      let operation = 'select'
+      const builder = {
+        select() {
+          operation = 'select'
+          return builder
+        },
+        update(payload: unknown) {
+          operation = 'update'
+          operations.push({ table, operation, payload })
+          return builder
+        },
+        insert(payload: unknown) {
+          operation = 'insert'
+          operations.push({ table, operation, payload })
+          return builder
+        },
+        delete() {
+          operation = 'delete'
+          operations.push({ table, operation })
+          return builder
+        },
+        eq() {
+          return builder
+        },
+        in() {
+          return builder
+        },
+        single() {
+          return builder
+        },
+        then<TResult1 = ScriptedResponse, TResult2 = never>(
+          onfulfilled?: ((value: ScriptedResponse) => TResult1 | PromiseLike<TResult1>) | null,
+          onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+        ) {
+          const response = script[`${table}:${operation}`]?.shift() || { data: [], error: null }
+          return Promise.resolve(response).then(onfulfilled, onrejected)
+        },
+      }
+
+      return builder
+    },
+  }
+}
+
 describe('combo domain pricing and stock', () => {
+  beforeEach(() => {
+    getSupabaseEcommerceMock.mockReset()
+  })
+
   const components = [
     {
       productId: 'coffee-250g',
@@ -157,5 +225,171 @@ describe('combo domain pricing and stock', () => {
     expect(hydrated[1].availability.blockingComponents).toEqual(
       expect.arrayContaining([expect.objectContaining({ productName: 'Combo incompleto' })]),
     )
+  })
+
+  it('keeps inactive hydrated combos unavailable even when components have stock', async () => {
+    const supabase = createComboHydrationSupabase({
+      product_combo_components: [
+        {
+          data: [
+            { combo_id: 'combo-inactive', product_id: 'coffee-250g', variant_id: null, quantity: 1 },
+            { combo_id: 'combo-inactive', product_id: 'mug', variant_id: null, quantity: 1 },
+          ],
+          error: null,
+        },
+      ],
+      store_items: [
+        {
+          data: [
+            {
+              id: 'coffee-250g',
+              item_name: 'Café 250g',
+              base_price: 30000,
+              currency_code: 'COP',
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+            {
+              id: 'mug',
+              item_name: 'Mug',
+              base_price: 20000,
+              currency_code: 'COP',
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+          ],
+          error: null,
+        },
+      ],
+    })
+
+    const [combo] = await hydrateCombos(
+      [
+        {
+          id: 'combo-inactive',
+          name: 'Combo inactivo',
+          discount_type: 'percentage',
+          discount_value: 0,
+          is_active: false,
+        },
+      ],
+      supabase,
+    )
+
+    expect(combo.availability.isAvailable).toBe(false)
+    expect(combo.isActive).toBe(false)
+  })
+
+  it('defers combo image upload until save and surfaces storage failure before persistence', async () => {
+    const file = { name: 'combo.png' } as File
+    const uploadImage = vi.fn().mockResolvedValue({
+      success: false,
+      error: 'new row violates row-level security policy',
+    })
+
+    await expect(
+      resolveDeferredImageUpload({
+        file,
+        imageUrl: 'https://example.com/old.png',
+        uploadImage,
+      }),
+    ).rejects.toThrow('new row violates row-level security policy')
+
+    expect(uploadImage).toHaveBeenCalledWith(file, 'product-images')
+  })
+
+  it('uses an existing combo image URL without uploading a file', async () => {
+    const uploadImage = vi.fn()
+
+    await expect(
+      resolveDeferredImageUpload({
+        imageUrl: ' https://example.com/combo.jpg ',
+        uploadImage,
+      }),
+    ).resolves.toEqual({ imageUrl: 'https://example.com/combo.jpg' })
+
+    expect(uploadImage).not.toHaveBeenCalled()
+  })
+
+  it('rolls component replacement back when combo update fails after deferred image upload', async () => {
+    const operations: MutationOperation[] = []
+    const existingComponentRows = [
+      {
+        id: 'old-row-1',
+        combo_id: 'combo-1',
+        product_id: 'old-coffee',
+        variant_id: null,
+        quantity: 1,
+        display_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]
+    const supabase = createComboMutationSupabase(
+      {
+        'product_combos:select': [{ data: { store_id: 'store-1' }, error: null }],
+        'store_items:select': [
+          {
+            data: [
+              {
+                id: 'coffee-250g',
+                store_id: 'store-1',
+                item_name: 'Café 250g',
+                is_active: true,
+                is_available_for_sale: true,
+              },
+              {
+                id: 'mug',
+                store_id: 'store-1',
+                item_name: 'Mug',
+                is_active: true,
+                is_available_for_sale: true,
+              },
+            ],
+            error: null,
+          },
+        ],
+        'item_variants:select': [{ data: [], error: null }],
+        'product_combo_components:select': [{ data: existingComponentRows, error: null }],
+        'product_combo_components:delete': [{ error: null }, { error: null }],
+        'product_combo_components:insert': [{ error: null }, { error: null }],
+        'product_combos:update': [{ error: { message: 'RLS bloqueó la actualización del combo' } }],
+      },
+      operations,
+    )
+    getSupabaseEcommerceMock.mockReturnValue(supabase as any)
+
+    const result = await updateCombo('combo-1', {
+      name: 'Combo actualizado',
+      image_url: 'https://cdn.example.com/new-combo.png',
+      discount_type: 'percentage',
+      discount_value: 10,
+      components: [
+        { product_id: 'coffee-250g', quantity: 1 },
+        { product_id: 'mug', quantity: 1 },
+      ],
+    })
+
+    expect(result).toEqual({ success: false, error: 'RLS bloqueó la actualización del combo' })
+    expect(operations.map((operation) => `${operation.table}:${operation.operation}`)).toEqual([
+      'product_combo_components:delete',
+      'product_combo_components:insert',
+      'product_combos:update',
+      'product_combo_components:delete',
+      'product_combo_components:insert',
+    ])
+    expect(operations.at(-1)?.payload).toEqual([
+      {
+        combo_id: 'combo-1',
+        product_id: 'old-coffee',
+        variant_id: null,
+        quantity: 1,
+        display_order: 0,
+      },
+    ])
   })
 })

--- a/tests/products/combo-domain.test.ts
+++ b/tests/products/combo-domain.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSupabaseEcommerce } from '@/lib/supabase/client'
-import { hydrateCombos, updateCombo } from '@/lib/supabase/combos-api'
+import { comboToStoreItem, hydrateCombos, normalizeComboSlug, updateCombo } from '@/lib/supabase/combos-api'
 import {
   calculateComboPricing,
   deriveComboAvailability,
@@ -147,6 +147,11 @@ describe('combo domain pricing and stock', () => {
     expect(pricing.finalUnitPrice).toBe(0)
   })
 
+  it('normalizes combo slugs before they are used as product routes', () => {
+    expect(normalizeComboSlug(' Combo Test ')).toBe('combo-test')
+    expect(normalizeComboSlug('Combo Café Premium!!')).toBe('combo-cafe-premium')
+  })
+
   it('derives combo stock as the minimum purchasable component ratio', () => {
     const availability = deriveComboAvailability(components)
 
@@ -282,6 +287,68 @@ describe('combo domain pricing and stock', () => {
 
     expect(combo.availability.isAvailable).toBe(false)
     expect(combo.isActive).toBe(false)
+  })
+
+  it('maps combo category metadata into catalog items so category filters can include combos', async () => {
+    const supabase = createComboHydrationSupabase({
+      product_combo_components: [
+        {
+          data: [
+            { combo_id: 'combo-categorized', product_id: 'coffee-250g', variant_id: null, quantity: 1 },
+            { combo_id: 'combo-categorized', product_id: 'mug', variant_id: null, quantity: 1 },
+          ],
+          error: null,
+        },
+      ],
+      store_items: [
+        {
+          data: [
+            {
+              id: 'coffee-250g',
+              item_name: 'Café 250g',
+              base_price: 30000,
+              currency_code: 'COP',
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+            {
+              id: 'mug',
+              item_name: 'Mug',
+              base_price: 20000,
+              currency_code: 'COP',
+              track_inventory: true,
+              inventory_quantity: 10,
+              is_active: true,
+              is_available_for_sale: true,
+            },
+          ],
+          error: null,
+        },
+      ],
+    })
+
+    const [combo] = await hydrateCombos(
+      [
+        {
+          id: 'combo-categorized',
+          name: 'Combo categorizado',
+          slug: 'combo-categorizado',
+          discount_type: 'percentage',
+          discount_value: 0,
+          is_active: true,
+          metadata: { category_id: 'category-cafe' },
+        },
+      ],
+      supabase,
+    )
+
+    expect(combo.categoryId).toBe('category-cafe')
+    expect(comboToStoreItem(combo)).toEqual(expect.objectContaining({
+      category_id: 'category-cafe',
+      item_slug: 'combo-categorizado',
+    }))
   })
 
   it('defers combo image upload until save and surfaces storage failure before persistence', async () => {

--- a/tests/security/home-discount-popup-admin-page.test.ts
+++ b/tests/security/home-discount-popup-admin-page.test.ts
@@ -187,9 +187,7 @@ describe("home discount popup admin page", () => {
       "/api/admin/home-discount-popup/upload",
       expect.anything(),
     );
-    expect(
-      screen.getByText(/hay una nueva imagen pendiente/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/hay una nueva imagen pendiente/i)).not.toBeNull();
   });
 
   it("uploads the pending image on save and then persists the popup config", async () => {
@@ -307,9 +305,8 @@ describe("home discount popup admin page", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(
       screen.getByText("Texto sin guardar para preview", { selector: "p" }),
-    ).toBeInTheDocument();
-    expect(screen.getByAltText("Promo preview")).toHaveAttribute(
-      "src",
+    ).not.toBeNull();
+    expect(screen.getByAltText("Promo preview").getAttribute("src")).toBe(
       "blob:preview-image",
     );
   });


### PR DESCRIPTION
## Summary

- Adds a reusable deferred image upload flow for admin combo images with immediate preview and upload only on save.
- Validates combo-derived stock before adding combo items to cart and preserves existing product/variant stock behavior.
- Hardens combo persistence and checkout tests: component rollback on update failure, inactive/stale combo rejection, and storage upload failure coverage.

## Why

Issue #30 requires combos to behave like purchasable product-like catalog items while keeping stock derived from component products and avoiding broken/partial image persistence when storage/RLS fails.

## Orchestration Details

- Workflow: `codex-sdd-orchestrator`
- Orchestrator: Hermes
- Primary engine: Codex
- Fallback engine: OpenCode (`unused`)
- Artifact store: Engram
- Worktree path: `/home/ubuntu/Osoria/OsorIa-Ecomerce/.worktrees/feat-combo-purchasable-parity-issue-30`
- Task brief file: `/home/ubuntu/.hermes/briefs/osoria-ecommerce/sdd/combo-purchasable-parity-issue-30.md`
- Last checkpoint: `sdd/combo-purchasable-parity-issue-30/apply-progress`

## Scope

### In Scope
- Admin combo image preview and deferred upload on save.
- Cleanup/rollback behavior for failed image upload or failed combo persistence.
- Combo add-to-cart stock validation using component-derived combo stock.
- Checkout negative-state coverage for stale inactive combos.
- Tests covering combo availability, deferred upload failures, rollback behavior, order validation, and affected admin preview assertions.

### Out Of Scope
- General promotions engine.
- Customer-built bundles.
- Stackable coupons or recommendations.
- Combo-owned sellable stock.
- Live staging RLS/policy mutation.

## Validation

- [x] `corepack pnpm test tests/products/combo-domain.test.ts tests/orders/order-flow.contract.test.ts` — exit 0 — 21 tests passed
- [x] `corepack pnpm test tests/security/home-discount-popup-admin-page.test.ts` — exit 0 — 3 tests passed
- [x] `corepack pnpm typecheck` — exit 0
- [x] `corepack pnpm lint` — exit 0
- [x] `corepack pnpm exec eslint app/admin/products/combos/page.tsx app/admin/products/components/deferred-image-upload.tsx components/cart/add-to-cart.tsx lib/products/index.ts lib/products/deferred-image-upload.ts lib/supabase/combos-api.ts tests/products/combo-domain.test.ts tests/orders/order-flow.contract.test.ts tests/security/home-discount-popup-admin-page.test.ts --max-warnings=0` — exit 0
- [x] `corepack pnpm build` — exit 0
- [x] `git diff --check` — exit 0

Note: `pnpm` binary is not directly on PATH in this runtime, so validation used `corepack pnpm`.

## Acceptance Criteria

- [x] Admin combo image flow has preview before save and performs upload on save (`DeferredImageUpload`, `resolveDeferredImageUpload`).
- [x] Failed upload/storage or persistence shows an error and avoids broken partial image state; update rollback covered by test.
- [x] Active purchasable combos remain available through existing catalog/filter combo path without duplicate manual appending.
- [x] Combo detail price/components/availability path is preserved via existing combo-to-product adapter and detail lookup.
- [x] Combo add-to-cart validates component-derived stock via `getComboStock`.
- [x] Cart combo line with component detail is preserved through existing combo cart metadata.
- [x] Checkout revalidates combo availability and rejects stale inactive combos.
- [x] Existing order snapshot/component decrement contract tests pass.
- [x] Negative states covered: inactive combo, invalid component/integrity failure, insufficient/stale stock, upload failure, rollback after persistence failure.
- [x] No promotions engine, free-form bundle builder, stackable coupons, recommender, or combo-owned sellable stock introduced.

## Sync / Gateway Evidence

- Overlay sync requested: `no`
- Gateway restart requested: `no`
- Readiness evidence: `n/a`

## Risks / Follow-Ups

- Manual `ecommerce-staging` validation is still needed for actual Supabase storage/RLS upload policies; this PR does not mutate live policies.
- Build logs still show existing environment warnings for missing local Supabase/Shopify env vars and Next workspace-root inference, but build exits 0.

## Closure Gate

- Implementation complete: `yes`
- Technical validation passed: `yes`
- Functional validation status: `pending_manual_validation` for live staging storage/RLS upload evidence
- Ready for merge: `yes`, subject to review
- Ready to close issue: `no`; keep issue #30 open until PR is merged and manual/staging acceptance evidence is confirmed

## Delivery Evidence Matrix

| Acceptance criterion | Evidence | Status |
| --- | --- | --- |
| Admin image preview/upload on save | `DeferredImageUpload`; deferred upload tests | pass |
| No partial broken image state on failure | `resolveDeferredImageUpload`; `updateCombo` rollback test | pass |
| Combo catalog/filter visibility | Existing `getItems` combo path preserved; duplicate append removed | pass |
| Combo detail price/components | Existing combo detail adapter/lookup preserved; typecheck/build pass | pass |
| Add-to-cart parity | `components/cart/add-to-cart.tsx` combo `getComboStock` validation | pass |
| Cart combo line with detail | Existing cart metadata preserved; typecheck/build pass | pass |
| Checkout snapshot/revalidation | `tests/orders/order-flow.contract.test.ts` | pass |
| Component stock decrement | Existing order contract test passes | pass |
| Negative states | `tests/products/combo-domain.test.ts`, `tests/orders/order-flow.contract.test.ts` | pass |

Refs #30
