### PR TITLE
fix(auth): revalidate admin fallback by user

### DIFF
--- a/contexts/admin-permissions-context.tsx
+++ b/contexts/admin-permissions-context.tsx
@@ -17,13 +17,15 @@ interface AdminPermissionsContextType {
 const AdminPermissionsContext = createContext<AdminPermissionsContextType | undefined>(undefined)
 
 export function AdminPermissionsProvider({ children }: { children: ReactNode }) {
-  const { isLoading: authLoading, isAuthenticated } = useAuth()
+  const { isLoading: authLoading, isAuthenticated, user } = useAuth()
+  const currentUserId = user?.id ?? null
   const [isAdmin, setIsAdmin] = useState(false)
   const [role, setRole] = useState<UserRole | null>(null)
   const [loading, setLoading] = useState(true)
   const [hasChecked, setHasChecked] = useState(false) // Indica si ya se verificó al menos una vez
   const refreshRef = useRef(false) // Ref para evitar múltiples llamadas simultáneas
   const verifiedAsAdminRef = useRef(false) // Ref para rastrear si ya se verificó como admin exitosamente
+  const checkedUserIdRef = useRef<string | null>(null) // Evita reutilizar permisos de otro usuario autenticado
 
   const refreshPermissions = async () => {
     // Evitar múltiples verificaciones simultáneas
@@ -120,14 +122,6 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
 
   // Esperar a que la autenticación esté lista antes de comprobar permisos (evita "no tienes permisos" al entrar)
   useEffect(() => {
-    // Si ya se verificó exitosamente como admin y el usuario sigue autenticado, no verificar de nuevo
-    // Esto evita verificaciones innecesarias al navegar entre páginas
-    if (verifiedAsAdminRef.current && isAuthenticated && !authLoading) {
-      console.log("[AdminPermissions] Ya verificado como admin, omitiendo verificación adicional")
-      setLoading(false) // Asegurar que loading esté en false
-      return
-    }
-
     if (authLoading) {
       deferStateUpdate(() => setLoading(true))
       return
@@ -135,7 +129,7 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
 
     // Si el usuario se desautenticó, resetear estado
     if (!isAuthenticated) {
-      if (verifiedAsAdminRef.current || hasChecked) {
+      if (verifiedAsAdminRef.current || hasChecked || checkedUserIdRef.current !== null) {
         console.log("[AdminPermissions] Usuario desautenticado, reseteando estado")
         deferStateUpdate(() => {
           setIsAdmin(false)
@@ -143,8 +137,32 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
           setHasChecked(false)
         })
         verifiedAsAdminRef.current = false // Resetear ref
+        checkedUserIdRef.current = null
       }
       deferStateUpdate(() => setLoading(false))
+      return
+    }
+
+    // Si cambió el usuario autenticado, negar hasta volver a verificar ese usuario.
+    if (checkedUserIdRef.current !== currentUserId) {
+      console.log("[AdminPermissions] Usuario autenticado cambió, revalidando permisos")
+      checkedUserIdRef.current = currentUserId
+      verifiedAsAdminRef.current = false
+      deferStateUpdate(() => {
+        setIsAdmin(false)
+        setRole(null)
+        setHasChecked(false)
+        setLoading(true)
+        void refreshPermissions()
+      })
+      return
+    }
+
+    // Si ya se verificó exitosamente como admin y el usuario sigue autenticado, no verificar de nuevo
+    // Esto evita verificaciones innecesarias al navegar entre páginas
+    if (verifiedAsAdminRef.current && isAuthenticated && !authLoading) {
+      console.log("[AdminPermissions] Ya verificado como admin, omitiendo verificación adicional")
+      setLoading(false) // Asegurar que loading esté en false
       return
     }
 
@@ -159,7 +177,7 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
     }
     // refreshPermissions intentionally stays outside deps to avoid repeated permission checks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authLoading, isAuthenticated]) // Solo depender de authLoading e isAuthenticated para evitar loops
+  }, [authLoading, isAuthenticated, currentUserId]) // Revalidar cuando cambia el usuario autenticado, no solo el booleano de sesión
 
 
   return (

--- a/docs/auth/issue-35-safe-role-redirects-runtime.md
+++ b/docs/auth/issue-35-safe-role-redirects-runtime.md
@@ -1,0 +1,28 @@
+# Issue #35 Safe Role Redirects — Runtime Notes
+
+## Runtime environment
+
+The route guard and return-intent flow reuse the existing Supabase Auth/session setup. Deployments must provide:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+`SUPABASE_SERVICE_ROLE_KEY` stays server-only and is required for the proxy/server admin role lookup against the existing `ecommerce.user_profiles.role` value.
+
+## Supabase changes
+
+Issue #35 does **not** introduce Supabase migrations, schema changes, storage changes, or RLS changes. It continues to use the current Auth session cookies and the existing `ecommerce.user_profiles.role = 'admin'` contract for admin users.
+
+## Manual QA matrix
+
+| Flow | Expected result |
+| --- | --- |
+| Guest opens `/admin` or `/admin/orders` | Redirects before admin content renders to `/?auth=login&next=/admin...`. |
+| Authenticated non-admin opens `/admin*` | Redirects before admin content renders to `/?admin_access=denied`. |
+| Admin opens `/admin*` | Requested admin route renders after admin status is verified; client fallback must not redirect the verified admin home from stale state. |
+| Expired or missing session opens `/admin*` | Redirects to login with safe admin return intent and no admin content render. |
+| Supabase role lookup fails on `/admin*` | Redirects to safe fallback with `admin_access=error`. |
+| Callback/login with safe admin `next` | Admin returns once to the safe `/admin*` destination; non-admin receives `admin_access=denied`. |
+| Callback/login with external or `//` next | Unsafe target is rejected; no open redirect occurs. |
+| `/dashboard`, `/checkout`, and public routes | Existing behavior remains unchanged by issue #35. |

--- a/tests/contexts/admin-permissions-context.test.tsx
+++ b/tests/contexts/admin-permissions-context.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIsCurrentUserAdmin = vi.hoisted(() => vi.fn());
+const mockGetCurrentUserRole = vi.hoisted(() => vi.fn());
+const authState = vi.hoisted(() => ({
+  isLoading: false,
+  isAuthenticated: true,
+  user: { id: "admin-1", email: "admin@example.com" },
+}));
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/lib/supabase/permissions-api", () => ({
+  isCurrentUserAdmin: () => mockIsCurrentUserAdmin(),
+  getCurrentUserRole: () => mockGetCurrentUserRole(),
+}));
+
+import {
+  AdminPermissionsProvider,
+  useAdminPermissions,
+} from "@/contexts/admin-permissions-context";
+
+function Harness() {
+  const { isAdmin, role, loading, hasChecked } = useAdminPermissions();
+
+  return (
+    <div>
+      <div data-testid="is-admin">{String(isAdmin)}</div>
+      <div data-testid="role">{role ?? "none"}</div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="has-checked">{String(hasChecked)}</div>
+    </div>
+  );
+}
+
+function renderHarness() {
+  return render(
+    <AdminPermissionsProvider>
+      <Harness />
+    </AdminPermissionsProvider>,
+  );
+}
+
+describe("AdminPermissionsProvider deny-until-verified fallback", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    authState.isLoading = false;
+    authState.isAuthenticated = true;
+    authState.user = { id: "admin-1", email: "admin@example.com" };
+    mockIsCurrentUserAdmin.mockResolvedValue(true);
+    mockGetCurrentUserRole.mockResolvedValue("admin");
+  });
+
+  it("keeps permissions loading until the authenticated user's admin role is verified", async () => {
+    let resolveAdmin!: (value: boolean) => void;
+    let resolveRole!: (value: string) => void;
+    mockIsCurrentUserAdmin.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAdmin = resolve;
+      }),
+    );
+    mockGetCurrentUserRole.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRole = resolve;
+      }),
+    );
+
+    renderHarness();
+
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    expect(screen.getByTestId("has-checked")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
+
+    resolveAdmin(true);
+    resolveRole("admin");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("has-checked")).toHaveTextContent("true");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    expect(screen.getByTestId("role")).toHaveTextContent("admin");
+  });
+
+  it("rechecks permissions when the authenticated user id changes so stale admin state cannot leak", async () => {
+    const { rerender } = renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(1);
+
+    mockIsCurrentUserAdmin.mockResolvedValue(false);
+    mockGetCurrentUserRole.mockResolvedValue("user");
+    authState.user = { id: "customer-1", email: "customer@example.com" };
+
+    rerender(
+      <AdminPermissionsProvider>
+        <Harness />
+      </AdminPermissionsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("has-checked")).toHaveTextContent("true");
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
+    expect(screen.getByTestId("role")).toHaveTextContent("user");
+  });
+});


### PR DESCRIPTION
Closes #35

## Summary
- Revalidates client admin fallback state when the authenticated `user.id` changes so stale admin permissions cannot leak to a different user.
- Adds focused fallback tests for deny-until-verified and changed-user revalidation.
- Documents final issue #35 runtime requirements, no-migration boundary, and manual QA matrix.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes
| File | Change |
|------|--------|
| `contexts/admin-permissions-context.tsx` | Tracks the checked `user.id`, resets trusted admin state when the authenticated user changes, and revalidates before trusting fallback state. |
| `tests/contexts/admin-permissions-context.test.tsx` | Adds strict-TDD tests for loading/deny-until-verified and stale admin state across user changes. |
| `docs/auth/issue-35-safe-role-redirects-runtime.md` | Documents required env vars, no Supabase migration/schema/storage/RLS changes, and manual QA matrix for issue #35. |

## Verification
- [x] Strict TDD RED: stale user-id fallback test failed before implementation.
- [x] `node scripts/run-vitest.mjs tests/contexts/admin-permissions-context.test.tsx tests/auth/auth-callback-redirect.test.tsx tests/components/header-login-return-intent.test.tsx tests/proxy/admin-route-guard.test.ts tests/security/admin-access.test.ts` — 30/30 passed.
- [x] `corepack pnpm typecheck` — passed.
- [x] `corepack pnpm exec eslint contexts/admin-permissions-context.tsx tests/contexts/admin-permissions-context.test.tsx --max-warnings=0` — passed.
- [x] `corepack pnpm test` — 44 files / 263 tests passed.
- [x] `git diff --check` — passed.

## Supabase / migrations
- No Supabase migration required.
- No schema, storage bucket, RLS/storage policy, seed, or data backfill changes.
- Runtime requirements documented in `docs/auth/issue-35-safe-role-redirects-runtime.md`: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`.

## Chained PR completion
This is the final stacked slice for issue #35. The chain is:
1. PR #55 — proxy `/admin*` gate.
2. PR #56 — callback/login safe return intent.
3. This PR — client fallback revalidation + runtime docs.

## Manual QA notes
Before merge, run the matrix in `docs/auth/issue-35-safe-role-redirects-runtime.md`: guest/non-admin/admin `/admin*`, expired session, lookup failure, callback/login safe `next`, unsafe `next`, and unaffected `/dashboard`, `/checkout`, and public routes.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no shell scripts changed)
- [x] Skills tested in at least one agent (SDD apply/verify Unit 3 final)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
