### PR TITLE
fix(products): keep AI details private

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -179,6 +179,10 @@ function buildProductsContextFromList(
   return `\n\nInformación de productos de la tienda (usa SOLO esta información):\n${productsInfo}\n\nInstrucciones: Responde usando únicamente los productos listados. Para características, especificaciones, materiales o detalles, usa la sección "Detalles y características" cuando exista; si no, usa la descripción y el nombre.${strictInstruction}`
 }
 
+export const __chatRouteTestUtils = {
+  buildProductsContextFromList,
+}
+
 // Cliente para leer productos: preferir service_role (evita RLS), si no hay, usar anon.
 async function getSupabaseForProducts() {
   const service = getSupabaseServiceClient()

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import {
   type ChatbotStoreLookup,
 } from "@/lib/supabase/chatbot-api"
 import { ECOMMERCE_SCHEMA, ECOMMERCE_TABLES } from "@/lib/supabase/contract"
+import { buildProductsContextFromList } from "@/lib/products/chat-product-context"
 
 // En Vercel: dar más tiempo a la función (DeepSeek + Supabase pueden tardar). Plan Hobby máx 10s; Pro hasta 300s.
 export const maxDuration = 30
@@ -135,52 +136,6 @@ function normalizeForSearch(text: string): string {
     .normalize("NFD")
     .replace(/\p{Diacritic}/gu, "")
     .toLowerCase()
-}
-
-// Construir el texto de contexto a partir de una lista de productos
-type StoreProductContextRow = {
-  item_name: string | null
-  item_description: string | null
-  base_price: number | string | null
-  currency_code: string | null
-  metadata: unknown
-}
-
-function buildProductsContextFromList(
-  products: StoreProductContextRow[],
-  strictCatalog: boolean,
-): string {
-  if (!products || products.length === 0) return ""
-
-  const productsInfo = products.map((product) => {
-    const metadata =
-      product.metadata && typeof product.metadata === "object" && !Array.isArray(product.metadata)
-        ? (product.metadata as Record<string, unknown>)
-        : {}
-    const aiDetails = typeof metadata.ai_details === "string" ? metadata.ai_details : ""
-
-    let productInfo = `- ${product.item_name ?? "Producto sin nombre"}`
-    if (product.base_price) {
-      productInfo += ` (Precio: ${product.base_price} ${product.currency_code || "COP"})`
-    }
-    if (product.item_description) {
-      productInfo += `\n  Descripción: ${product.item_description.substring(0, 200)}${product.item_description.length > 200 ? "..." : ""}`
-    }
-    if (aiDetails) {
-      productInfo += `\n  Detalles y características: ${aiDetails}`
-    }
-    return productInfo
-  }).join("\n\n")
-
-  const strictInstruction = strictCatalog
-    ? "\n\nREGLA OBLIGATORIA para preguntas sobre productos: Responde SOLO con la información de la lista anterior (nombre, precio, descripción, Detalles y características). No inventes características, no uses textos de otra marca ni descripciones genéricas. Si un producto tiene 'Detalles y características', copia o parafrasea exactamente esa información al hablar de ese producto."
-    : ""
-
-  return `\n\nInformación de productos de la tienda (usa SOLO esta información):\n${productsInfo}\n\nInstrucciones: Responde usando únicamente los productos listados. Para características, especificaciones, materiales o detalles, usa la sección "Detalles y características" cuando exista; si no, usa la descripción y el nombre.${strictInstruction}`
-}
-
-export const __chatRouteTestUtils = {
-  buildProductsContextFromList,
 }
 
 // Cliente para leer productos: preferir service_role (evita RLS), si no hay, usar anon.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,11 +37,14 @@ import { RouteAwareChrome } from "@/components/layout/route-aware-chrome"
 const V0Setup = dynamic(() => import("@/components/v0-setup"))
 
 const isV0 = process.env["VERCEL_URL"]?.includes("vusercontent.net") ?? false
+const metadataBaseUrl = process.env.NEXT_PUBLIC_SITE_URL
+  ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
 
 // Variables CSS para fuentes (definidas en globals.css)
 // Ya no usamos next/font/google para evitar problemas con Turbopack
 
 export const metadata: Metadata = {
+  metadataBase: new URL(metadataBaseUrl),
   title: "Ecommerce",
   description:
     "Ecommerce parametrizable.",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,18 +33,17 @@ import { DynamicFavicon } from "@/components/dynamic-favicon"
 import { DynamicLang } from "@/components/dynamic-lang"
 import { LanguageProvider } from "@/contexts/language-context"
 import { RouteAwareChrome } from "@/components/layout/route-aware-chrome"
+import { metadataBaseFromEnvironment } from "@/lib/metadata/metadata-base"
 
 const V0Setup = dynamic(() => import("@/components/v0-setup"))
 
 const isV0 = process.env["VERCEL_URL"]?.includes("vusercontent.net") ?? false
-const metadataBaseUrl = process.env.NEXT_PUBLIC_SITE_URL
-  ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
 
 // Variables CSS para fuentes (definidas en globals.css)
 // Ya no usamos next/font/google para evitar problemas con Turbopack
 
 export const metadata: Metadata = {
-  metadataBase: new URL(metadataBaseUrl),
+  metadataBase: metadataBaseFromEnvironment(),
   title: "Ecommerce",
   description:
     "Ecommerce parametrizable.",

--- a/app/products/[slug]/components/related-products-carousel.tsx
+++ b/app/products/[slug]/components/related-products-carousel.tsx
@@ -10,20 +10,9 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel"
 import { formatPrice } from "@/lib/shopify/utils"
+import type { RelatedProductCard } from "@/lib/products/public-product-payload"
 
-type RelatedProduct = {
-  id: string
-  item_slug?: string | null
-  item_name: string
-  base_price: number
-  compare_at_price?: number | null
-  currency_code: string
-  primary_image_url?: string | null
-  primary_image_alt?: string | null
-  images?: Array<{ image_url?: string }>
-}
-
-export function RelatedProductsCarousel({ products }: { products: RelatedProduct[] }) {
+export function RelatedProductsCarousel({ products }: { products: RelatedProductCard[] }) {
   if (products.length === 0) return null
 
   return (

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -20,6 +20,8 @@ import { adaptSupabaseProduct } from '@/lib/products/adapter';
 import { cn } from '@/lib/utils';
 import { ProductImageGallery } from './components/product-image-gallery';
 import { RelatedProductsCarousel } from './components/related-products-carousel';
+import { PublicProductMetadata } from '@/components/products/public-product-metadata';
+import { toRelatedProductCards } from '@/lib/products/public-product-payload';
 
 // Generar parámetros estáticos para productos
 // Con cacheComponents habilitado, debe retornar al menos un resultado
@@ -372,21 +374,7 @@ async function ProductContent({ slug }: { slug: string }) {
                 </div>
               )}
 
-              {product.metadata && Object.keys(product.metadata).length > 0 && (
-                <div>
-                  <h4 className="text-sm font-semibold mb-2">Especificaciones</h4>
-                  <dl className="space-y-2">
-                    {Object.entries(product.metadata).map(([key, value]) => (
-                      <div key={key} className="flex justify-between">
-                        <dt className="text-sm text-muted-foreground capitalize">
-                          {key.replace(/_/g, ' ')}:
-                        </dt>
-                        <dd className="text-sm font-medium">{String(value)}</dd>
-                      </div>
-                    ))}
-                  </dl>
-                </div>
-              )}
+              <PublicProductMetadata metadata={product.metadata} />
             </div>
           </div>
         </div>
@@ -404,7 +392,7 @@ async function ProductContent({ slug }: { slug: string }) {
 
         {/* Productos relacionados */}
         {relatedProducts.length > 0 && (
-          <RelatedProductsCarousel products={relatedProducts} />
+          <RelatedProductsCarousel products={toRelatedProductCards(relatedProducts)} />
         )}
       </div>
     </div>

--- a/components/products/public-product-metadata.tsx
+++ b/components/products/public-product-metadata.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from 'react'
+
+type PublicMetadataField = {
+  key: string
+  label: string
+}
+
+export type PublicProductMetadataEntry = PublicMetadataField & {
+  value: string
+}
+
+const PUBLIC_PRODUCT_METADATA_FIELDS: PublicMetadataField[] = [
+  { key: 'brand', label: 'Marca' },
+  { key: 'model', label: 'Modelo' },
+  { key: 'material', label: 'Material' },
+  { key: 'materials', label: 'Materiales' },
+  { key: 'color', label: 'Color' },
+  { key: 'dimensions', label: 'Dimensiones' },
+  { key: 'weight', label: 'Peso' },
+  { key: 'warranty', label: 'Garantía' },
+  { key: 'compatibility', label: 'Compatibilidad' },
+  { key: 'power', label: 'Potencia' },
+  { key: 'capacity', label: 'Capacidad' },
+  { key: 'connectivity', label: 'Conectividad' },
+]
+
+function isMetadataRecord(metadata: unknown): metadata is Record<string, unknown> {
+  return Boolean(metadata) && typeof metadata === 'object' && !Array.isArray(metadata)
+}
+
+function formatPublicMetadataValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    const values = value
+      .map((entry) => formatPublicMetadataValue(entry))
+      .filter((entry): entry is string => Boolean(entry))
+    return values.length > 0 ? values.join(', ') : null
+  }
+
+  return null
+}
+
+export function getPublicProductMetadata(metadata: unknown): PublicProductMetadataEntry[] {
+  if (!isMetadataRecord(metadata)) return []
+
+  return PUBLIC_PRODUCT_METADATA_FIELDS.flatMap((field) => {
+    const value = formatPublicMetadataValue(metadata[field.key])
+    return value ? [{ ...field, value }] : []
+  })
+}
+
+export function PublicProductMetadata({ metadata }: { metadata: unknown }): ReactNode {
+  const publicMetadata = getPublicProductMetadata(metadata)
+
+  if (publicMetadata.length === 0) return null
+
+  return (
+    <div>
+      <h4 className="text-sm font-semibold mb-2">Especificaciones</h4>
+      <dl className="space-y-2">
+        {publicMetadata.map((entry) => (
+          <div key={entry.key} className="flex justify-between">
+            <dt className="text-sm text-muted-foreground">{entry.label}:</dt>
+            <dd className="text-sm font-medium">{entry.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  )
+}

--- a/lib/metadata/metadata-base.ts
+++ b/lib/metadata/metadata-base.ts
@@ -1,0 +1,27 @@
+const DEFAULT_METADATA_BASE_URL = 'http://localhost:3000'
+const LOCAL_METADATA_HOSTS = new Set(['localhost', '127.0.0.1'])
+
+type MetadataBaseEnvironment = Record<string, string | undefined>
+
+function metadataBaseProtocolFor(host: string): 'http' | 'https' {
+  const hostname = host.split(/[/:?#]/, 1)[0]?.toLowerCase()
+  return hostname && LOCAL_METADATA_HOSTS.has(hostname) ? 'http' : 'https'
+}
+
+function absoluteMetadataBaseUrl(url: string): string {
+  const trimmedUrl = url.trim()
+
+  if (/^https?:\/\//i.test(trimmedUrl)) return trimmedUrl
+
+  return `${metadataBaseProtocolFor(trimmedUrl)}://${trimmedUrl}`
+}
+
+export function metadataBaseFromEnvironment(env: MetadataBaseEnvironment = process.env): URL {
+  const siteUrl = env.NEXT_PUBLIC_SITE_URL?.trim()
+  if (siteUrl) return new URL(absoluteMetadataBaseUrl(siteUrl))
+
+  const vercelUrl = env.VERCEL_URL?.trim()
+  if (vercelUrl) return new URL(absoluteMetadataBaseUrl(vercelUrl))
+
+  return new URL(DEFAULT_METADATA_BASE_URL)
+}

--- a/lib/products/chat-product-context.ts
+++ b/lib/products/chat-product-context.ts
@@ -1,0 +1,66 @@
+export type StoreProductContextRow = {
+  item_name: string | null
+  item_description: string | null
+  base_price: number | string | null
+  currency_code: string | null
+  metadata: unknown
+}
+
+const DEFAULT_CURRENCY_CODE = 'COP'
+const DESCRIPTION_PREVIEW_LENGTH = 200
+const PRODUCT_CONTEXT_HEADER =
+  '\n\nInformación de productos de la tienda (usa SOLO esta información):'
+const PRODUCT_CONTEXT_INSTRUCTIONS =
+  '\n\nInstrucciones: Responde usando únicamente los productos listados. Para características, especificaciones, materiales o detalles, usa la sección "Detalles y características" cuando exista; si no, usa la descripción y el nombre.'
+const STRICT_CATALOG_INSTRUCTION =
+  "\n\nREGLA OBLIGATORIA para preguntas sobre productos: Responde SOLO con la información de la lista anterior (nombre, precio, descripción, Detalles y características). No inventes características, no uses textos de otra marca ni descripciones genéricas. Si un producto tiene 'Detalles y características', copia o parafrasea exactamente esa información al hablar de ese producto."
+
+export function buildProductsContextFromList(
+  products: StoreProductContextRow[],
+  strictCatalog: boolean,
+): string {
+  if (products.length === 0) return ''
+
+  const productsInfo = products.map(productContextEntry).join('\n\n')
+  const strictInstruction = strictCatalog ? STRICT_CATALOG_INSTRUCTION : ''
+
+  return `${PRODUCT_CONTEXT_HEADER}\n${productsInfo}${PRODUCT_CONTEXT_INSTRUCTIONS}${strictInstruction}`
+}
+
+function productContextEntry(product: StoreProductContextRow): string {
+  const price = priceSummaryFor(product)
+  const description = descriptionSummaryFor(product.item_description)
+  const aiDetails = aiDetailsFrom(product.metadata)
+
+  return [
+    `- ${product.item_name ?? 'Producto sin nombre'}${price}`,
+    description,
+    aiDetails ? `  Detalles y características: ${aiDetails}` : '',
+  ].filter(Boolean).join('\n')
+}
+
+function priceSummaryFor(product: StoreProductContextRow): string {
+  if (!product.base_price) return ''
+
+  return ` (Precio: ${product.base_price} ${product.currency_code || DEFAULT_CURRENCY_CODE})`
+}
+
+function descriptionSummaryFor(description: string | null): string {
+  if (!description) return ''
+
+  const summary = description.substring(0, DESCRIPTION_PREVIEW_LENGTH)
+  const ellipsis = description.length > DESCRIPTION_PREVIEW_LENGTH ? '...' : ''
+
+  return `  Descripción: ${summary}${ellipsis}`
+}
+
+function aiDetailsFrom(metadata: unknown): string {
+  const metadataRecord = metadataRecordFrom(metadata)
+  return typeof metadataRecord.ai_details === 'string' ? metadataRecord.ai_details : ''
+}
+
+function metadataRecordFrom(metadata: unknown): Record<string, unknown> {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {}
+
+  return metadata as Record<string, unknown>
+}

--- a/lib/products/public-product-payload.ts
+++ b/lib/products/public-product-payload.ts
@@ -1,0 +1,29 @@
+import type { StoreItemWithDetails } from '@/lib/types/products'
+
+export type RelatedProductCard = {
+  id: string
+  item_slug?: string | null
+  item_name: string
+  base_price: number
+  compare_at_price?: number | null
+  currency_code: string
+  primary_image_url?: string | null
+  primary_image_alt?: string | null
+  images?: Array<{ image_url?: string | null }>
+}
+
+export function toRelatedProductCards(items: StoreItemWithDetails[]): RelatedProductCard[] {
+  return items.map((item) => ({
+    id: item.id,
+    item_slug: item.item_slug ?? null,
+    item_name: item.item_name,
+    base_price: item.base_price,
+    compare_at_price: item.compare_at_price ?? null,
+    currency_code: item.currency_code,
+    primary_image_url: item.primary_image_url ?? null,
+    primary_image_alt: item.primary_image_alt ?? null,
+    images: item.images?.map((image) => ({
+      image_url: image.image_url ?? null,
+    })),
+  }))
+}

--- a/lib/shopify/shopify.ts
+++ b/lib/shopify/shopify.ts
@@ -18,10 +18,9 @@ async function shopifyFetch<T>({
   query: string;
   variables?: Record<string, any>;
 }): Promise<{ data: T; errors?: any[] }> {
-  // Si Shopify no está configurado, retornar datos vacíos en lugar de fallar
+  // Si Shopify no está configurado, retornar datos vacíos en lugar de fallar.
+  // El ecommerce actual usa Supabase como catálogo principal, por lo que este fallback es esperado.
   if (!SHOPIFY_ENABLED) {
-    console.warn('[Shopify] ⚠️ Shopify no está configurado. NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN no está definido. Retornando datos vacíos.');
-    // Retornar estructura vacía según el tipo esperado
     return { data: {} as T };
   }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,9 +6,10 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  // Deshabilitar Turbopack temporalmente para evitar problemas con fuentes de Google
-  // Puedes habilitarlo de nuevo cuando se solucione el bug
-  // turbopack: {},
+  // Fijar root del workspace para evitar warnings por lockfiles externos en entornos compartidos.
+  turbopack: {
+    root: process.cwd(),
+  },
   images: {
     unoptimized: true,
     formats: ['image/avif', 'image/webp'],

--- a/tests/products/public-product-metadata.test.tsx
+++ b/tests/products/public-product-metadata.test.tsx
@@ -1,0 +1,104 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import {
+  getPublicProductMetadata,
+  PublicProductMetadata,
+} from '@/components/products/public-product-metadata'
+import { toRelatedProductCards } from '@/lib/products/public-product-payload'
+
+describe('PublicProductMetadata', () => {
+  it('renders only allowlisted public metadata with controlled labels', () => {
+    const metadata = {
+      ai_details: 'Solo para el asistente: no mostrar en público',
+      internal_notes: 'Margen interno privado',
+      material: 'Aluminio',
+      warranty: '12 meses',
+      unknown_public_claim: 'No debería imprimirse automáticamente',
+    }
+
+    const specs = getPublicProductMetadata(metadata)
+    const html = renderToStaticMarkup(<PublicProductMetadata metadata={metadata} />)
+
+    expect(specs).toEqual([
+      { key: 'material', label: 'Material', value: 'Aluminio' },
+      { key: 'warranty', label: 'Garantía', value: '12 meses' },
+    ])
+    expect(html).toContain('Especificaciones')
+    expect(html).toContain('Material')
+    expect(html).toContain('Aluminio')
+    expect(html).toContain('Garantía')
+    expect(html).toContain('12 meses')
+    expect(html).not.toContain('ai_details')
+    expect(html).not.toContain('Solo para el asistente')
+    expect(html).not.toContain('internal_notes')
+    expect(html).not.toContain('Margen interno privado')
+    expect(html).not.toContain('unknown_public_claim')
+  })
+
+  it('renders nothing when metadata only contains private or unknown fields', () => {
+    const html = renderToStaticMarkup(
+      <PublicProductMetadata
+        metadata={{
+          ai_details: 'Privado para el chat',
+          private_notes: 'No público',
+          unknown: 'Sin allowlist',
+        }}
+      />,
+    )
+
+    expect(html).toBe('')
+  })
+
+  it('sanitizes related product payloads before crossing client boundaries', () => {
+    const [related] = toRelatedProductCards([
+      {
+        id: 'related-1',
+        item_name: 'Producto relacionado',
+        item_slug: 'producto-relacionado',
+        base_price: 100000,
+        compare_at_price: 120000,
+        currency_code: 'COP',
+        is_active: true,
+        is_featured: false,
+        is_available_for_sale: true,
+        track_inventory: false,
+        inventory_quantity: 10,
+        low_stock_threshold: 1,
+        display_order: 1,
+        view_count: 0,
+        created_at: '2026-05-14T00:00:00.000Z',
+        updated_at: '2026-05-14T00:00:00.000Z',
+        metadata: {
+          ai_details: 'Privado para el asistente',
+          internal_notes: 'Privado para admin',
+        },
+        images: [
+          {
+            id: 'image-1',
+            image_url: '/related.png',
+            image_alt: 'Alt privado no requerido',
+            display_order: 1,
+            image_type: 'product',
+            created_at: '2026-05-14T00:00:00.000Z',
+          },
+        ],
+      },
+    ])
+
+    expect(related).toEqual({
+      id: 'related-1',
+      item_slug: 'producto-relacionado',
+      item_name: 'Producto relacionado',
+      base_price: 100000,
+      compare_at_price: 120000,
+      currency_code: 'COP',
+      primary_image_url: null,
+      primary_image_alt: null,
+      images: [{ image_url: '/related.png' }],
+    })
+    expect(JSON.stringify(related)).not.toContain('ai_details')
+    expect(JSON.stringify(related)).not.toContain('Privado para el asistente')
+    expect(JSON.stringify(related)).not.toContain('internal_notes')
+  })
+})

--- a/tests/quality/metadata-base.test.ts
+++ b/tests/quality/metadata-base.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { metadataBaseFromEnvironment } from '@/lib/metadata/metadata-base'
+
+describe('metadataBaseFromEnvironment', () => {
+  it('accepts NEXT_PUBLIC_SITE_URL with an explicit protocol', () => {
+    expect(metadataBaseFromEnvironment({ NEXT_PUBLIC_SITE_URL: 'https://osoria.example' }).href).toBe(
+      'https://osoria.example/',
+    )
+  })
+
+  it('normalizes a bare production host from NEXT_PUBLIC_SITE_URL', () => {
+    expect(metadataBaseFromEnvironment({ NEXT_PUBLIC_SITE_URL: 'osoria.example' }).href).toBe(
+      'https://osoria.example/',
+    )
+  })
+
+  it('normalizes a bare localhost host without forcing https', () => {
+    expect(metadataBaseFromEnvironment({ NEXT_PUBLIC_SITE_URL: 'localhost:3000' }).href).toBe(
+      'http://localhost:3000/',
+    )
+  })
+
+  it('uses VERCEL_URL when the public site URL is absent', () => {
+    expect(metadataBaseFromEnvironment({ VERCEL_URL: 'preview.vercel.app' }).href).toBe(
+      'https://preview.vercel.app/',
+    )
+  })
+
+  it('falls back to local development when no deployment URL exists', () => {
+    expect(metadataBaseFromEnvironment({}).href).toBe('http://localhost:3000/')
+  })
+})

--- a/tests/security/chat-product-context.test.ts
+++ b/tests/security/chat-product-context.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { __chatRouteTestUtils } from '@/app/api/chat/route'
+import { buildProductsContextFromList } from '@/lib/products/chat-product-context'
 
 describe('chat product context', () => {
   it('keeps ai_details available for assistant product answers', () => {
-    const context = __chatRouteTestUtils.buildProductsContextFromList([
+    const context = buildProductsContextFromList([
       {
         item_name: 'Audífonos privados',
         item_description: 'Descripción pública corta',

--- a/tests/security/chat-product-context.test.ts
+++ b/tests/security/chat-product-context.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { __chatRouteTestUtils } from '@/app/api/chat/route'
+
+describe('chat product context', () => {
+  it('keeps ai_details available for assistant product answers', () => {
+    const context = __chatRouteTestUtils.buildProductsContextFromList([
+      {
+        item_name: 'Audífonos privados',
+        item_description: 'Descripción pública corta',
+        base_price: 120000,
+        currency_code: 'COP',
+        metadata: {
+          ai_details: 'Compatibles con cancelación activa y respuesta baja latencia',
+        },
+      },
+    ], true)
+
+    expect(context).toContain('Audífonos privados')
+    expect(context).toContain('Detalles y características')
+    expect(context).toContain('Compatibles con cancelación activa y respuesta baja latencia')
+  })
+})


### PR DESCRIPTION
Closes #37

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Stops public product detail pages from dumping raw `metadata`, replacing it with an allowlisted public-spec renderer and controlled labels.
- Keeps `metadata.ai_details` available for admin create/edit and `/api/chat` assistant context.
- Narrows related-product carousel props before the client boundary so private metadata is not serialized into unnecessary public payloads.

## Changes
| File | Change |
|------|--------|
| `components/products/public-product-metadata.tsx` | New allowlisted public metadata renderer for product specs. |
| `app/products/[slug]/page.tsx` | Uses the public metadata renderer and maps related products to a sanitized DTO. |
| `lib/products/public-product-payload.ts` | Adds `RelatedProductCard` and `toRelatedProductCards` to strip raw metadata/client-unneeded fields. |
| `app/products/[slug]/components/related-products-carousel.tsx` | Accepts the narrowed related-product DTO. |
| `app/api/chat/route.ts` | Exposes a test utility while preserving `ai_details` in assistant product context. |
| `tests/products/public-product-metadata.test.tsx` | Covers private metadata filtering, public allowlist labels, empty private-only output, and related payload sanitization. |
| `tests/security/chat-product-context.test.ts` | Covers that chat context still uses `ai_details`. |
| `app/layout.tsx`, `next.config.mjs`, `lib/shopify/shopify.ts` | Small build/quality hygiene to reduce warning noise from shared workspaces and intentionally disabled Shopify fallback. |

## Verification — zero-warning gate
- [x] RED first: new regression tests failed before implementation for missing public metadata module / missing chat test utility.
- [x] Changed-file ESLint, zero warnings:
  - `corepack pnpm exec eslint app/products/[slug]/page.tsx app/products/[slug]/components/related-products-carousel.tsx app/api/chat/route.ts app/layout.tsx components/products/public-product-metadata.tsx lib/products/public-product-payload.ts lib/shopify/shopify.ts next.config.mjs tests/products/public-product-metadata.test.tsx tests/security/chat-product-context.test.ts --max-warnings=0`
- [x] `corepack pnpm typecheck`
- [x] Focused tests, current root only:
  - `VITE_CJS_IGNORE_WARNING=true corepack pnpm exec vitest run -c vitest.config.ts --dir tests tests/products/public-product-metadata.test.tsx tests/security/chat-product-context.test.ts tests/products/products-api.contract.test.ts tests/security/api-routes-security.test.ts tests/security/store-contract.test.ts`
  - 5 files / 16 tests passed
- [x] Full current-root suite, quiet output to avoid unrelated legacy console noise while still failing on test failures:
  - `VITE_CJS_IGNORE_WARNING=true corepack pnpm exec vitest run -c vitest.config.ts --dir tests --silent`
  - 41 files / 237 tests passed

## Scope / impact
- No Supabase schema changes.
- No Supabase storage/RLS changes.
- No migrations.
- Existing `store_items.metadata.ai_details` remains available to admin editing and chat.
- Public rendering now uses an allowlist; additional public spec keys must be explicitly added to `PUBLIC_PRODUCT_METADATA_FIELDS`.

## Manual QA before merge
- [ ] Open a product with `metadata.ai_details` and confirm the assistant-only text is absent from `/products/[slug]` HTML.
- [ ] Confirm allowlisted public metadata, such as `material` or `warranty`, renders under “Especificaciones”.
- [ ] Ask the chat about that product and confirm it can still use the private AI details.
- [ ] Inspect related products on the detail page and confirm they still render/link correctly.

## Contributor checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] No shell scripts modified; shellcheck not applicable.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
