### PR TITLE
feat(products): migrate home grid cards

### DIFF
--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import Link from "next/link"
+import { VisualProductCard } from "@/components/products/visual-product-card"
+import { normalizeCommercePrice } from "@/lib/products/adapter"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 interface Product {
   id: string
@@ -26,39 +25,25 @@ function generateSlug(name: string): string {
 
 export function ProductCard({ product }: { product: Product }) {
   const productSlug = product.slug || generateSlug(product.name)
+  const price = normalizeCommercePrice(product.price, "COP", product.originalPrice)
+  const card: CommerceProductCard = {
+    id: product.id,
+    title: product.name,
+    description: product.description,
+    href: `/products/${productSlug}`,
+    imageUrl: product.image || "/placeholder.svg",
+    imageAlt: product.name,
+    price,
+    badges: [
+      ...(product.badge ? [{ label: product.badge, tone: "default" as const }] : []),
+      ...(price.hasDiscount ? [{ label: "VENTA", tone: "sale" as const }] : []),
+    ],
+    ctaLabel: "Ver detalles",
+  }
   
   return (
-    <div className="bg-card rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-      <Link href={`/products/${productSlug}`} className="block">
-        <div className="relative aspect-square cursor-pointer">
-          <img src={product.image || "/placeholder.svg"} alt={product.name} className="w-full h-full object-cover" />
-          {product.badge && (
-            <Badge className="absolute top-2 right-2 bg-primary text-primary-foreground">{product.badge}</Badge>
-          )}
-          {product.originalPrice && <Badge className="absolute top-2 left-2 bg-destructive text-white">VENTA</Badge>}
-        </div>
-      </Link>
-      <div className="p-4">
-        <Link href={`/products/${productSlug}`}>
-          <h3 className="text-lg font-bold text-foreground mb-2 hover:text-primary transition-colors cursor-pointer">{product.name}</h3>
-        </Link>
-        <p className="text-sm text-muted-foreground mb-4">{product.description}</p>
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <span className="text-xl font-bold text-primary">${product.price.toLocaleString("es-CO")}</span>
-            {product.originalPrice && (
-              <span className="text-sm text-muted-foreground line-through ml-2">
-                ${product.originalPrice.toLocaleString("es-CO")}
-              </span>
-            )}
-          </div>
-        </div>
-        <Button className="w-full bg-primary hover:bg-primary/90 text-primary-foreground" asChild>
-          <Link href={`/products/${productSlug}`}>
-            Ver detalles
-          </Link>
-        </Button>
-      </div>
-    </div>
+    <VisualProductCard
+      product={card}
+    />
   )
 }

--- a/components/sections/products-grid-wrapper.tsx
+++ b/components/sections/products-grid-wrapper.tsx
@@ -1,9 +1,11 @@
 import { ProductsGrid } from "./products-grid"
+import { toCommerceProductCard } from "@/lib/products/adapter"
 import { getItems } from "@/lib/supabase/products-api"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 export async function ProductsGridWrapper() {
   // Obtener productos de la base de datos
-  let products: Array<{ id: string; name: string; category: string; price: string; image: string; slug: string }> = []
+  let products: CommerceProductCard[] = []
   
   try {
     const result = await getItems({
@@ -14,29 +16,10 @@ export async function ProductsGridWrapper() {
       order_direction: 'asc',
     })
     
-    products = result.items.map(item => ({
-      id: item.id,
-      name: item.item_name,
-      category: item.category?.category_name || "Sin categoría",
-      price: formatPrice(item.base_price, item.currency_code),
-      image: item.primary_image_url || "/placeholder.svg",
-      slug: item.item_slug || item.id,
-    }))
+    products = result.items.map(toCommerceProductCard)
   } catch (error) {
     console.error('Error fetching products:', error)
   }
 
   return <ProductsGrid initialProducts={products} />
 }
-
-// Helper para formatear precio
-function formatPrice(price: number | string, currencyCode: string = "COP"): string {
-  const numPrice = typeof price === 'string' ? parseFloat(price) : price
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(numPrice)
-}
-

--- a/components/sections/products-grid.tsx
+++ b/components/sections/products-grid.tsx
@@ -1,11 +1,11 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import Link from "next/link"
 import { useComponentStyle } from "@/contexts/styles-context"
 import { useAdmin } from "@/contexts/admin-context"
 import { useStore } from "@/contexts/store-context"
-import { useState } from "react"
+import { VisualProductCard } from "@/components/products/visual-product-card"
+import { normalizeCommercePrice } from "@/lib/products/adapter"
+import type { CommerceProductBadge, CommerceProductCard, CommerceProductPrice } from "@/lib/types/products"
 
 // Helper para generar slug desde el nombre
 function generateSlug(name: string): string {
@@ -17,52 +17,58 @@ function generateSlug(name: string): string {
     .replace(/(^-|-$)/g, "")
 }
 
-// Componente Image con fallback automático a placeholder
-function ProductImageWithFallback({ src, alt }: { src: string; alt: string }) {
-  const [imgSrc, setImgSrc] = useState(src)
-  const [hasError, setHasError] = useState(false)
-
-  const handleError = () => {
-    if (!hasError && imgSrc !== "/placeholder.svg") {
-      setHasError(true)
-      setImgSrc("/placeholder.svg")
-    }
-  }
-
-  // Si ya hubo error, mostrar placeholder directamente
-  if (hasError || imgSrc === "/placeholder.svg") {
-    return (
-      <img
-        src="/placeholder.svg"
-        alt={alt}
-        className="w-full h-full object-contain"
-        onError={(e) => {
-          // Prevenir loops infinitos
-          e.currentTarget.src = "/placeholder.svg"
-        }}
-      />
-    )
-  }
-
-  return (
-    <img
-      src={imgSrc}
-      alt={alt}
-      className="w-full h-full object-contain"
-      onError={handleError}
-    />
-  )
+type EditableProduct = Partial<CommerceProductCard> & {
+  name?: string
+  title?: string
+  slug?: string
+  image?: string
+  imageUrl?: string
+  price?: string | number | CommerceProductPrice
+  originalPrice?: number
+  compareAtPrice?: number
+  badge?: string
+  badges?: CommerceProductBadge[]
 }
 
 interface ProductsGridProps {
-  initialProducts?: Array<{
-    id: string
-    name: string
-    category: string
-    price: string
-    image: string
-    slug?: string
-  }>
+  initialProducts?: CommerceProductCard[]
+}
+
+function isCommercePrice(price: EditableProduct["price"]): price is CommerceProductPrice {
+  return Boolean(price && typeof price === "object" && "label" in price)
+}
+
+function toCard(product: EditableProduct, index: number): CommerceProductCard {
+  const title = product.title || product.name || `Producto ${index + 1}`
+  const slug = product.slug || generateSlug(title)
+  const price = isCommercePrice(product.price)
+    ? product.price
+    : typeof product.price === "number"
+      ? normalizeCommercePrice(product.price, "COP", product.originalPrice ?? product.compareAtPrice)
+      : {
+          amount: 0,
+          currencyCode: "COP",
+          label: product.price || "",
+          hasDiscount: false,
+        }
+  const saleBadge = price.hasDiscount ? [{ label: "Oferta", tone: "sale" as const }] : []
+
+  return {
+    id: product.id || `product-${index}`,
+    title,
+    description: product.description,
+    href: product.href || `/products/${slug}`,
+    imageUrl: product.imageUrl || product.image || undefined,
+    imageAlt: product.imageAlt || title,
+    category: product.category,
+    price,
+    badges: product.badges || [
+      ...(product.badge ? [{ label: product.badge, tone: "default" as const }] : []),
+      ...saleBadge,
+    ],
+    ctaLabel: product.ctaLabel || "Ver detalles",
+    availableForSale: product.availableForSale,
+  }
 }
 
 export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
@@ -71,7 +77,7 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
     title: "Productos populares",
   })
   const { componentEdits } = useAdmin()
-  
+
   // Combinar estilos de BD con ediciones locales para mostrar cambios en tiempo real
   const edits = componentEdits.get("products") || {}
   const title = edits.title ?? styleData.title ?? "Productos populares"
@@ -85,18 +91,21 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
   // Si es repostería, usar imágenes de repostería, si no, usar imágenes de tecnología
   const defaultProducts = isReposteria ? [
     {
+      id: "cupcakes-decorados",
       name: "Cupcakes Decorados",
       category: "Cupcakes",
       price: "$25.00",
       image: "/reposteria/cupcakes-decorados.jpg",
     },
     {
+      id: "tarta-berries",
       name: "Tarta de Berries",
       category: "Tartas",
       price: "$45.00",
       image: "/reposteria/tarta-berries.jpg",
     },
     {
+      id: "macarons-artesanales",
       name: "Macarons Artesanales",
       category: "Macarons",
       price: "$18.00",
@@ -104,25 +113,28 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
     },
   ] : [
     {
+      id: "beshow-volcano",
       name: "BeShow Volcano",
       category: "Proyectores",
       price: "$1,420.00",
       image: "/white-projector.jpg",
     },
     {
+      id: "soporte-laptop-desk-muo-g",
       name: "Soporte para Laptop Desk MUO-g",
       category: "Soportes",
       price: "$82.00",
       image: "/laptop-stand.png",
     },
     {
+      id: "beshow-volcano-alt",
       name: "BeShow Volcano",
       category: "Proyectores",
       price: "$1,420.00",
       image: "/white-projector.jpg",
     },
   ]
-  
+
   // Imágenes de repostería para reemplazar cuando hay productos de BD
   const reposteriaImages = [
     "/reposteria/cupcakes-decorados.jpg",
@@ -138,15 +150,16 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
   const products = initialProducts && initialProducts.length > 0
     ? initialProducts.map((p, index) => ({
         ...p,
-        image: isReposteria 
-          ? (reposteriaImages[index % reposteriaImages.length] || p.image)
-          : p.image,
+        imageUrl: isReposteria
+          ? (reposteriaImages[index % reposteriaImages.length] || p.imageUrl)
+          : p.imageUrl,
       }))
     : (edits.products ?? styleData.products ?? defaultProducts)
+  const productCards = products.map((product: EditableProduct, index: number) => toCard(product, index))
 
   return (
-    <section 
-      data-component="products" 
+    <section
+      data-component="products"
       className="py-6 sm:py-8 md:py-12 px-4 sm:px-6"
       style={{
         ...(bgColor && { backgroundColor: bgColor }),
@@ -154,46 +167,17 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
       }}
     >
       <div className="container mx-auto">
-        <h2 
-          className="text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-[51px] font-inter font-normal mb-4 sm:mb-6 md:mb-8" 
+        <h2
+          className="text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-[51px] font-inter font-normal mb-4 sm:mb-6 md:mb-8"
           style={{ color: textColor || "var(--foreground)" }}
         >
           {title}
         </h2>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-5 md:gap-6">
-          {products.map((product: any, index: number) => {
-            const productSlug = product.slug || generateSlug(product.name)
-            const productId = initialProducts?.[index]?.id || `product-${index}`
-            return (
-              <Link 
-                key={productId} 
-                href={`/products/${productSlug}`}
-                className="rounded-2xl overflow-hidden hover:shadow-lg transition-shadow cursor-pointer block"
-                style={{ backgroundColor: "var(--card)" }}
-              >
-                <div className="p-3 sm:p-4">
-                  <h3 className="font-inter font-normal text-sm sm:text-base md:text-[17.4854px] mb-1 hover:text-primary transition-colors" style={{ color: "var(--card-foreground)" }}>
-                    {product.name}
-                  </h3>
-                  <p className="text-xs sm:text-sm md:text-[13.9775px] font-inter font-normal mb-2" style={{ color: "var(--muted-foreground)" }}>{product.category}</p>
-                  <p className="text-base sm:text-lg md:text-[20.5864px] font-inter font-normal" style={{ color: "var(--card-foreground)" }}>
-                    {product.price}
-                  </p>
-                </div>
-
-                <div 
-                  className="aspect-square flex items-center justify-center p-3 sm:p-4"
-                  style={{ backgroundColor: "var(--background)" }}
-                >
-                  <ProductImageWithFallback
-                    src={product.image || "/placeholder.svg"}
-                    alt={product.name}
-                  />
-                </div>
-              </Link>
-            )
-          })}
+          {productCards.map((product) => (
+            <VisualProductCard key={product.id} product={product} />
+          ))}
         </div>
       </div>
     </section>

--- a/tests/components/products-grid.test.tsx
+++ b/tests/components/products-grid.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProductsGrid } from '@/components/sections/products-grid'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+const mockUseStore = vi.fn()
+const mockUseComponentStyle = vi.fn()
+const mockUseAdmin = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/contexts/store-context', () => ({
+  useStore: () => mockUseStore(),
+}))
+
+vi.mock('@/contexts/styles-context', () => ({
+  useComponentStyle: (...args: unknown[]) => mockUseComponentStyle(...args),
+}))
+
+vi.mock('@/contexts/admin-context', () => ({
+  useAdmin: () => mockUseAdmin(),
+}))
+
+const dtoProduct: CommerceProductCard = {
+  id: 'product-1',
+  title: 'Auriculares Premium',
+  href: '/products/auriculares-premium',
+  imageAlt: 'Auriculares Premium',
+  category: 'Audio',
+  price: {
+    amount: 129000,
+    currencyCode: 'COP',
+    label: '$ 129.000',
+    compareAtAmount: 159000,
+    compareAtLabel: '$ 159.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('ProductsGrid', () => {
+  beforeEach(() => {
+    mockUseStore.mockReturnValue({ store: { subdomain: 'default' } })
+    mockUseComponentStyle.mockReturnValue({ styles: { title: 'Productos destacados' } })
+    mockUseAdmin.mockReturnValue({ componentEdits: new Map() })
+  })
+
+  it('renders shared DTO products with compare price, badges, CTA, and no-image fallback', () => {
+    render(<ProductsGrid initialProducts={[dtoProduct]} />)
+
+    expect(screen.getByRole('heading', { name: 'Productos destacados' })).toBeInTheDocument()
+    expect(screen.getByText('Auriculares Premium')).toBeInTheDocument()
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/159\.000/)).toHaveClass('line-through')
+    expect(screen.getByText('Oferta')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /sin imagen para auriculares premium/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', '/products/auriculares-premium')
+  })
+
+  it('preserves admin-edited legacy product records and generated slugs', () => {
+    mockUseAdmin.mockReturnValue({
+      componentEdits: new Map([
+        ['products', {
+          title: 'Ofertas editadas',
+          products: [{ id: 'edited-1', name: 'Cámara 4K', category: 'Video', price: '$99', image: '' }],
+        }],
+      ]),
+    })
+
+    render(<ProductsGrid />)
+
+    expect(screen.getByRole('heading', { name: 'Ofertas editadas' })).toBeInTheDocument()
+    expect(screen.getByText('Cámara 4K')).toBeInTheDocument()
+    expect(screen.getByText('$99')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver cámara 4k/i })).toHaveAttribute('href', '/products/camara-4k')
+  })
+})


### PR DESCRIPTION
Refs #36

## Summary
- Migrates the home products grid wrapper to pass the shared `CommerceProductCard` DTO from Supabase products.
- Refactors `ProductsGrid` to render the shared `VisualProductCard` while preserving the `products` component-style/admin-edit key and legacy editable records.
- Updates the legacy `components/product-card.tsx` entry point to reuse the shared card shell for `ProductsSection`.

## Changes
| File | Change |
|------|--------|
| `components/sections/products-grid-wrapper.tsx` | Uses `toCommerceProductCard` instead of string-only price/image mapping. |
| `components/sections/products-grid.tsx` | Normalizes Supabase DTOs and legacy admin/style records into shared cards; preserves reposteria image fallback behavior. |
| `components/product-card.tsx` | Adapts legacy product props into `CommerceProductCard` and renders `VisualProductCard`. |
| `tests/components/products-grid.test.tsx` | Covers DTO rendering with compare price/no-image fallback and legacy admin-edited product compatibility. |

## Chain / scope
- PR 2 of 3 for issue #36.
- Base branch: `feat/issue-36-card-foundation` / PR #58.
- This PR intentionally leaves `PopularItems`, catalog list, and final visual QA for PR 3.

## Supabase / migrations
- No Supabase schema, storage, RLS, or migration changes.
- Reads the same product fields already fetched by `getItems`; mapping now keeps compare-at metadata instead of flattening it into a string.

## Verification
- [x] RED first: `tests/components/products-grid.test.tsx` failed against the old grid because DTO products lacked `name` and CTA/no-image semantics.
- [x] `corepack pnpm exec eslint components/product-card.tsx components/sections/products-grid.tsx components/sections/products-grid-wrapper.tsx tests/components/products-grid.test.tsx --max-warnings=0`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts tests/components/products-grid.test.tsx tests/components/visual-product-card.test.tsx tests/products/product-card-adapter.test.ts`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts --dir tests` — 42 files / 241 tests passed.

## Manual QA
- [ ] Pending in PR 3/final: desktop/mobile home comparison, missing image product, compare-at product, theme/admin-edit contrast, and reference comparison evidence.
