### PR TITLE
feat(products): add shared card foundation

### DIFF
--- a/components/products/visual-product-card.tsx
+++ b/components/products/visual-product-card.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable @next/next/no-img-element -- Storefront product media can be tenant-provided remote URLs; Next image migration is outside this UI-slice scope. */
+import Link from "next/link"
+import type { ReactNode } from "react"
+import type { CommerceProductBadge, CommerceProductCard } from "@/lib/types/products"
+
+interface VisualProductCardProps {
+  product: CommerceProductCard
+  variant?: "grid" | "compact" | "overlay"
+  showCta?: boolean
+  favoriteSlot?: ReactNode
+  actionSlot?: ReactNode
+  className?: string
+}
+
+const badgeToneClass: Record<NonNullable<CommerceProductBadge["tone"]>, string> = {
+  default: "bg-primary text-primary-foreground",
+  sale: "bg-destructive text-white",
+  combo: "bg-primary text-primary-foreground",
+}
+
+export function VisualProductCard({
+  product,
+  variant = "grid",
+  showCta = true,
+  favoriteSlot,
+  actionSlot,
+  className = "",
+}: VisualProductCardProps) {
+  const isOverlay = variant === "overlay"
+  const imageAlt = product.imageAlt || product.title
+  const imageContent = product.imageUrl ? (
+    <img
+      src={product.imageUrl}
+      alt={imageAlt}
+      className={`h-full w-full ${isOverlay ? "object-cover transition-transform duration-300 group-hover:scale-105" : "object-contain"}`}
+    />
+  ) : (
+    <div
+      role="img"
+      aria-label={`Sin imagen para ${product.title}`}
+      className="flex h-full w-full items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/40 px-4 text-center text-sm text-muted-foreground"
+    >
+      Sin imagen
+    </div>
+  )
+
+  return (
+    <article
+      className={`group relative overflow-hidden rounded-2xl border border-border/60 bg-card text-card-foreground shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl focus-within:ring-2 focus-within:ring-primary/50 ${className}`}
+    >
+      <div className="absolute left-3 top-3 z-10 flex flex-wrap gap-2">
+        {product.badges.map((badge) => (
+          <span
+            key={`${badge.tone || "default"}-${badge.label}`}
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-sm ${badgeToneClass[badge.tone || "default"]}`}
+          >
+            {badge.label}
+          </span>
+        ))}
+      </div>
+
+      {favoriteSlot ? (
+        <div className="absolute right-3 top-3 z-20">{favoriteSlot}</div>
+      ) : null}
+
+      <Link
+        href={product.href}
+        className="block focus-visible:outline-none"
+        aria-label={`Ver ${product.title}`}
+      >
+        <div
+          className={`${isOverlay ? "aspect-[4/3]" : "aspect-square"} flex items-center justify-center bg-background p-4`}
+        >
+          {imageContent}
+        </div>
+      </Link>
+
+      <div className="space-y-3 p-4 sm:p-5">
+        {product.category ? (
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {product.category}
+          </p>
+        ) : null}
+
+        <Link href={product.href} className="block focus-visible:outline-none">
+          <h3 className="line-clamp-2 text-base font-semibold leading-snug transition-colors hover:text-primary md:text-lg">
+            {product.title}
+          </h3>
+        </Link>
+
+        {product.description ? (
+          <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+            {product.description}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="text-xl font-bold text-primary">{product.price.label}</span>
+          {product.price.compareAtLabel ? (
+            <span className="text-sm font-medium text-muted-foreground line-through">
+              {product.price.compareAtLabel}
+            </span>
+          ) : null}
+        </div>
+
+        {actionSlot ? <div>{actionSlot}</div> : null}
+
+        {showCta && product.ctaLabel ? (
+          <Link
+            href={product.href}
+            className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {product.ctaLabel}
+          </Link>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/lib/products/adapter.ts
+++ b/lib/products/adapter.ts
@@ -4,6 +4,9 @@
  */
 
 import type {
+  CommerceProductBadge,
+  CommerceProductCard,
+  CommerceProductPrice,
   StoreItemWithDetails,
   ItemCategory,
   ItemOption,
@@ -15,6 +18,75 @@ function formatMoney(amount: number, currencyCode: string = 'COP'): Money {
   return {
     amount: amount.toString(),
     currencyCode,
+  };
+}
+
+export function formatCommercePrice(amount: number, currencyCode: string = 'COP'): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: currencyCode,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function normalizeCommercePrice(
+  amount: number,
+  currencyCode: string = 'COP',
+  compareAtAmount?: number | null,
+): CommerceProductPrice {
+  const hasDiscount = typeof compareAtAmount === 'number' && compareAtAmount > amount;
+
+  return {
+    amount,
+    currencyCode,
+    label: formatCommercePrice(amount, currencyCode),
+    compareAtAmount: hasDiscount ? compareAtAmount : undefined,
+    compareAtLabel: hasDiscount ? formatCommercePrice(compareAtAmount, currencyCode) : undefined,
+    hasDiscount,
+  };
+}
+
+function getCommerceImageUrl(item: StoreItemWithDetails): string {
+  if (item.primary_image_url && item.primary_image_url.trim() !== '') {
+    return item.primary_image_url;
+  }
+
+  const firstImage = item.images?.find((image) => image.image_url?.trim());
+  return firstImage?.image_url || '/placeholder.svg';
+}
+
+function getCommerceBadges(item: StoreItemWithDetails, price: CommerceProductPrice): CommerceProductBadge[] {
+  if (item.item_kind === 'combo') {
+    return [{ label: 'Combo', tone: 'combo' }];
+  }
+
+  if (price.hasDiscount) {
+    return [{ label: 'Oferta', tone: 'sale' }];
+  }
+
+  return [];
+}
+
+export function toCommerceProductCard(item: StoreItemWithDetails): CommerceProductCard {
+  const price = normalizeCommercePrice(
+    item.base_price,
+    item.currency_code || 'COP',
+    item.compare_at_price,
+  );
+
+  return {
+    id: item.id,
+    title: item.item_name,
+    description: item.item_description,
+    href: `/products/${item.item_slug || item.id}`,
+    imageUrl: getCommerceImageUrl(item),
+    imageAlt: item.primary_image_alt || item.item_name,
+    category: item.category?.category_name,
+    price,
+    badges: getCommerceBadges(item, price),
+    ctaLabel: 'Ver detalles',
+    availableForSale: item.is_available_for_sale && item.is_active,
   };
 }
 
@@ -257,4 +329,3 @@ export function adaptSupabaseProducts(items: StoreItemWithDetails[]): Product[] 
 export function adaptSupabaseCategories(categories: ItemCategory[]): Collection[] {
   return categories.map(adaptSupabaseCategory);
 }
-

--- a/lib/types/products.ts
+++ b/lib/types/products.ts
@@ -95,6 +95,34 @@ export interface StoreItemWithDetails extends StoreItem {
   combo?: ComboCatalogDetails
 }
 
+export interface CommerceProductPrice {
+  amount: number
+  currencyCode: string
+  label: string
+  compareAtAmount?: number
+  compareAtLabel?: string
+  hasDiscount: boolean
+}
+
+export interface CommerceProductBadge {
+  label: string
+  tone?: 'default' | 'sale' | 'combo'
+}
+
+export interface CommerceProductCard {
+  id: string
+  title: string
+  description?: string
+  href: string
+  imageUrl?: string
+  imageAlt: string
+  category?: string
+  price: CommerceProductPrice
+  badges: CommerceProductBadge[]
+  ctaLabel?: string
+  availableForSale?: boolean
+}
+
 export interface GetItemsParams {
   store_id?: string // ID de la tienda para filtrar productos
   item_kind?: 'all' | 'products' | 'combos'
@@ -115,7 +143,6 @@ export interface GetItemsResult {
   total: number
   has_more: boolean
 }
-
 
 
 

--- a/tests/components/visual-product-card.test.tsx
+++ b/tests/components/visual-product-card.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { VisualProductCard } from '@/components/products/visual-product-card'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+const product: CommerceProductCard = {
+  id: 'product-1',
+  title: 'Auriculares Premium',
+  description: 'Audio inalámbrico',
+  href: '/products/auriculares-premium',
+  imageUrl: '/products/headphones.png',
+  imageAlt: 'Auriculares negros',
+  category: 'Audio',
+  price: {
+    amount: 129000,
+    currencyCode: 'COP',
+    label: '$ 129.000',
+    compareAtAmount: 159000,
+    compareAtLabel: '$ 159.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('VisualProductCard', () => {
+  it('renders the shared product card content with accessible links and price semantics', () => {
+    render(<VisualProductCard product={product} />)
+
+    expect(screen.getByRole('link', { name: /ver auriculares premium/i })).toHaveAttribute('href', product.href)
+    expect(screen.getByRole('img', { name: 'Auriculares negros' })).toHaveAttribute('src', product.imageUrl)
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    expect(screen.getByText('Auriculares Premium')).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/159\.000/)).toHaveClass('line-through')
+    expect(screen.getByText('Oferta')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', product.href)
+  })
+
+  it('uses a no-image fallback and omits optional compare, category, badge, and CTA content cleanly', () => {
+    render(
+      <VisualProductCard
+        product={{
+          ...product,
+          category: undefined,
+          imageUrl: undefined,
+          imageAlt: 'Auriculares Premium',
+          price: {
+            amount: 129000,
+            currencyCode: 'COP',
+            label: '$ 129.000',
+            hasDiscount: false,
+          },
+          badges: [],
+          ctaLabel: undefined,
+        }}
+        showCta={false}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: /sin imagen para auriculares premium/i })).toBeInTheDocument()
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+    expect(screen.queryByText(/159\.000/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Oferta')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /ver detalles/i })).not.toBeInTheDocument()
+  })
+
+  it('places favorite and custom action slots without nesting them in the product link', () => {
+    render(
+      <VisualProductCard
+        product={product}
+        favoriteSlot={<button type="button" aria-label="Agregar a favoritos" />}
+        actionSlot={<button type="button">Agregar al carrito</button>}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /agregar a favoritos/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /agregar al carrito/i })).toBeInTheDocument()
+  })
+})

--- a/tests/products/product-card-adapter.test.ts
+++ b/tests/products/product-card-adapter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeCommercePrice,
+  toCommerceProductCard,
+} from '@/lib/products/adapter'
+import type { StoreItemWithDetails } from '@/lib/types/products'
+
+function makeItem(overrides: Partial<StoreItemWithDetails> = {}): StoreItemWithDetails {
+  return {
+    id: 'product-1',
+    item_name: 'Auriculares Premium',
+    item_description: 'Audio inalámbrico',
+    category_id: 'cat-1',
+    base_price: 129000,
+    compare_at_price: 159000,
+    currency_code: 'COP',
+    is_active: true,
+    is_featured: true,
+    is_available_for_sale: true,
+    track_inventory: false,
+    inventory_quantity: 10,
+    low_stock_threshold: 2,
+    item_slug: 'auriculares-premium',
+    primary_image_url: '/products/headphones.png',
+    primary_image_alt: 'Auriculares negros',
+    display_order: 1,
+    view_count: 0,
+    created_at: '2026-05-14T00:00:00Z',
+    updated_at: '2026-05-14T00:00:00Z',
+    category: {
+      id: 'cat-1',
+      category_name: 'Audio',
+      display_order: 1,
+      is_active: true,
+      created_at: '2026-05-14T00:00:00Z',
+      updated_at: '2026-05-14T00:00:00Z',
+    },
+    ...overrides,
+  }
+}
+
+describe('commerce product card adapters', () => {
+  it('normalizes Supabase product data into the shared card DTO', () => {
+    const card = toCommerceProductCard(makeItem())
+
+    expect(card).toMatchObject({
+      id: 'product-1',
+      title: 'Auriculares Premium',
+      description: 'Audio inalámbrico',
+      href: '/products/auriculares-premium',
+      imageUrl: '/products/headphones.png',
+      imageAlt: 'Auriculares negros',
+      category: 'Audio',
+      availableForSale: true,
+    })
+    expect(card.price.label).toBe('$ 129.000')
+    expect(card.price.compareAtLabel).toBe('$ 159.000')
+    expect(card.price.hasDiscount).toBe(true)
+    expect(card.badges).toEqual([{ label: 'Oferta', tone: 'sale' }])
+  })
+
+  it('omits misleading discount treatment when compare-at is not greater than base price', () => {
+    expect(normalizeCommercePrice(129000, 'COP', 129000)).toMatchObject({
+      label: '$ 129.000',
+      compareAtLabel: undefined,
+      hasDiscount: false,
+    })
+
+    const card = toCommerceProductCard(makeItem({ compare_at_price: 99000 }))
+    expect(card.price.compareAtLabel).toBeUndefined()
+    expect(card.badges).toEqual([])
+  })
+
+  it('falls back to id href, placeholder image, and combo badge when optional data is absent', () => {
+    const card = toCommerceProductCard(
+      makeItem({
+        item_slug: undefined,
+        primary_image_url: undefined,
+        primary_image_alt: undefined,
+        compare_at_price: undefined,
+        category: undefined,
+        item_kind: 'combo',
+        combo: {} as StoreItemWithDetails['combo'],
+      }),
+    )
+
+    expect(card.href).toBe('/products/product-1')
+    expect(card.imageUrl).toBe('/placeholder.svg')
+    expect(card.imageAlt).toBe('Auriculares Premium')
+    expect(card.category).toBeUndefined()
+    expect(card.badges).toEqual([{ label: 'Combo', tone: 'combo' }])
+  })
+})


### PR DESCRIPTION
Refs #36

## Summary
- Adds a shared `CommerceProductCard` DTO and guarded price normalization for product-card surfaces.
- Adds a hook-free `VisualProductCard` shell with image/no-image fallback, badges, base/compare price rendering, CTA, and action slots.
- Adds focused adapter and component tests as the first PR in the issue #36 feature-branch chain.

## Changes
| File | Change |
|------|--------|
| `lib/types/products.ts` | Adds shared commerce card, badge, and price DTOs. |
| `lib/products/adapter.ts` | Adds COP price formatting, compare-at guard, Supabase-to-card adapter, and combo/sale badge derivation. |
| `components/products/visual-product-card.tsx` | Creates shared visual card shell for upcoming home/catalog migrations. |
| `tests/products/product-card-adapter.test.ts` | Covers DTO normalization, compare-at semantics, fallbacks, and combo badge. |
| `tests/components/visual-product-card.test.tsx` | Covers accessible links, no-image fallback, price/badge rendering, CTA and action slots. |

## Chain / scope
- PR 1 of 3 for issue #36.
- This PR is foundation-only and intentionally does **not** migrate `ProductsGrid`, `PopularItems`, catalog, or shop cards yet to keep the diff at the 400-line review budget.
- Next PR will target `feat/issue-36-card-foundation` and migrate the home grid / legacy products section.

## Supabase / migrations
- No Supabase schema, storage, RLS, or migration changes.
- Uses existing product fields: `base_price`, `compare_at_price`, `currency_code`, category, slug, image, active/available flags, and combo kind metadata.

## Verification
- [x] RED first: focused tests initially failed for missing adapter exports and missing `VisualProductCard` module.
- [x] `corepack pnpm install --frozen-lockfile`
- [x] `corepack pnpm exec eslint lib/types/products.ts lib/products/adapter.ts components/products/visual-product-card.tsx tests/products/product-card-adapter.test.ts tests/components/visual-product-card.test.tsx --max-warnings=0`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts tests/components/visual-product-card.test.tsx tests/products/product-card-adapter.test.ts`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts --dir tests` — 41 files / 239 tests passed.

## Manual QA
- [ ] Pending in later visual slices: desktop/mobile home comparison, missing image product, compare-at product, theme/admin-edit contrast, and reference comparison evidence.
