### PR TITLE
feat(products): align popular and catalog cards

### DIFF
--- a/app/catalog/[category]/page.tsx
+++ b/app/catalog/[category]/page.tsx
@@ -97,6 +97,9 @@ async function CategoryContent({ categorySlug }: { categorySlug: string }) {
       name: item.item_name,
       category: category.category_name,
       price: formatPrice(item.base_price, item.currency_code),
+      compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+        ? formatPrice(item.compare_at_price, item.currency_code)
+        : undefined,
       image: item.primary_image_url || "/placeholder.svg",
       slug: item.item_slug || item.id,
     }))

--- a/app/catalog/earphones/page.tsx
+++ b/app/catalog/earphones/page.tsx
@@ -37,6 +37,9 @@ async function EarphonesContent() {
         name: item.item_name,
         category: item.category?.category_name || "Earphones",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -47,6 +47,9 @@ async function CategorySection({ categoryId, categoryName, storeId }: { category
       name: item.item_name,
       category: categoryName,
       price: formatPrice(item.base_price, item.currency_code),
+      compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+        ? formatPrice(item.compare_at_price, item.currency_code)
+        : undefined,
       image: item.primary_image_url || "/placeholder.svg",
       slug: item.item_slug || item.id,
     }))

--- a/app/catalog/projectors/page.tsx
+++ b/app/catalog/projectors/page.tsx
@@ -35,6 +35,9 @@ async function ProjectorsContent() {
         name: item.item_name,
         category: item.category?.category_name || "Projectors",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/speakers/page.tsx
+++ b/app/catalog/speakers/page.tsx
@@ -36,6 +36,9 @@ async function SpeakersContent() {
         name: item.item_name,
         category: item.category?.category_name || "Speakers",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/stands/page.tsx
+++ b/app/catalog/stands/page.tsx
@@ -35,6 +35,9 @@ async function StandsContent() {
         name: item.item_name,
         category: item.category?.category_name || "Stands",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/components/catalog/catalog-products-list.tsx
+++ b/components/catalog/catalog-products-list.tsx
@@ -1,21 +1,52 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { VisualProductCard } from "@/components/products/visual-product-card"
 import { useQuantityModal } from "@/hooks/use-quantity-modal"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 interface Product {
   id: string
   name: string
   category: string
   price: string
+  compareAtPrice?: string
   image: string
   slug?: string
 }
 
 interface CatalogProductsListProps {
   products: Product[]
+}
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+}
+
+function toCard(product: Product): CommerceProductCard {
+  const slug = product.slug || generateSlug(product.name)
+  return {
+    id: product.id,
+    title: product.name,
+    href: `/products/${slug}`,
+    imageUrl: product.image || undefined,
+    imageAlt: product.name,
+    category: product.category,
+    price: {
+      amount: 0,
+      currencyCode: "COP",
+      label: product.price,
+      compareAtLabel: product.compareAtPrice,
+      hasDiscount: Boolean(product.compareAtPrice),
+    },
+    badges: product.compareAtPrice ? [{ label: "Oferta", tone: "sale" }] : [],
+    ctaLabel: "Ver detalles",
+  }
 }
 
 export function CatalogProductsList({ products }: CatalogProductsListProps) {
@@ -32,86 +63,30 @@ export function CatalogProductsList({ products }: CatalogProductsListProps) {
   return (
     <>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8">
-        {products.map((product) => {
-          const productSlug = product.slug || product.name
-            .toLowerCase()
-            .normalize("NFD")
-            .replace(/[\u0300-\u036f]/g, "")
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/(^-|-$)/g, "")
-          
-          return (
-            <div
-              key={product.id}
-              className="group relative rounded-2xl overflow-hidden hover:shadow-xl transition-all duration-300"
-              style={{ backgroundColor: "var(--card)" }}
-            >
-              {/* Product Image */}
-              <Link href={`/products/${productSlug}`}>
-                <div
-                  className="aspect-square flex items-center justify-center p-6 relative overflow-hidden cursor-pointer"
-                  style={{ backgroundColor: "var(--background)" }}
-                >
-                  <img
-                    src={product.image || "/placeholder.svg"}
-                    alt={product.name}
-                    className="w-full h-full object-contain transition-transform duration-300 group-hover:scale-110"
-                  />
-                </div>
-              </Link>
-
-              {/* Product Info */}
-              <div className="p-4 md:p-6">
-                <p className="text-sm md:text-base font-inter font-medium mb-1" style={{ color: "var(--muted-foreground)" }}>
-                  {product.category}
-                </p>
-                <Link href={`/products/${productSlug}`}>
-                  <h3 className="text-lg md:text-xl font-inter font-semibold mb-3 hover:text-primary transition-colors cursor-pointer" style={{ color: "var(--card-foreground)" }}>
-                    {product.name}
-                  </h3>
-                </Link>
-                
-                {/* Pricing */}
-                <div className="flex items-center gap-3 mb-4">
-                  <span className="text-xl md:text-2xl font-inter font-bold" style={{ color: "var(--primary)" }}>
-                    {product.price}
-                  </span>
-                </div>
-
-                {/* Add to Cart Button */}
-                <Button
-                  className="w-full"
-                  style={{
-                    backgroundColor: "var(--primary)",
-                    color: "var(--primary-foreground)",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.opacity = "0.9"
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.opacity = "1"
-                  }}
-                  onClick={() => {
-                    openModal({
-                      id: product.id,
-                      name: product.name,
-                      price: product.price,
-                      image: product.image,
-                      category: product.category,
-                    })
-                  }}
-                >
-                  Agregar al carrito
-                </Button>
-              </div>
-            </div>
-          )
-        })}
+        {products.map((product) => (
+          <VisualProductCard
+            key={product.id}
+            product={toCard(product)}
+            actionSlot={(
+              <Button
+                className="w-full"
+                style={{ backgroundColor: "var(--primary)", color: "var(--primary-foreground)" }}
+                onClick={() => openModal({
+                  id: product.id,
+                  name: product.name,
+                  price: product.price,
+                  image: product.image,
+                  category: product.category,
+                })}
+              >
+                Agregar al carrito
+              </Button>
+            )}
+          />
+        ))}
       </div>
 
-      {/* Modal de cantidad */}
       {QuantityModalComponent}
     </>
   )
 }
-

--- a/components/sections/popular-items-wrapper.tsx
+++ b/components/sections/popular-items-wrapper.tsx
@@ -1,19 +1,18 @@
 import { PopularItems } from "./popular-items"
+import { toCommerceProductCard } from "@/lib/products/adapter"
 import { getFeaturedItems } from "@/lib/supabase/products-api"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 // Deshabilitar caché para asegurar que siempre se obtengan los productos más recientes
 export const revalidate = 0
 export const dynamic = 'force-dynamic'
 
 export async function PopularItemsWrapper() {
-  // Obtener productos destacados de la base de datos
-  let featuredProducts: Array<{ id: string; title: string; price: string; image: string; slug: string }> = []
-  
+  let featuredProducts: CommerceProductCard[] = []
+
   try {
-    // Primero intentar obtener productos destacados
     let items = await getFeaturedItems(10)
-    
-    // Si no hay productos destacados, obtener productos activos y disponibles
+
     if (items.length === 0) {
       const { getItems } = await import('@/lib/supabase/products-api')
       const result = await getItems({
@@ -25,43 +24,13 @@ export async function PopularItemsWrapper() {
       })
       items = result.items
     }
-    
-    // Mapear productos asegurando que todos tengan slug válido
+
     featuredProducts = items
-      .filter(item => item.item_slug || item.id) // Solo productos con slug o ID válido
-      .map(item => ({
-        id: item.id,
-        title: item.item_name,
-        price: item.compare_at_price && parseFloat(String(item.compare_at_price)) > parseFloat(String(item.base_price))
-          ? `Desde ${formatPrice(item.base_price, item.currency_code)}`
-          : `${formatPrice(item.base_price, item.currency_code)}`,
-        // Asegurar que siempre se use la URL completa de la imagen
-        image: item.primary_image_url && item.primary_image_url.trim() !== "" 
-          ? item.primary_image_url 
-          : "/placeholder.svg",
-        // Asegurar que siempre haya un slug válido (priorizar item_slug, luego ID)
-        slug: item.item_slug || item.id,
-      }))
-    
-    console.log('[PopularItemsWrapper] Productos obtenidos de BD:', featuredProducts.length, 'productos')
-    if (featuredProducts.length > 0) {
-      console.log('[PopularItemsWrapper] Primer producto:', featuredProducts[0]?.title, 'Slug:', featuredProducts[0]?.slug)
-    }
+      .filter(item => item.item_slug || item.id)
+      .map(toCommerceProductCard)
   } catch (error) {
     console.error('Error fetching products:', error)
   }
 
   return <PopularItems initialProducts={featuredProducts} />
 }
-
-// Helper para formatear precio
-function formatPrice(price: number | string, currencyCode: string = "COP"): string {
-  const numPrice = typeof price === 'string' ? parseFloat(price) : price
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(numPrice)
-}
-

--- a/components/sections/popular-items.tsx
+++ b/components/sections/popular-items.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner"
 import { QuantityModal } from "@/components/cart/quantity-modal"
 import { useLanguage } from "@/contexts/language-context"
 import { deferStateUpdate } from "@/lib/react/defer-state-update"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 // Helper para generar slug desde el título
 function generateSlug(title: string): string {
@@ -80,13 +81,16 @@ function ItemImageWithFallback({ src, alt }: { src: string; alt: string }) {
 }
 
 interface PopularItemsProps {
-  initialProducts?: Array<{
-    id: string
-    title: string
-    price: string
-    image: string
-    slug?: string
-  }>
+  initialProducts?: CommerceProductCard[]
+}
+
+type PopularCardItem = {
+  id?: string
+  title: string
+  price: string
+  compareAtPrice?: string
+  image?: string
+  slug?: string
 }
 
 export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
@@ -106,15 +110,6 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
   const title = edits.title ?? styleData.title ?? "Lo más vendido"
   const bgColor = edits.bgColor ?? styleData.bgColor
   const textColor = edits.textColor ?? styleData.textColor
-  
-  // Debug: Log para ver qué datos se están cargando
-  useEffect(() => {
-    console.log('[PopularItems] styleData:', styleData)
-    console.log('[PopularItems] edits:', edits)
-    console.log('[PopularItems] styleData.items:', styleData.items)
-    console.log('[PopularItems] edits.items:', edits.items)
-    console.log('[PopularItems] initialProducts:', initialProducts)
-  }, [styleData, edits, initialProducts])
   
   // Detectar si es tienda de repostería
   const isReposteria = store?.subdomain === 'reposteria'
@@ -218,18 +213,16 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
   const items = useMemo(() => {
     // PRIMERO: Usar productos de BD si existen (tienen prioridad para asegurar páginas reales)
     if (initialProducts && initialProducts.length > 0) {
-      console.log('[PopularItems] Usando productos de BD:', initialProducts.length, 'productos')
       return initialProducts.map((p, index) => ({
         title: p.title,
-        price: p.price,
-        // Usar la imagen del producto de BD si existe, solo usar imagen de repostería como fallback
-        image: p.image && p.image !== "/placeholder.svg" 
-          ? p.image 
-          : (isReposteria 
+        price: p.price.label,
+        compareAtPrice: p.price.compareAtLabel,
+        image: p.imageUrl && p.imageUrl !== "/placeholder.svg"
+          ? p.imageUrl
+          : (isReposteria
               ? (reposteriaImages[index % reposteriaImages.length] || "/placeholder.svg")
               : "/placeholder.svg"),
-        // Asegurar que siempre se use el slug de la BD (p.slug viene de item_slug o id)
-        slug: p.slug || p.id || generateSlug(p.title),
+        slug: p.href.replace(/^\/products\//, "") || p.id,
         id: p.id,
       }))
     }
@@ -239,16 +232,14 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
     const savedItems = edits.items ?? styleData.items
     if (savedItems && Array.isArray(savedItems) && savedItems.length > 0) {
       // Filtrar items guardados que tengan slug o ID válido
-      const validSavedItems = savedItems.filter((item: any) => item.slug || item.id)
+      const validSavedItems = savedItems.filter((item: PopularCardItem) => item.slug || item.id)
       if (validSavedItems.length > 0) {
-        console.log('[PopularItems] Usando items guardados válidos:', validSavedItems.length, 'items')
         return validSavedItems
       }
     }
     
     // TERCERO: Si no hay productos de BD ni items guardados válidos, usar defaults
     // (solo como último recurso, pero estos también tienen slugs ahora)
-    console.log('[PopularItems] Usando items por defecto (último recurso)')
     return defaultItems
   }, [defaultItems, edits.items, initialProducts, isReposteria, reposteriaImages, styleData.items])
   
@@ -327,7 +318,7 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
             className="w-full"
           >
             <CarouselContent className="-ml-2 md:-ml-4">
-              {items.map((item: any, index: number) => {
+              {items.map((item: PopularCardItem, index: number) => {
                 // Priorizar: slug de BD > id > slug generado desde título
                 const itemSlug = item.slug || item.id || generateSlug(item.title)
                 const itemId = item.id || initialProducts?.[index]?.id || `popular-${index}`
@@ -368,7 +359,7 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
                               id: itemId,
                               name: item.title,
                               price: item.price,
-                              image: item.image,
+                              image: item.image || "/placeholder.svg",
                             })
                             setQuantityModalOpen(true)
                           }}
@@ -396,6 +387,9 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
                         <Link href={`/products/${itemSlug}`} className="pointer-events-auto block">
                           <h3 className="text-white text-xl md:text-[31.1153px] font-inter font-medium mb-2 hover:underline">{item.title}</h3>
                           <p className="text-white/90 text-sm md:text-[15.447px] font-inter font-medium">{item.price}</p>
+                          {item.compareAtPrice && (
+                            <p className="text-white/70 text-xs md:text-sm font-inter font-medium line-through">{item.compareAtPrice}</p>
+                          )}
                         </Link>
                       </div>
                     </div>

--- a/tests/components/catalog-products-list.test.tsx
+++ b/tests/components/catalog-products-list.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CatalogProductsList } from '@/components/catalog/catalog-products-list'
+
+const mockOpenModal = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/hooks/use-quantity-modal', () => ({
+  useQuantityModal: () => ({ openModal: mockOpenModal, QuantityModalComponent: <div data-testid="quantity-modal" /> }),
+}))
+
+describe('CatalogProductsList', () => {
+  it('renders the shared card price pattern and keeps quantity modal payloads', () => {
+    render(
+      <CatalogProductsList
+        products={[{
+          id: 'catalog-1',
+          name: 'Cámara 4K',
+          category: 'Video',
+          price: '$99',
+          compareAtPrice: '$129',
+          image: '',
+          slug: 'camara-4k',
+        }]}
+      />,
+    )
+
+    expect(screen.getByText('Cámara 4K')).toBeInTheDocument()
+    expect(screen.getByText('$99')).toBeInTheDocument()
+    expect(screen.getByText('$129')).toHaveClass('line-through')
+    expect(screen.getByRole('img', { name: /sin imagen para cámara 4k/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /agregar al carrito/i }))
+    expect(mockOpenModal).toHaveBeenCalledWith(expect.objectContaining({ id: 'catalog-1', name: 'Cámara 4K', price: '$99' }))
+  })
+})

--- a/tests/components/popular-items.test.tsx
+++ b/tests/components/popular-items.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PopularItems } from '@/components/sections/popular-items'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+const mockUseStore = vi.fn()
+const mockUseComponentStyle = vi.fn()
+const mockUseAdmin = vi.fn()
+const mockAddToCart = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/contexts/store-context', () => ({ useStore: () => mockUseStore() }))
+vi.mock('@/contexts/styles-context', () => ({ useComponentStyle: (...args: unknown[]) => mockUseComponentStyle(...args) }))
+vi.mock('@/contexts/admin-context', () => ({ useAdmin: () => mockUseAdmin() }))
+vi.mock('@/contexts/cart-context', () => ({ useCart: () => ({ addToCart: mockAddToCart }) }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn() } }))
+vi.mock('@/contexts/language-context', () => ({
+  useLanguage: () => ({
+    language: 'es',
+    t: {
+      products: { addToCart: 'Agregar al carrito', addToCartDescription: '{quantity} {unit} de {name} {verb} agregado{plural}' },
+      wishlist: { viewDetails: 'Ver detalles', addedToCart: 'Agregado' },
+    },
+  }),
+}))
+vi.mock('@/components/ui/carousel', () => ({
+  Carousel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselNext: () => <button type="button">Siguiente</button>,
+  CarouselPrevious: () => <button type="button">Anterior</button>,
+}))
+vi.mock('@/components/cart/quantity-modal', () => ({
+  QuantityModal: ({ open, productName }: { open: boolean; productName: string }) => open ? <div role="dialog">Cantidad {productName}</div> : null,
+}))
+
+const product: CommerceProductCard = {
+  id: 'popular-1',
+  title: 'Speaker Pro',
+  href: '/products/speaker-pro',
+  imageAlt: 'Speaker Pro',
+  category: 'Audio',
+  price: {
+    amount: 99000,
+    currencyCode: 'COP',
+    label: '$ 99.000',
+    compareAtAmount: 129000,
+    compareAtLabel: '$ 129.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('PopularItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseStore.mockReturnValue({ store: { subdomain: 'default' } })
+    mockUseComponentStyle.mockReturnValue({ styles: { title: 'Lo más vendido' } })
+    mockUseAdmin.mockReturnValue({ componentEdits: new Map() })
+  })
+
+  it('renders shared DTO cards with compare price and preserves add-to-cart modal flow', () => {
+    render(<PopularItems initialProducts={[product]} />)
+
+    expect(screen.getByRole('heading', { name: 'Lo más vendido' })).toBeInTheDocument()
+    expect(screen.getByText('Speaker Pro')).toBeInTheDocument()
+    expect(screen.getByText(/99\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toHaveClass('line-through')
+    expect(screen.getByRole('img', { name: 'Speaker Pro' })).toHaveAttribute('src', '/placeholder.svg')
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', '/products/speaker-pro')
+
+    fireEvent.click(screen.getByRole('button', { name: /agregar al carrito/i }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('Cantidad Speaker Pro')
+  })
+})


### PR DESCRIPTION
Closes #36

## PR chain
- PR 3 of 3 for issue #36
- Base branch: `feat/issue-36-home-grid-cards`
- Depends on: #58 and #59

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Aligns popular-carousel and catalog product cards with the shared commerce card contract/visual semantics introduced in the chain.
- Preserves popular carousel behavior, admin key, add-to-cart modal, and toast flow while normalizing DTO price/compare-at/image data.
- Adds catalog compare-at support through existing Supabase fields and keeps the cart modal payload stable.

## Changes
| File | Change |
|------|--------|
| `components/sections/popular-items-wrapper.tsx` | Maps Supabase products into shared `CommerceProductCard` DTOs. |
| `components/sections/popular-items.tsx` | Consumes DTO price/image semantics while preserving carousel/add-to-cart behavior. |
| `components/catalog/catalog-products-list.tsx` | Renders catalog cards through `VisualProductCard` with existing modal action slot. |
| `app/catalog/**/*.tsx` | Passes compare-at prices when `compare_at_price > base_price`. |
| `tests/components/popular-items.test.tsx` | Covers DTO price/compare display, fallback image, details link, and modal flow. |
| `tests/components/catalog-products-list.test.tsx` | Covers compare-at rendering, no-image fallback, and modal payload. |

## Verification
- [x] RED first: new popular/catalog tests failed against the old implementation.
- [x] `corepack pnpm exec eslint components/sections/popular-items.tsx components/sections/popular-items-wrapper.tsx components/catalog/catalog-products-list.tsx app/catalog/page.tsx app/catalog/[category]/page.tsx app/catalog/projectors/page.tsx app/catalog/earphones/page.tsx app/catalog/stands/page.tsx app/catalog/speakers/page.tsx tests/components/popular-items.test.tsx tests/components/catalog-products-list.test.tsx --max-warnings=0`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts tests/components/popular-items.test.tsx tests/components/catalog-products-list.test.tsx tests/components/products-grid.test.tsx tests/components/visual-product-card.test.tsx tests/products/product-card-adapter.test.ts`
- [x] `corepack pnpm exec vitest run -c vitest.config.ts --dir tests` — 44 files / 243 tests passed

## Scope / impact
- No Supabase schema, storage, RLS, or migration changes.
- Uses existing fields only: `base_price`, `compare_at_price`, `currency_code`, image, slug, and category data.
- Shop card was not touched in this final slice because current merged shop combo/add-to-cart parity already has tests and expanding it would exceed the bounded PR slice.

## Manual QA before merge
- [ ] Desktop screenshot comparison against the reference direction.
- [ ] Mobile screenshot comparison.
- [ ] Missing-image card fallback.
- [ ] Product with compare-at price.
- [ ] Theme/admin-edit contrast and configurability smoke check.

## Contributor checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label: `type:feature`.
- [x] No shell scripts modified; shellcheck not applicable.
- [x] Docs updated where behavior changed: PR/issue delivery notes.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
