### PR TITLE
fix(auth): gate admin routes in proxy

### DIFF
--- a/lib/supabase/admin-access.ts
+++ b/lib/supabase/admin-access.ts
@@ -1,0 +1,152 @@
+import { createServerClient } from "@supabase/ssr";
+import type { NextRequest } from "next/server";
+import { ECOMMERCE_TABLES } from "./contract";
+
+export type AdminAccessResult =
+  | { status: "admin"; userId: string }
+  | { status: "guest"; reason: "no_user" | "auth_error" | "supabase_not_configured" }
+  | { status: "non_admin"; userId: string; reason?: "missing_profile" | "role_mismatch" }
+  | { status: "error"; userId?: string; reason: "supabase_not_configured" | "profile_lookup_failed" };
+
+type AuthenticatedUser = {
+  id: string;
+};
+
+function isAdminRoute(pathname: string) {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
+export function normalizeSafeAdminPath(candidate: string | null | undefined) {
+  if (!candidate) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate, "http://osoria.local");
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "http://osoria.local") {
+    return null;
+  }
+
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return null;
+  }
+
+  const pathname = parsed.pathname;
+  if (!isAdminRoute(pathname)) {
+    return null;
+  }
+
+  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
+    return null;
+  }
+
+  return `${pathname}${parsed.search}`;
+}
+
+function createRequestAuthClient(request: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null;
+  }
+
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll().map((cookie) => ({
+          name: cookie.name,
+          value: cookie.value,
+        }));
+      },
+      setAll() {
+        // Proxy admin access checks are read-only. Any auth cookie refresh remains
+        // owned by Supabase/browser flows outside this PR slice.
+      },
+    },
+  });
+}
+
+async function getCurrentUser(request: NextRequest): Promise<AuthenticatedUser | null> {
+  const authSupabase = createRequestAuthClient(request);
+  if (!authSupabase) {
+    return null;
+  }
+
+  const { data, error } = await authSupabase.auth.getUser();
+  if (error || !data.user?.id) {
+    return null;
+  }
+
+  return { id: data.user.id };
+}
+
+async function fetchProfileRole(userId: string) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { kind: "error" as const };
+  }
+
+  const params = new URLSearchParams({
+    id: `eq.${userId}`,
+    select: "role",
+    limit: "1",
+  });
+
+  const response = await fetch(
+    `${supabaseUrl}/rest/v1/${ECOMMERCE_TABLES.userProfiles}?${params.toString()}`,
+    {
+      headers: {
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+        "Content-Type": "application/json",
+        "Accept-Profile": "ecommerce",
+      },
+      signal: AbortSignal.timeout(5000),
+    },
+  );
+
+  if (!response.ok) {
+    return { kind: "error" as const };
+  }
+
+  const data = await response.json();
+  const role = Array.isArray(data) && data[0]?.role ? String(data[0].role) : null;
+
+  return { kind: "role" as const, role };
+}
+
+export async function resolveAdminAccess(request: NextRequest): Promise<AdminAccessResult> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return { status: "guest", reason: "supabase_not_configured" };
+  }
+
+  const user = await getCurrentUser(request);
+  if (!user) {
+    return { status: "guest", reason: "no_user" };
+  }
+
+  try {
+    const profile = await fetchProfileRole(user.id);
+    if (profile.kind === "error") {
+      return { status: "error", userId: user.id, reason: "profile_lookup_failed" };
+    }
+
+    if (profile.role === "admin") {
+      return { status: "admin", userId: user.id };
+    }
+
+    return profile.role
+      ? { status: "non_admin", userId: user.id }
+      : { status: "non_admin", userId: user.id, reason: "missing_profile" };
+  } catch {
+    return { status: "error", userId: user.id, reason: "profile_lookup_failed" };
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { resolveStoreSubdomain } from '@/lib/utils/store-host'
+import { normalizeSafeAdminPath, resolveAdminAccess } from '@/lib/supabase/admin-access'
 
 // Variable de entorno para deshabilitar multi-tenant temporalmente
 const DISABLE_SUBDOMAIN_MULTI_TENANT = process.env.DISABLE_SUBDOMAIN_MULTI_TENANT === 'true'
@@ -20,6 +21,40 @@ interface Store {
 // Caché simple en memoria para las tiendas (evita consultas repetidas)
 const storeCache = new Map<string, { store: Store | null; timestamp: number }>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutos
+
+function isAdminRoute(pathname: string) {
+  return pathname === '/admin' || pathname.startsWith('/admin/')
+}
+
+async function applyAdminRouteGate(request: NextRequest, response: NextResponse) {
+  const { pathname, search } = request.nextUrl
+
+  if (!isAdminRoute(pathname)) {
+    return response
+  }
+
+  const access = await resolveAdminAccess(request)
+  if (access.status === 'admin') {
+    return response
+  }
+
+  const redirectUrl = request.nextUrl.clone()
+  redirectUrl.pathname = '/'
+  redirectUrl.search = ''
+
+  if (access.status === 'guest') {
+    const next = normalizeSafeAdminPath(`${pathname}${search}`) || '/admin'
+    redirectUrl.searchParams.set('auth', 'login')
+    redirectUrl.searchParams.set('next', next)
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  redirectUrl.searchParams.set(
+    'admin_access',
+    access.status === 'error' ? 'error' : 'denied',
+  )
+  return NextResponse.redirect(redirectUrl)
+}
 
 /**
  * Obtiene la tienda desde Supabase por subdominio (schema ecommerce, vista stores_legacy)
@@ -109,7 +144,7 @@ export async function proxy(request: NextRequest) {
       sameSite: 'lax',
     })
 
-    return response
+    return applyAdminRouteGate(request, response)
   }
 
   // Extraer subdominio
@@ -133,7 +168,7 @@ export async function proxy(request: NextRequest) {
         sameSite: 'lax',
       })
       
-      return response
+      return applyAdminRouteGate(request, response)
     }
     
     // Si no existe tienda por defecto, permitir continuar con valores por defecto
@@ -149,7 +184,7 @@ export async function proxy(request: NextRequest) {
       sameSite: 'lax',
     })
     
-    return response
+    return applyAdminRouteGate(request, response)
   }
 
   // Obtener información de la tienda
@@ -182,7 +217,7 @@ export async function proxy(request: NextRequest) {
     sameSite: 'lax',
   })
 
-  return response
+  return applyAdminRouteGate(request, response)
 }
 
 // Configurar qué rutas deben ejecutar el proxy

--- a/tests/proxy/admin-route-guard.test.ts
+++ b/tests/proxy/admin-route-guard.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const defaultStore = {
+  id: "84f0a892-cf12-4826-befd-cf64e1235123",
+  subdomain: "default",
+  store_name: "Tienda Principal",
+  domain: "example.com",
+  is_active: true,
+  is_public: true,
+};
+
+const resolveAdminAccessMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin-access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin-access")>();
+
+  return {
+    ...actual,
+    resolveAdminAccess: resolveAdminAccessMock,
+  };
+});
+
+function makeRequest(pathname: string) {
+  return new NextRequest(`http://localhost:3000${pathname}`, {
+    headers: { host: "localhost:3000" },
+  });
+}
+
+function mockStoreFetch() {
+  return vi.fn(async () => new Response(JSON.stringify([defaultStore]), { status: 200 }));
+}
+
+describe("proxy admin route guard", () => {
+  let fetchMock: ReturnType<typeof mockStoreFetch>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = mockStoreFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+    delete process.env.DISABLE_SUBDOMAIN_MULTI_TENANT;
+    delete process.env.DEFAULT_STORE_ID;
+    resolveAdminAccessMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    errorSpy.mockRestore();
+  });
+
+  it("redirects a guest /admin/orders request before render with login intent", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "guest" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?auth=login&next=%2Fadmin%2Forders",
+    );
+  });
+
+  it("redirects a non-admin safely with denied feedback", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "non_admin", userId: "customer-1" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?admin_access=denied",
+    );
+  });
+
+  it("passes an admin through while preserving store headers and cookies", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "admin", userId: "admin-1" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-store-id")).toBe(defaultStore.id);
+    expect(response.headers.get("x-store-subdomain")).toBe("default");
+    expect(response.headers.get("set-cookie")).toContain(`store_id=${defaultStore.id}`);
+  });
+
+  it("treats an expired or missing user as a login redirect", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "guest", reason: "no_user" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?auth=login&next=%2Fadmin",
+    );
+  });
+
+  it("redirects lookup and service errors to safe error feedback", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "error", reason: "profile_lookup_failed" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?admin_access=error",
+    );
+  });
+
+  it.each(["/", "/checkout", "/dashboard"])(
+    "leaves %s unaffected by the admin proxy gate",
+    async (path) => {
+      const { proxy } = await import("@/proxy");
+
+      const response = await proxy(makeRequest(path));
+
+      expect(resolveAdminAccessMock).not.toHaveBeenCalled();
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.headers.get("x-store-subdomain")).toBe("default");
+    },
+  );
+});

--- a/tests/security/admin-access.test.ts
+++ b/tests/security/admin-access.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const getUserMock = vi.fn();
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: getUserMock },
+  })),
+}));
+
+function makeRequest(pathname = "/admin/orders") {
+  return new NextRequest(`http://localhost:3000${pathname}`, {
+    headers: { host: "localhost:3000" },
+  });
+}
+
+describe("admin access resolver", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role");
+    getUserMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ["/admin/orders", "/admin/orders"],
+    ["/admin/orders?status=open", "/admin/orders?status=open"],
+    ["//evil.com/admin", null],
+    ["https://evil.com/admin", null],
+    ["/auth/callback?next=/admin", null],
+    ["/?admin_access=denied", null],
+  ])("normalizes safe admin return target %s", async (input, expected) => {
+    const { normalizeSafeAdminPath } = await import("@/lib/supabase/admin-access");
+
+    expect(normalizeSafeAdminPath(input)).toBe(expected);
+  });
+
+  it("returns guest when Supabase auth has no current user", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "guest",
+      reason: "no_user",
+    });
+  });
+
+  it("returns admin for a user with ecommerce.user_profiles.role admin", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify([{ role: "admin" }]), { status: 200 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "admin",
+      userId: "admin-1",
+    });
+  });
+
+  it("returns non_admin for an authenticated non-admin profile", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "customer-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify([{ role: "customer" }]), { status: 200 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "non_admin",
+      userId: "customer-1",
+    });
+  });
+
+  it("returns error when the service-role profile lookup fails", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ message: "boom" }), { status: 500 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "error",
+      userId: "admin-1",
+      reason: "profile_lookup_failed",
+    });
+  });
+});


### PR DESCRIPTION
Refs #35

## Summary
- Adds a shared server admin-access resolver for `/admin` route checks using Supabase Auth cookies plus existing `ecommerce.user_profiles.role`.
- Gates `/admin` and `/admin/*` in `proxy.ts` before admin route rendering: guests go to `/?auth=login&next=...`, non-admin users go to `/?admin_access=denied`, lookup errors go to `/?admin_access=error`, admins pass through.
- Adds focused route-matrix and admin-access tests while leaving callback/login return-intent work for the next chained PR slice.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes
| File | Change |
|------|--------|
| `proxy.ts` | Applies `/admin`/`/admin/*` admin route gate after existing store resolution, preserving store headers/cookies for allowed admin requests. |
| `lib/supabase/admin-access.ts` | Adds safe admin-path normalization and server admin-access resolution using Supabase Auth cookies and service-role profile lookup. |
| `tests/proxy/admin-route-guard.test.ts` | Covers guest, non-admin, admin, expired/no-user, lookup-error, and unaffected public/checkout/dashboard paths. |
| `tests/security/admin-access.test.ts` | Covers safe destination normalization and resolver role outcomes. |

## Verification
- [x] Strict TDD RED: new Unit 1 tests failed before implementation (missing helper / admin redirects returned pass-through).
- [x] `node scripts/run-vitest.mjs tests/proxy/store-resolution.test.ts tests/proxy/admin-route-guard.test.ts tests/security/admin-access.test.ts` — 24/24 passed.
- [x] `corepack pnpm typecheck` — passed.
- [x] `corepack pnpm exec eslint proxy.ts lib/supabase/admin-access.ts tests/proxy/admin-route-guard.test.ts tests/security/admin-access.test.ts --max-warnings=0` — passed.
- [x] `corepack pnpm test` — 41 files / 251 tests passed.
- [x] `git diff --check` — passed.

## Supabase / migrations
- No Supabase migration required.
- No schema, storage bucket, RLS/storage policy, seed, or data backfill changes.
- Runtime requirements for this slice: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` so proxy/server code can verify `ecommerce.user_profiles.role`.

## Chained PR boundary
This is Unit 1 of issue #35 only. Remaining planned slices:
1. Callback/login return intent hardening (`app/auth/callback/page.tsx` and narrow login helper/header path).
2. Residual client fallback UX alignment and docs/runtime notes if still needed.

## Manual QA notes
- Before merging the full issue chain, manually verify guest, non-admin, and admin navigation to `/admin/orders`, `/admin/products`, `/admin`, `/dashboard`, `/checkout`, and a public route.
- This PR alone intentionally does not complete callback/login `next` consumption.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no shell scripts changed)
- [x] Skills tested in at least one agent (SDD propose/spec/design/tasks/apply/verify)
- [x] Docs updated if behavior changed (PR + issue notes document Unit 1 scope)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
