### PR TITLE
fix(auth): preserve safe admin return intent

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { getSupabaseBrowserClient } from "@/lib/supabase/client"
+import { getCurrentUser } from "@/lib/supabase/auth-api"
+import { getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
 
 function AuthCallbackContent() {
   const router = useRouter()
@@ -29,6 +31,16 @@ function AuthCallbackContent() {
           return
         }
 
+        const returnPath = getAuthReturnPath(searchParams)
+
+        const pushPostAuthDestination = async () => {
+          const currentUser = await getCurrentUser()
+          router.push(resolvePostAuthDestination({
+            returnPath,
+            user: currentUser.success ? currentUser.user : null,
+          }))
+        }
+
         if (code) {
           // Intercambiar el código por una sesión
           const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
@@ -41,7 +53,8 @@ function AuthCallbackContent() {
 
           if (data.session) {
             // Sesión creada (p. ej. tras confirmar correo), redirigir a página de éxito
-            router.push("/auth/cuenta-confirmada")
+            // salvo que exista un destino admin seguro permitido para el usuario.
+            await pushPostAuthDestination()
             return
           }
         }
@@ -57,7 +70,8 @@ function AuthCallbackContent() {
 
         if (session) {
           // Ya hay sesión (p. ej. llegó sin code), redirigir a éxito o inicio
-          router.push("/auth/cuenta-confirmada")
+          // salvo que exista un destino admin seguro permitido para el usuario.
+          await pushPostAuthDestination()
         } else {
           // No hay sesión, redirigir al login
           router.push("/?error=no_session")

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import { useState, useMemo, useEffect } from "react"
-import { useRouter, usePathname } from "next/navigation"
+import { useState, useMemo, useEffect, useRef } from "react"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Search, Heart, ShoppingCart, Palette, AlignLeft, Menu, LogIn, LogOut, User, Eye, EyeOff, CreditCard, Building2, Wallet, LayoutDashboard, Edit } from "lucide-react"
 import { VisaIcon, MasterCardIcon, AmexIcon } from "@/components/icons/cc-icons"
@@ -21,6 +21,7 @@ import { Trash2, Plus, Minus } from "lucide-react"
 import { toast } from "sonner"
 import { resetPassword } from "@/lib/supabase/auth-api"
 import { deferStateUpdate } from "@/lib/react/defer-state-update"
+import { ADMIN_ACCESS_DENIED_PATH, getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
 import {
   Sheet,
   SheetContent,
@@ -67,6 +68,7 @@ function generateCategorySlug(name: string): string {
 
 export function Header() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [themeModalOpen, setThemeModalOpen] = useState(false)
   const [fontModalOpen, setFontModalOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -87,6 +89,8 @@ export function Header() {
   const [forgotPasswordModalOpen, setForgotPasswordModalOpen] = useState(false)
   const [resetEmail, setResetEmail] = useState("")
   const [resetEmailSent, setResetEmailSent] = useState(false)
+  const [pendingLoginReturnPath, setPendingLoginReturnPath] = useState<string | null>(null)
+  const openedLoginReturnIntentRef = useRef<string | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
   const [searchSuggestions, setSearchSuggestions] = useState<Array<{ id: string; title: string; slug: string; image?: string }>>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -146,6 +150,26 @@ export function Header() {
     ? (styleData.logoImageDark || "/logo-osoria-blanco.svg")
     : (styleData.logoImage || "/logo-negro.svg")
   const pathname = usePathname()
+
+  useEffect(() => {
+    if (searchParams.get("auth") !== "login") {
+      return
+    }
+
+    const safeReturnPath = getAuthReturnPath(searchParams)
+    if (!safeReturnPath) {
+      return
+    }
+
+    if (openedLoginReturnIntentRef.current === safeReturnPath) {
+      return
+    }
+
+    openedLoginReturnIntentRef.current = safeReturnPath
+    setPendingLoginReturnPath(safeReturnPath)
+    setIsRegisterMode(false)
+    setLoginModalOpen(true)
+  }, [searchParams])
 
   // Sincronizar el query de búsqueda con la URL cuando esté en /shop
   useEffect(() => {
@@ -1323,7 +1347,8 @@ export function Header() {
                   // Refrescar el usuario para obtener el rol actualizado
                   await refreshUser()
                   
-                  // Todos los usuarios (admin y user) van a la página principal
+                  // Todos los usuarios (admin y user) inician sesión; solo admins consumen
+                  // un destino admin seguro solicitado desde ?auth=login&next=...
                   toast.success(t.header.sessionStarted, {
                     description: result.user?.role === 'admin' 
                       ? t.header.welcomeAdminLogin 
@@ -1331,6 +1356,8 @@ export function Header() {
                     duration: 3000,
                   })
                   
+                  const loginReturnPath = pendingLoginReturnPath
+                  setPendingLoginReturnPath(null)
                   setLoginModalOpen(false)
                   setEmail("")
                   setPassword("")
@@ -1340,6 +1367,15 @@ export function Header() {
                   setShowPassword(false)
                   setShowConfirmPassword(false)
                   setIsRegisterMode(false)
+
+                  if (loginReturnPath) {
+                    const nextDestination = resolvePostAuthDestination({
+                      returnPath: loginReturnPath,
+                      user: result.user,
+                      fallback: ADMIN_ACCESS_DENIED_PATH,
+                    })
+                    router.push(nextDestination)
+                  }
                 } else {
                   toast.error(t.header.errorLoggingIn, {
                     description: result.error || "Verifica tus credenciales e intenta nuevamente",

--- a/lib/auth-return-intent.ts
+++ b/lib/auth-return-intent.ts
@@ -1,0 +1,67 @@
+import type { UserProfile } from "@/lib/types/user";
+
+export const AUTH_CONFIRMATION_SUCCESS_PATH = "/auth/cuenta-confirmada";
+export const ADMIN_ACCESS_DENIED_PATH = "/?admin_access=denied";
+
+export type AuthReturnUser = Pick<UserProfile, "role"> | null | undefined;
+
+function isAdminRoute(pathname: string) {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
+export function normalizeAuthReturnPath(candidate: string | null | undefined) {
+  if (!candidate) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate, "http://osoria.local");
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "http://osoria.local") {
+    return null;
+  }
+
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return null;
+  }
+
+  const pathname = parsed.pathname;
+  if (!isAdminRoute(pathname)) {
+    return null;
+  }
+
+  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
+    return null;
+  }
+
+  return `${pathname}${parsed.search}`;
+}
+
+export function getAuthReturnPath(params: Pick<URLSearchParams, "get">) {
+  return normalizeAuthReturnPath(params.get("next") ?? params.get("redirect"));
+}
+
+export function resolvePostAuthDestination({
+  returnPath,
+  user,
+  fallback = AUTH_CONFIRMATION_SUCCESS_PATH,
+}: {
+  returnPath: string | null | undefined;
+  user: AuthReturnUser;
+  fallback?: string;
+}) {
+  const safeReturnPath = normalizeAuthReturnPath(returnPath);
+  if (!safeReturnPath) {
+    return fallback;
+  }
+
+  if (user?.role === "admin") {
+    return safeReturnPath;
+  }
+
+  return ADMIN_ACCESS_DENIED_PATH;
+}

--- a/lib/supabase/admin-access.ts
+++ b/lib/supabase/admin-access.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import type { NextRequest } from "next/server";
 import { ECOMMERCE_TABLES } from "./contract";
+import { normalizeAuthReturnPath } from "@/lib/auth-return-intent";
 
 export type AdminAccessResult =
   | { status: "admin"; userId: string }
@@ -12,40 +13,8 @@ type AuthenticatedUser = {
   id: string;
 };
 
-function isAdminRoute(pathname: string) {
-  return pathname === "/admin" || pathname.startsWith("/admin/");
-}
-
 export function normalizeSafeAdminPath(candidate: string | null | undefined) {
-  if (!candidate) {
-    return null;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(candidate, "http://osoria.local");
-  } catch {
-    return null;
-  }
-
-  if (parsed.origin !== "http://osoria.local") {
-    return null;
-  }
-
-  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
-    return null;
-  }
-
-  const pathname = parsed.pathname;
-  if (!isAdminRoute(pathname)) {
-    return null;
-  }
-
-  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
-    return null;
-  }
-
-  return `${pathname}${parsed.search}`;
+  return normalizeAuthReturnPath(candidate);
 }
 
 function createRequestAuthClient(request: NextRequest) {

--- a/tests/auth/auth-callback-redirect.test.tsx
+++ b/tests/auth/auth-callback-redirect.test.tsx
@@ -1,0 +1,170 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerPush = vi.hoisted(() => vi.fn());
+const searchParamsGet = vi.hoisted(() => vi.fn());
+const exchangeCodeForSession = vi.hoisted(() => vi.fn());
+const getSession = vi.hoisted(() => vi.fn());
+const getCurrentUser = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  useSearchParams: () => ({ get: searchParamsGet }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  getSupabaseBrowserClient: () => ({
+    auth: {
+      exchangeCodeForSession,
+      getSession,
+    },
+  }),
+}));
+
+vi.mock("@/lib/supabase/auth-api", () => ({
+  getCurrentUser,
+}));
+
+import AuthCallback from "@/app/auth/callback/page";
+
+describe("auth callback safe return destinations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: null,
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
+    getSession.mockResolvedValue({ data: { session: null }, error: null });
+    getCurrentUser.mockResolvedValue({ success: true, user: { id: "admin-1", email: "admin@example.com", role: "admin" } });
+  });
+
+  it("returns an admin to a safe admin next destination after code exchange", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: "/admin/orders?status=open",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders?status=open");
+    });
+  });
+
+  it.each([
+    "https://evil.example/admin/orders",
+    "//evil.example/admin/orders",
+  ])("rejects unsafe external next destination %s and preserves confirmation success", async (unsafeNext) => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: unsafeNext,
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/auth/cuenta-confirmada");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith(expect.stringContaining("evil"));
+  });
+
+  it("does not send a non-admin user into an admin next destination", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getCurrentUser.mockResolvedValue({ success: true, user: { id: "user-1", email: "user@example.com", role: "user" } });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?admin_access=denied");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith("/admin/orders");
+  });
+
+  it("preserves the callback error branch", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: "access_denied",
+        error_description: "Denied",
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?error=auth_callback_failed");
+    });
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("preserves the no-session branch when there is no code and no active session", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getSession.mockResolvedValue({ data: { session: null }, error: null });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?error=no_session");
+    });
+  });
+
+  it("uses a safe admin next destination for an existing admin session", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getSession.mockResolvedValue({ data: { session: { access_token: "existing" } }, error: null });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders");
+    });
+  });
+});

--- a/tests/components/header-login-return-intent.test.tsx
+++ b/tests/components/header-login-return-intent.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text -- Test-only next/image mock renders a native img. */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerPush = vi.hoisted(() => vi.fn());
+const searchParamsGet = vi.hoisted(() => vi.fn());
+const loginMock = vi.hoisted(() => vi.fn());
+const refreshUserMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  usePathname: () => "/",
+  useSearchParams: () => ({ get: searchParamsGet }),
+}));
+
+vi.mock("next/image", () => ({ default: ({ priority: _priority, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => <img {...props} /> }));
+vi.mock("next/link", () => ({ default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => <a href={href} {...props}>{children}</a> }));
+
+vi.mock("lucide-react", () => ({
+  Search: () => <span aria-hidden="true" />,
+  Heart: () => <span aria-hidden="true" />,
+  ShoppingCart: () => <span aria-hidden="true" />,
+  Palette: () => <span aria-hidden="true" />,
+  AlignLeft: () => <span aria-hidden="true" />,
+  Menu: () => <span aria-hidden="true" />,
+  LogIn: () => <span aria-hidden="true" />,
+  LogOut: () => <span aria-hidden="true" />,
+  User: () => <span aria-hidden="true" />,
+  Eye: () => <span aria-hidden="true" />,
+  EyeOff: () => <span aria-hidden="true" />,
+  CreditCard: () => <span aria-hidden="true" />,
+  Building2: () => <span aria-hidden="true" />,
+  Wallet: () => <span aria-hidden="true" />,
+  LayoutDashboard: () => <span aria-hidden="true" />,
+  Edit: () => <span aria-hidden="true" />,
+  Trash2: () => <span aria-hidden="true" />,
+  Plus: () => <span aria-hidden="true" />,
+  Minus: () => <span aria-hidden="true" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({ Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button> }));
+vi.mock("@/components/ui/input", () => ({ Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} /> }));
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SheetContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  SheetHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  SheetTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: React.PropsWithChildren<{ open?: boolean }>) => open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  AlertDialogAction: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogCancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("@/contexts/styles-context", () => ({ useComponentStyle: (_name: string, defaults: Record<string, string>) => ({ styles: defaults }) }));
+vi.mock("@/contexts/theme-context", () => ({ useTheme: () => ({ activeTheme: null }) }));
+vi.mock("@/contexts/store-context", () => ({ useStore: () => ({ store: null }) }));
+vi.mock("@/contexts/cart-context", () => ({ useCart: () => ({ items: [], removeFromCart: vi.fn(), updateQuantity: vi.fn(), getTotal: () => 0, getItemSubtotal: () => 0, getTotalItems: () => 0 }) }));
+vi.mock("@/contexts/wishlist-context", () => ({ useWishlist: () => ({ getTotalItems: () => 0 }) }));
+vi.mock("@/contexts/auth-context", () => ({ useAuth: () => ({ user: null, isAuthenticated: false, login: loginMock, register: vi.fn(), logout: vi.fn(), refreshUser: refreshUserMock }) }));
+vi.mock("@/contexts/language-context", () => ({
+  useLanguage: () => ({
+    t: {
+      auth: { login: "Iniciar sesión", createAccount: "Crear cuenta", signIn: "Entrar" },
+      header: {
+        sessionStarted: "Sesión iniciada",
+        welcomeAdminLogin: "Admin listo",
+        errorLoggingIn: "Error al iniciar sesión",
+        passwordsDoNotMatch: "Las contraseñas no coinciden",
+        passwordsDoNotMatchDescription: "Revisa las contraseñas",
+        confirmEmailSent: "Confirma tu correo",
+        confirmEmailDescription: "Te enviamos un correo",
+        accountCreated: "Cuenta creada",
+        welcomeAdminMessage: "Admin creado",
+        accountCreatedSuccess: "Cuenta creada",
+        errorCreatingAccount: "Error al crear cuenta",
+        loginRequired: "Login requerido",
+        loginRequiredDescription: "Debes iniciar sesión",
+        loginRequiredDescription2: "Continúa para comprar",
+      },
+      cart: { checkout: "Checkout" },
+      nav: { wishlist: "Wishlist", cart: "Cart" },
+    },
+  }),
+}));
+vi.mock("@/components/theme/theme-selector-modal", () => ({ ThemeSelectorModal: () => null }));
+vi.mock("@/components/font/font-selector-modal", () => ({ FontSelectorModal: () => null }));
+vi.mock("@/components/cart/checkout-options-dialog", () => ({ CheckoutOptionsDialog: () => null }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/supabase/auth-api", () => ({ resetPassword: vi.fn() }));
+
+import { Header } from "@/components/layout/header";
+
+describe("Header login return intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = { auth: "login", next: "/admin/orders" };
+      return values[key] ?? null;
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify([]), { status: 200 })));
+    loginMock.mockResolvedValue({ success: true, user: { id: "admin-1", email: "admin@example.com", role: "admin" } });
+    refreshUserMock.mockResolvedValue(undefined);
+  });
+
+  it("opens the login modal once for a safe admin return intent query", async () => {
+    const { rerender } = render(<Header />);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Iniciar sesión" })).toBeInTheDocument();
+
+    rerender(<Header />);
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+
+  it("routes an admin login to the safe next path once", async () => {
+    render(<Header />);
+
+    fireEvent.change(await screen.findByPlaceholderText("tu@email.com"), { target: { value: "admin@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("••••••••"), { target: { value: "secret123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders");
+    });
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not route a non-admin login into the admin next path", async () => {
+    loginMock.mockResolvedValue({ success: true, user: { id: "user-1", email: "user@example.com", role: "user" } });
+    render(<Header />);
+
+    fireEvent.change(await screen.findByPlaceholderText("tu@email.com"), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("••••••••"), { target: { value: "secret123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?admin_access=denied");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith("/admin/orders");
+  });
+});


### PR DESCRIPTION
Refs #35

## Summary
- Adds a client-safe auth return-intent helper shared by callback, header login, and the existing admin proxy helper.
- Preserves safe `/admin*` `next`/`redirect` destinations after auth only for admin users.
- Rejects unsafe external/`//` return targets and prevents non-admin logins from routing into `/admin`.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes
| File | Change |
|------|--------|
| `lib/auth-return-intent.ts` | Adds shared normalization and post-auth destination helpers for safe admin return paths. |
| `lib/supabase/admin-access.ts` | Reuses the shared helper for proxy safe-admin path normalization, avoiding duplicate logic. |
| `app/auth/callback/page.tsx` | Uses safe return intent after code exchange/existing session; preserves existing success/error/no-session fallback branches. |
| `components/layout/header.tsx` | Opens login modal once for `?auth=login&next=...`; admin login consumes safe next once; non-admin falls back denied. |
| `tests/auth/auth-callback-redirect.test.tsx` | Covers safe admin next, unsafe next rejection, non-admin denial, callback error, no-session, and existing-session cases. |
| `tests/components/header-login-return-intent.test.tsx` | Covers login modal opening once, admin next consumption, and non-admin denial. |

## Verification
- [x] Strict TDD RED: Unit 2 tests failed before implementation (callback returned to confirmation page; header did not consume return intent).
- [x] `node scripts/run-vitest.mjs tests/auth/auth-callback-redirect.test.tsx tests/components/header-login-return-intent.test.tsx tests/security/admin-access.test.ts` — 20/20 passed.
- [x] `corepack pnpm typecheck` — passed.
- [x] `corepack pnpm exec eslint app/auth/callback/page.tsx components/layout/header.tsx lib/auth-return-intent.ts lib/supabase/admin-access.ts tests/auth/auth-callback-redirect.test.tsx tests/components/header-login-return-intent.test.tsx --max-warnings=0` — passed.
- [x] `corepack pnpm test` — 43 files / 261 tests passed.
- [x] `git diff --check` — passed.

## Supabase / migrations
- No Supabase migration required.
- No schema, storage bucket, RLS/storage policy, seed, or data backfill changes.
- This PR reuses the existing authenticated user profile role (`user.role`) from current auth APIs.

## Chained PR boundary
This PR is Unit 2 and is stacked on PR #55 (`fix/issue-35-admin-proxy-gate`). Remaining planned work:
- Unit 3: residual client fallback UX alignment and docs/runtime notes if still needed.

## Manual QA notes
Before merging the full issue chain, manually verify:
- Guest opens `/admin/orders` → login intent appears with safe next.
- Admin login returns to `/admin/orders` once.
- Non-admin login does not enter `/admin` and lands on denied fallback.
- Existing auth callback success without `next` still lands on confirmation success.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no shell scripts changed)
- [x] Skills tested in at least one agent (SDD apply/verify Unit 2)
- [x] Docs updated if behavior changed (PR + issue notes document Unit 2 scope)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
