### PR TITLE
fix(auth): consolidate safe role redirects

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { getSupabaseBrowserClient } from "@/lib/supabase/client"
+import { getCurrentUser } from "@/lib/supabase/auth-api"
+import { getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
 
 function AuthCallbackContent() {
   const router = useRouter()
@@ -29,6 +31,16 @@ function AuthCallbackContent() {
           return
         }
 
+        const returnPath = getAuthReturnPath(searchParams)
+
+        const pushPostAuthDestination = async () => {
+          const currentUser = await getCurrentUser()
+          router.push(resolvePostAuthDestination({
+            returnPath,
+            user: currentUser.success ? currentUser.user : null,
+          }))
+        }
+
         if (code) {
           // Intercambiar el código por una sesión
           const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
@@ -41,7 +53,8 @@ function AuthCallbackContent() {
 
           if (data.session) {
             // Sesión creada (p. ej. tras confirmar correo), redirigir a página de éxito
-            router.push("/auth/cuenta-confirmada")
+            // salvo que exista un destino admin seguro permitido para el usuario.
+            await pushPostAuthDestination()
             return
           }
         }
@@ -57,7 +70,8 @@ function AuthCallbackContent() {
 
         if (session) {
           // Ya hay sesión (p. ej. llegó sin code), redirigir a éxito o inicio
-          router.push("/auth/cuenta-confirmada")
+          // salvo que exista un destino admin seguro permitido para el usuario.
+          await pushPostAuthDestination()
         } else {
           // No hay sesión, redirigir al login
           router.push("/?error=no_session")

--- a/components/admin/admin-session-actions.tsx
+++ b/components/admin/admin-session-actions.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { LogOut } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/contexts/auth-context"
+
+export function AdminSessionActions() {
+  const router = useRouter()
+  const { isAuthenticated, isLoading, logout } = useAuth()
+  const [isSigningOut, setIsSigningOut] = useState(false)
+
+  if (isLoading || !isAuthenticated) return null
+
+  const handleLogout = async () => {
+    setIsSigningOut(true)
+    await logout()
+    router.push("/")
+  }
+
+  return (
+    <div className="fixed bottom-4 left-4 z-50">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-2 border-border bg-background/95 text-foreground shadow-lg backdrop-blur hover:bg-accent"
+        disabled={isSigningOut}
+        onClick={handleLogout}
+      >
+        <LogOut className="h-4 w-4" />
+        {isSigningOut ? "Cerrando..." : "Cerrar sesión"}
+      </Button>
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import { useState, useMemo, useEffect } from "react"
-import { useRouter, usePathname } from "next/navigation"
+import { useState, useMemo, useEffect, useRef } from "react"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Search, Heart, ShoppingCart, Palette, AlignLeft, Menu, LogIn, LogOut, User, Eye, EyeOff, CreditCard, Building2, Wallet, LayoutDashboard, Edit } from "lucide-react"
 import { VisaIcon, MasterCardIcon, AmexIcon } from "@/components/icons/cc-icons"
@@ -21,6 +21,7 @@ import { Trash2, Plus, Minus } from "lucide-react"
 import { toast } from "sonner"
 import { resetPassword } from "@/lib/supabase/auth-api"
 import { deferStateUpdate } from "@/lib/react/defer-state-update"
+import { ADMIN_ACCESS_DENIED_PATH, getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
 import {
   Sheet,
   SheetContent,
@@ -67,6 +68,7 @@ function generateCategorySlug(name: string): string {
 
 export function Header() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [themeModalOpen, setThemeModalOpen] = useState(false)
   const [fontModalOpen, setFontModalOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -87,6 +89,8 @@ export function Header() {
   const [forgotPasswordModalOpen, setForgotPasswordModalOpen] = useState(false)
   const [resetEmail, setResetEmail] = useState("")
   const [resetEmailSent, setResetEmailSent] = useState(false)
+  const [pendingLoginReturnPath, setPendingLoginReturnPath] = useState<string | null>(null)
+  const openedLoginReturnIntentRef = useRef<string | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
   const [searchSuggestions, setSearchSuggestions] = useState<Array<{ id: string; title: string; slug: string; image?: string }>>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -146,6 +150,26 @@ export function Header() {
     ? (styleData.logoImageDark || "/logo-osoria-blanco.svg")
     : (styleData.logoImage || "/logo-negro.svg")
   const pathname = usePathname()
+
+  useEffect(() => {
+    if (searchParams.get("auth") !== "login") {
+      return
+    }
+
+    const safeReturnPath = getAuthReturnPath(searchParams)
+    if (!safeReturnPath) {
+      return
+    }
+
+    if (openedLoginReturnIntentRef.current === safeReturnPath) {
+      return
+    }
+
+    openedLoginReturnIntentRef.current = safeReturnPath
+    setPendingLoginReturnPath(safeReturnPath)
+    setIsRegisterMode(false)
+    setLoginModalOpen(true)
+  }, [searchParams])
 
   // Sincronizar el query de búsqueda con la URL cuando esté en /shop
   useEffect(() => {
@@ -1323,7 +1347,8 @@ export function Header() {
                   // Refrescar el usuario para obtener el rol actualizado
                   await refreshUser()
                   
-                  // Todos los usuarios (admin y user) van a la página principal
+                  // Todos los usuarios (admin y user) inician sesión; solo admins consumen
+                  // un destino admin seguro solicitado desde ?auth=login&next=...
                   toast.success(t.header.sessionStarted, {
                     description: result.user?.role === 'admin' 
                       ? t.header.welcomeAdminLogin 
@@ -1331,6 +1356,8 @@ export function Header() {
                     duration: 3000,
                   })
                   
+                  const loginReturnPath = pendingLoginReturnPath
+                  setPendingLoginReturnPath(null)
                   setLoginModalOpen(false)
                   setEmail("")
                   setPassword("")
@@ -1340,6 +1367,15 @@ export function Header() {
                   setShowPassword(false)
                   setShowConfirmPassword(false)
                   setIsRegisterMode(false)
+
+                  if (loginReturnPath) {
+                    const nextDestination = resolvePostAuthDestination({
+                      returnPath: loginReturnPath,
+                      user: result.user,
+                      fallback: ADMIN_ACCESS_DENIED_PATH,
+                    })
+                    router.push(nextDestination)
+                  }
                 } else {
                   toast.error(t.header.errorLoggingIn, {
                     description: result.error || "Verifica tus credenciales e intenta nuevamente",

--- a/components/layout/route-aware-chrome.tsx
+++ b/components/layout/route-aware-chrome.tsx
@@ -9,6 +9,7 @@ import { EditorPanel } from "@/components/admin/editor-panel"
 import { MainContentWrapper } from "@/components/admin/main-content-wrapper"
 import { FloatingContactButton } from "@/components/ui/floating-contact-button"
 import { Header } from "@/components/layout/header"
+import { AdminSessionActions } from "@/components/admin/admin-session-actions"
 
 interface RouteAwareChromeProps {
   children: ReactNode
@@ -33,6 +34,7 @@ export function RouteAwareChrome({ children }: RouteAwareChromeProps) {
     serverHydrationSnapshot,
   )
   const showStorefrontChrome = hasHydrated && !isAdminChromeRoute(pathname)
+  const showAdminSessionActions = hasHydrated && isAdminChromeRoute(pathname)
 
   return (
     <>
@@ -46,6 +48,7 @@ export function RouteAwareChrome({ children }: RouteAwareChromeProps) {
           {children}
         </main>
       </MainContentWrapper>
+      {showAdminSessionActions && <AdminSessionActions />}
       {showStorefrontChrome && (
         <>
           <FloatingContactButton />

--- a/contexts/admin-permissions-context.tsx
+++ b/contexts/admin-permissions-context.tsx
@@ -17,13 +17,15 @@ interface AdminPermissionsContextType {
 const AdminPermissionsContext = createContext<AdminPermissionsContextType | undefined>(undefined)
 
 export function AdminPermissionsProvider({ children }: { children: ReactNode }) {
-  const { isLoading: authLoading, isAuthenticated } = useAuth()
+  const { isLoading: authLoading, isAuthenticated, user } = useAuth()
+  const currentUserId = user?.id ?? null
   const [isAdmin, setIsAdmin] = useState(false)
   const [role, setRole] = useState<UserRole | null>(null)
   const [loading, setLoading] = useState(true)
   const [hasChecked, setHasChecked] = useState(false) // Indica si ya se verificó al menos una vez
   const refreshRef = useRef(false) // Ref para evitar múltiples llamadas simultáneas
   const verifiedAsAdminRef = useRef(false) // Ref para rastrear si ya se verificó como admin exitosamente
+  const checkedUserIdRef = useRef<string | null>(null) // Evita reutilizar permisos de otro usuario autenticado
 
   const refreshPermissions = async () => {
     // Evitar múltiples verificaciones simultáneas
@@ -120,14 +122,6 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
 
   // Esperar a que la autenticación esté lista antes de comprobar permisos (evita "no tienes permisos" al entrar)
   useEffect(() => {
-    // Si ya se verificó exitosamente como admin y el usuario sigue autenticado, no verificar de nuevo
-    // Esto evita verificaciones innecesarias al navegar entre páginas
-    if (verifiedAsAdminRef.current && isAuthenticated && !authLoading) {
-      console.log("[AdminPermissions] Ya verificado como admin, omitiendo verificación adicional")
-      setLoading(false) // Asegurar que loading esté en false
-      return
-    }
-
     if (authLoading) {
       deferStateUpdate(() => setLoading(true))
       return
@@ -135,7 +129,7 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
 
     // Si el usuario se desautenticó, resetear estado
     if (!isAuthenticated) {
-      if (verifiedAsAdminRef.current || hasChecked) {
+      if (verifiedAsAdminRef.current || hasChecked || checkedUserIdRef.current !== null) {
         console.log("[AdminPermissions] Usuario desautenticado, reseteando estado")
         deferStateUpdate(() => {
           setIsAdmin(false)
@@ -143,8 +137,32 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
           setHasChecked(false)
         })
         verifiedAsAdminRef.current = false // Resetear ref
+        checkedUserIdRef.current = null
       }
       deferStateUpdate(() => setLoading(false))
+      return
+    }
+
+    // Si cambió el usuario autenticado, negar hasta volver a verificar ese usuario.
+    if (checkedUserIdRef.current !== currentUserId) {
+      console.log("[AdminPermissions] Usuario autenticado cambió, revalidando permisos")
+      checkedUserIdRef.current = currentUserId
+      verifiedAsAdminRef.current = false
+      deferStateUpdate(() => {
+        setIsAdmin(false)
+        setRole(null)
+        setHasChecked(false)
+        setLoading(true)
+        void refreshPermissions()
+      })
+      return
+    }
+
+    // Si ya se verificó exitosamente como admin y el usuario sigue autenticado, no verificar de nuevo
+    // Esto evita verificaciones innecesarias al navegar entre páginas
+    if (verifiedAsAdminRef.current && isAuthenticated && !authLoading) {
+      console.log("[AdminPermissions] Ya verificado como admin, omitiendo verificación adicional")
+      setLoading(false) // Asegurar que loading esté en false
       return
     }
 
@@ -159,7 +177,7 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
     }
     // refreshPermissions intentionally stays outside deps to avoid repeated permission checks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authLoading, isAuthenticated]) // Solo depender de authLoading e isAuthenticated para evitar loops
+  }, [authLoading, isAuthenticated, currentUserId]) // Revalidar cuando cambia el usuario autenticado, no solo el booleano de sesión
 
 
   return (

--- a/contexts/admin-permissions-context.tsx
+++ b/contexts/admin-permissions-context.tsx
@@ -23,18 +23,25 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
   const [role, setRole] = useState<UserRole | null>(null)
   const [loading, setLoading] = useState(true)
   const [hasChecked, setHasChecked] = useState(false) // Indica si ya se verificó al menos una vez
-  const refreshRef = useRef(false) // Ref para evitar múltiples llamadas simultáneas
+  const activeVerificationUserIdRef = useRef<string | null>(null) // Evita verificaciones duplicadas para el mismo usuario
+  const verificationRunIdRef = useRef(0) // Invalida verificaciones viejas si cambia el usuario
   const verifiedAsAdminRef = useRef(false) // Ref para rastrear si ya se verificó como admin exitosamente
   const checkedUserIdRef = useRef<string | null>(null) // Evita reutilizar permisos de otro usuario autenticado
 
-  const refreshPermissions = async () => {
-    // Evitar múltiples verificaciones simultáneas
-    if (refreshRef.current) {
+  const refreshPermissions = async (expectedUserId = currentUserId) => {
+    if (activeVerificationUserIdRef.current === expectedUserId) {
       console.log("[AdminPermissions] Verificación ya en progreso, ignorando llamada duplicada")
       return
     }
-    
-    refreshRef.current = true
+
+    const verificationRunId = verificationRunIdRef.current + 1
+    verificationRunIdRef.current = verificationRunId
+    activeVerificationUserIdRef.current = expectedUserId
+
+    const isCurrentVerification = () =>
+      verificationRunIdRef.current === verificationRunId
+      && checkedUserIdRef.current === expectedUserId
+
     console.log("[AdminPermissions] Iniciando verificación de permisos...")
     try {
       setLoading(true)
@@ -49,11 +56,13 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
       // Procesar resultado de isCurrentUserAdmin
       // IMPORTANTE: Actualizar isAdmin ANTES de establecer loading en false
       if (adminResult.status === 'fulfilled') {
+        if (!isCurrentVerification()) return
         const adminValue = adminResult.value
         setIsAdmin(adminValue)
         verifiedAsAdminRef.current = adminValue // Rastrear si es admin
         console.log(`[AdminPermissions] Estado de admin actualizado: ${adminValue}`)
       } else {
+        if (!isCurrentVerification()) return
         const error = adminResult.reason
         const errorMessage = error?.message || String(error) || ''
         console.warn("[AdminPermissions] Error al verificar admin status:", errorMessage)
@@ -75,8 +84,10 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
 
       // Procesar resultado de getCurrentUserRole
       if (roleResult.status === 'fulfilled') {
+        if (!isCurrentVerification()) return
         setRole(roleResult.value)
       } else {
+        if (!isCurrentVerification()) return
         const error = roleResult.reason
         const errorMessage = error?.message || String(error) || ''
         console.warn("[AdminPermissions] Error al obtener rol:", errorMessage)
@@ -97,8 +108,10 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
       }
 
       // Marcar que ya se verificó al menos una vez
+      if (!isCurrentVerification()) return
       setHasChecked(true)
     } catch (error) {
+      if (!isCurrentVerification()) return
       console.error("[AdminPermissions] Error inesperado al cargar permisos:", error)
       // Solo establecer valores por defecto si es un error definitivo
       // No cambiar el estado si es un timeout
@@ -113,9 +126,15 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
       // Establecer loading en false DESPUÉS de que los estados se hayan actualizado
       // Usar un pequeño delay para asegurar que React haya procesado los updates
       setTimeout(() => {
+        if (!isCurrentVerification()) {
+          if (activeVerificationUserIdRef.current === expectedUserId) {
+            activeVerificationUserIdRef.current = null
+          }
+          return
+        }
         setLoading(false)
         console.log("[AdminPermissions] Verificación de permisos completada, hasChecked:", true)
-        refreshRef.current = false // Permitir nuevas verificaciones
+        activeVerificationUserIdRef.current = null
       }, 100)
     }
   }
@@ -138,6 +157,8 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
         })
         verifiedAsAdminRef.current = false // Resetear ref
         checkedUserIdRef.current = null
+        activeVerificationUserIdRef.current = null
+        verificationRunIdRef.current += 1
       }
       deferStateUpdate(() => setLoading(false))
       return
@@ -153,7 +174,7 @@ export function AdminPermissionsProvider({ children }: { children: ReactNode }) 
         setRole(null)
         setHasChecked(false)
         setLoading(true)
-        void refreshPermissions()
+        void refreshPermissions(currentUserId)
       })
       return
     }

--- a/docs/auth/issue-35-safe-role-redirects-runtime.md
+++ b/docs/auth/issue-35-safe-role-redirects-runtime.md
@@ -1,0 +1,28 @@
+# Issue #35 Safe Role Redirects — Runtime Notes
+
+## Runtime environment
+
+The route guard and return-intent flow reuse the existing Supabase Auth/session setup. Deployments must provide:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+`SUPABASE_SERVICE_ROLE_KEY` stays server-only and is required for the proxy/server admin role lookup against the existing `ecommerce.user_profiles.role` value.
+
+## Supabase changes
+
+Issue #35 does **not** introduce Supabase migrations, schema changes, storage changes, or RLS changes. It continues to use the current Auth session cookies and the existing `ecommerce.user_profiles.role = 'admin'` contract for admin users.
+
+## Manual QA matrix
+
+| Flow | Expected result |
+| --- | --- |
+| Guest opens `/admin` or `/admin/orders` | Redirects before admin content renders to `/?auth=login&next=/admin...`. |
+| Authenticated non-admin opens `/admin*` | Redirects before admin content renders to `/?admin_access=denied`. |
+| Admin opens `/admin*` | Requested admin route renders after admin status is verified; client fallback must not redirect the verified admin home from stale state. |
+| Expired or missing session opens `/admin*` | Redirects to login with safe admin return intent and no admin content render. |
+| Supabase role lookup fails on `/admin*` | Redirects to safe fallback with `admin_access=error`. |
+| Callback/login with safe admin `next` | Admin returns once to the safe `/admin*` destination; non-admin receives `admin_access=denied`. |
+| Callback/login with external or `//` next | Unsafe target is rejected; no open redirect occurs. |
+| `/dashboard`, `/checkout`, and public routes | Existing behavior remains unchanged by issue #35. |

--- a/lib/auth-return-intent.ts
+++ b/lib/auth-return-intent.ts
@@ -1,0 +1,67 @@
+import type { UserProfile } from "@/lib/types/user";
+
+export const AUTH_CONFIRMATION_SUCCESS_PATH = "/auth/cuenta-confirmada";
+export const ADMIN_ACCESS_DENIED_PATH = "/?admin_access=denied";
+
+export type AuthReturnUser = Pick<UserProfile, "role"> | null | undefined;
+
+function isAdminRoute(pathname: string) {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
+export function normalizeAuthReturnPath(candidate: string | null | undefined) {
+  if (!candidate) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate, "http://osoria.local");
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "http://osoria.local") {
+    return null;
+  }
+
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return null;
+  }
+
+  const pathname = parsed.pathname;
+  if (!isAdminRoute(pathname)) {
+    return null;
+  }
+
+  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
+    return null;
+  }
+
+  return `${pathname}${parsed.search}`;
+}
+
+export function getAuthReturnPath(params: Pick<URLSearchParams, "get">) {
+  return normalizeAuthReturnPath(params.get("next") ?? params.get("redirect"));
+}
+
+export function resolvePostAuthDestination({
+  returnPath,
+  user,
+  fallback = AUTH_CONFIRMATION_SUCCESS_PATH,
+}: {
+  returnPath: string | null | undefined;
+  user: AuthReturnUser;
+  fallback?: string;
+}) {
+  const safeReturnPath = normalizeAuthReturnPath(returnPath);
+  if (!safeReturnPath) {
+    return fallback;
+  }
+
+  if (user?.role === "admin") {
+    return safeReturnPath;
+  }
+
+  return ADMIN_ACCESS_DENIED_PATH;
+}

--- a/lib/supabase/admin-access.ts
+++ b/lib/supabase/admin-access.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import type { NextRequest } from "next/server";
 import { ECOMMERCE_TABLES } from "./contract";
+import { normalizeAuthReturnPath } from "@/lib/auth-return-intent";
 
 export type AdminAccessResult =
   | { status: "admin"; userId: string }
@@ -12,40 +13,8 @@ type AuthenticatedUser = {
   id: string;
 };
 
-function isAdminRoute(pathname: string) {
-  return pathname === "/admin" || pathname.startsWith("/admin/");
-}
-
 export function normalizeSafeAdminPath(candidate: string | null | undefined) {
-  if (!candidate) {
-    return null;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(candidate, "http://osoria.local");
-  } catch {
-    return null;
-  }
-
-  if (parsed.origin !== "http://osoria.local") {
-    return null;
-  }
-
-  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
-    return null;
-  }
-
-  const pathname = parsed.pathname;
-  if (!isAdminRoute(pathname)) {
-    return null;
-  }
-
-  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
-    return null;
-  }
-
-  return `${pathname}${parsed.search}`;
+  return normalizeAuthReturnPath(candidate);
 }
 
 function createRequestAuthClient(request: NextRequest) {

--- a/lib/supabase/admin-access.ts
+++ b/lib/supabase/admin-access.ts
@@ -1,0 +1,152 @@
+import { createServerClient } from "@supabase/ssr";
+import type { NextRequest } from "next/server";
+import { ECOMMERCE_TABLES } from "./contract";
+
+export type AdminAccessResult =
+  | { status: "admin"; userId: string }
+  | { status: "guest"; reason: "no_user" | "auth_error" | "supabase_not_configured" }
+  | { status: "non_admin"; userId: string; reason?: "missing_profile" | "role_mismatch" }
+  | { status: "error"; userId?: string; reason: "supabase_not_configured" | "profile_lookup_failed" };
+
+type AuthenticatedUser = {
+  id: string;
+};
+
+function isAdminRoute(pathname: string) {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
+export function normalizeSafeAdminPath(candidate: string | null | undefined) {
+  if (!candidate) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate, "http://osoria.local");
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "http://osoria.local") {
+    return null;
+  }
+
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return null;
+  }
+
+  const pathname = parsed.pathname;
+  if (!isAdminRoute(pathname)) {
+    return null;
+  }
+
+  if (pathname === "/auth/callback" || parsed.searchParams.has("admin_access")) {
+    return null;
+  }
+
+  return `${pathname}${parsed.search}`;
+}
+
+function createRequestAuthClient(request: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null;
+  }
+
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll().map((cookie) => ({
+          name: cookie.name,
+          value: cookie.value,
+        }));
+      },
+      setAll() {
+        // Proxy admin access checks are read-only. Any auth cookie refresh remains
+        // owned by Supabase/browser flows outside this PR slice.
+      },
+    },
+  });
+}
+
+async function getCurrentUser(request: NextRequest): Promise<AuthenticatedUser | null> {
+  const authSupabase = createRequestAuthClient(request);
+  if (!authSupabase) {
+    return null;
+  }
+
+  const { data, error } = await authSupabase.auth.getUser();
+  if (error || !data.user?.id) {
+    return null;
+  }
+
+  return { id: data.user.id };
+}
+
+async function fetchProfileRole(userId: string) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { kind: "error" as const };
+  }
+
+  const params = new URLSearchParams({
+    id: `eq.${userId}`,
+    select: "role",
+    limit: "1",
+  });
+
+  const response = await fetch(
+    `${supabaseUrl}/rest/v1/${ECOMMERCE_TABLES.userProfiles}?${params.toString()}`,
+    {
+      headers: {
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+        "Content-Type": "application/json",
+        "Accept-Profile": "ecommerce",
+      },
+      signal: AbortSignal.timeout(5000),
+    },
+  );
+
+  if (!response.ok) {
+    return { kind: "error" as const };
+  }
+
+  const data = await response.json();
+  const role = Array.isArray(data) && data[0]?.role ? String(data[0].role) : null;
+
+  return { kind: "role" as const, role };
+}
+
+export async function resolveAdminAccess(request: NextRequest): Promise<AdminAccessResult> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return { status: "guest", reason: "supabase_not_configured" };
+  }
+
+  const user = await getCurrentUser(request);
+  if (!user) {
+    return { status: "guest", reason: "no_user" };
+  }
+
+  try {
+    const profile = await fetchProfileRole(user.id);
+    if (profile.kind === "error") {
+      return { status: "error", userId: user.id, reason: "profile_lookup_failed" };
+    }
+
+    if (profile.role === "admin") {
+      return { status: "admin", userId: user.id };
+    }
+
+    return profile.role
+      ? { status: "non_admin", userId: user.id }
+      : { status: "non_admin", userId: user.id, reason: "missing_profile" };
+  } catch {
+    return { status: "error", userId: user.id, reason: "profile_lookup_failed" };
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { resolveStoreSubdomain } from '@/lib/utils/store-host'
+import { normalizeSafeAdminPath, resolveAdminAccess } from '@/lib/supabase/admin-access'
 
 // Variable de entorno para deshabilitar multi-tenant temporalmente
 const DISABLE_SUBDOMAIN_MULTI_TENANT = process.env.DISABLE_SUBDOMAIN_MULTI_TENANT === 'true'
@@ -20,6 +21,40 @@ interface Store {
 // Caché simple en memoria para las tiendas (evita consultas repetidas)
 const storeCache = new Map<string, { store: Store | null; timestamp: number }>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutos
+
+function isAdminRoute(pathname: string) {
+  return pathname === '/admin' || pathname.startsWith('/admin/')
+}
+
+async function applyAdminRouteGate(request: NextRequest, response: NextResponse) {
+  const { pathname, search } = request.nextUrl
+
+  if (!isAdminRoute(pathname)) {
+    return response
+  }
+
+  const access = await resolveAdminAccess(request)
+  if (access.status === 'admin') {
+    return response
+  }
+
+  const redirectUrl = request.nextUrl.clone()
+  redirectUrl.pathname = '/'
+  redirectUrl.search = ''
+
+  if (access.status === 'guest') {
+    const next = normalizeSafeAdminPath(`${pathname}${search}`) || '/admin'
+    redirectUrl.searchParams.set('auth', 'login')
+    redirectUrl.searchParams.set('next', next)
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  redirectUrl.searchParams.set(
+    'admin_access',
+    access.status === 'error' ? 'error' : 'denied',
+  )
+  return NextResponse.redirect(redirectUrl)
+}
 
 /**
  * Obtiene la tienda desde Supabase por subdominio (schema ecommerce, vista stores_legacy)
@@ -109,7 +144,7 @@ export async function proxy(request: NextRequest) {
       sameSite: 'lax',
     })
 
-    return response
+    return applyAdminRouteGate(request, response)
   }
 
   // Extraer subdominio
@@ -133,7 +168,7 @@ export async function proxy(request: NextRequest) {
         sameSite: 'lax',
       })
       
-      return response
+      return applyAdminRouteGate(request, response)
     }
     
     // Si no existe tienda por defecto, permitir continuar con valores por defecto
@@ -149,7 +184,7 @@ export async function proxy(request: NextRequest) {
       sameSite: 'lax',
     })
     
-    return response
+    return applyAdminRouteGate(request, response)
   }
 
   // Obtener información de la tienda
@@ -182,7 +217,7 @@ export async function proxy(request: NextRequest) {
     sameSite: 'lax',
   })
 
-  return response
+  return applyAdminRouteGate(request, response)
 }
 
 // Configurar qué rutas deben ejecutar el proxy

--- a/tests/auth/auth-callback-redirect.test.tsx
+++ b/tests/auth/auth-callback-redirect.test.tsx
@@ -1,0 +1,170 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerPush = vi.hoisted(() => vi.fn());
+const searchParamsGet = vi.hoisted(() => vi.fn());
+const exchangeCodeForSession = vi.hoisted(() => vi.fn());
+const getSession = vi.hoisted(() => vi.fn());
+const getCurrentUser = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  useSearchParams: () => ({ get: searchParamsGet }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  getSupabaseBrowserClient: () => ({
+    auth: {
+      exchangeCodeForSession,
+      getSession,
+    },
+  }),
+}));
+
+vi.mock("@/lib/supabase/auth-api", () => ({
+  getCurrentUser,
+}));
+
+import AuthCallback from "@/app/auth/callback/page";
+
+describe("auth callback safe return destinations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: null,
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
+    getSession.mockResolvedValue({ data: { session: null }, error: null });
+    getCurrentUser.mockResolvedValue({ success: true, user: { id: "admin-1", email: "admin@example.com", role: "admin" } });
+  });
+
+  it("returns an admin to a safe admin next destination after code exchange", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: "/admin/orders?status=open",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders?status=open");
+    });
+  });
+
+  it.each([
+    "https://evil.example/admin/orders",
+    "//evil.example/admin/orders",
+  ])("rejects unsafe external next destination %s and preserves confirmation success", async (unsafeNext) => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: unsafeNext,
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/auth/cuenta-confirmada");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith(expect.stringContaining("evil"));
+  });
+
+  it("does not send a non-admin user into an admin next destination", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: "auth-code",
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getCurrentUser.mockResolvedValue({ success: true, user: { id: "user-1", email: "user@example.com", role: "user" } });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?admin_access=denied");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith("/admin/orders");
+  });
+
+  it("preserves the callback error branch", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: "access_denied",
+        error_description: "Denied",
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?error=auth_callback_failed");
+    });
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("preserves the no-session branch when there is no code and no active session", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getSession.mockResolvedValue({ data: { session: null }, error: null });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?error=no_session");
+    });
+  });
+
+  it("uses a safe admin next destination for an existing admin session", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        code: null,
+        error: null,
+        error_description: null,
+        next: "/admin/orders",
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+    getSession.mockResolvedValue({ data: { session: { access_token: "existing" } }, error: null });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders");
+    });
+  });
+});

--- a/tests/components/header-login-return-intent.test.tsx
+++ b/tests/components/header-login-return-intent.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text -- Test-only next/image mock renders a native img. */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerPush = vi.hoisted(() => vi.fn());
+const searchParamsGet = vi.hoisted(() => vi.fn());
+const loginMock = vi.hoisted(() => vi.fn());
+const refreshUserMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  usePathname: () => "/",
+  useSearchParams: () => ({ get: searchParamsGet }),
+}));
+
+vi.mock("next/image", () => ({ default: ({ priority: _priority, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => <img {...props} /> }));
+vi.mock("next/link", () => ({ default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => <a href={href} {...props}>{children}</a> }));
+
+vi.mock("lucide-react", () => ({
+  Search: () => <span aria-hidden="true" />,
+  Heart: () => <span aria-hidden="true" />,
+  ShoppingCart: () => <span aria-hidden="true" />,
+  Palette: () => <span aria-hidden="true" />,
+  AlignLeft: () => <span aria-hidden="true" />,
+  Menu: () => <span aria-hidden="true" />,
+  LogIn: () => <span aria-hidden="true" />,
+  LogOut: () => <span aria-hidden="true" />,
+  User: () => <span aria-hidden="true" />,
+  Eye: () => <span aria-hidden="true" />,
+  EyeOff: () => <span aria-hidden="true" />,
+  CreditCard: () => <span aria-hidden="true" />,
+  Building2: () => <span aria-hidden="true" />,
+  Wallet: () => <span aria-hidden="true" />,
+  LayoutDashboard: () => <span aria-hidden="true" />,
+  Edit: () => <span aria-hidden="true" />,
+  Trash2: () => <span aria-hidden="true" />,
+  Plus: () => <span aria-hidden="true" />,
+  Minus: () => <span aria-hidden="true" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({ Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button> }));
+vi.mock("@/components/ui/input", () => ({ Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} /> }));
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SheetContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  SheetHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  SheetTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: React.PropsWithChildren<{ open?: boolean }>) => open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  AlertDialogAction: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogCancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("@/contexts/styles-context", () => ({ useComponentStyle: (_name: string, defaults: Record<string, string>) => ({ styles: defaults }) }));
+vi.mock("@/contexts/theme-context", () => ({ useTheme: () => ({ activeTheme: null }) }));
+vi.mock("@/contexts/store-context", () => ({ useStore: () => ({ store: null }) }));
+vi.mock("@/contexts/cart-context", () => ({ useCart: () => ({ items: [], removeFromCart: vi.fn(), updateQuantity: vi.fn(), getTotal: () => 0, getItemSubtotal: () => 0, getTotalItems: () => 0 }) }));
+vi.mock("@/contexts/wishlist-context", () => ({ useWishlist: () => ({ getTotalItems: () => 0 }) }));
+vi.mock("@/contexts/auth-context", () => ({ useAuth: () => ({ user: null, isAuthenticated: false, login: loginMock, register: vi.fn(), logout: vi.fn(), refreshUser: refreshUserMock }) }));
+vi.mock("@/contexts/language-context", () => ({
+  useLanguage: () => ({
+    t: {
+      auth: { login: "Iniciar sesión", createAccount: "Crear cuenta", signIn: "Entrar" },
+      header: {
+        sessionStarted: "Sesión iniciada",
+        welcomeAdminLogin: "Admin listo",
+        errorLoggingIn: "Error al iniciar sesión",
+        passwordsDoNotMatch: "Las contraseñas no coinciden",
+        passwordsDoNotMatchDescription: "Revisa las contraseñas",
+        confirmEmailSent: "Confirma tu correo",
+        confirmEmailDescription: "Te enviamos un correo",
+        accountCreated: "Cuenta creada",
+        welcomeAdminMessage: "Admin creado",
+        accountCreatedSuccess: "Cuenta creada",
+        errorCreatingAccount: "Error al crear cuenta",
+        loginRequired: "Login requerido",
+        loginRequiredDescription: "Debes iniciar sesión",
+        loginRequiredDescription2: "Continúa para comprar",
+      },
+      cart: { checkout: "Checkout" },
+      nav: { wishlist: "Wishlist", cart: "Cart" },
+    },
+  }),
+}));
+vi.mock("@/components/theme/theme-selector-modal", () => ({ ThemeSelectorModal: () => null }));
+vi.mock("@/components/font/font-selector-modal", () => ({ FontSelectorModal: () => null }));
+vi.mock("@/components/cart/checkout-options-dialog", () => ({ CheckoutOptionsDialog: () => null }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/supabase/auth-api", () => ({ resetPassword: vi.fn() }));
+
+import { Header } from "@/components/layout/header";
+
+describe("Header login return intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = { auth: "login", next: "/admin/orders" };
+      return values[key] ?? null;
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify([]), { status: 200 })));
+    loginMock.mockResolvedValue({ success: true, user: { id: "admin-1", email: "admin@example.com", role: "admin" } });
+    refreshUserMock.mockResolvedValue(undefined);
+  });
+
+  it("opens the login modal once for a safe admin return intent query", async () => {
+    const { rerender } = render(<Header />);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Iniciar sesión" })).toBeInTheDocument();
+
+    rerender(<Header />);
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+
+  it("routes an admin login to the safe next path once", async () => {
+    render(<Header />);
+
+    fireEvent.change(await screen.findByPlaceholderText("tu@email.com"), { target: { value: "admin@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("••••••••"), { target: { value: "secret123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/admin/orders");
+    });
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not route a non-admin login into the admin next path", async () => {
+    loginMock.mockResolvedValue({ success: true, user: { id: "user-1", email: "user@example.com", role: "user" } });
+    render(<Header />);
+
+    fireEvent.change(await screen.findByPlaceholderText("tu@email.com"), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("••••••••"), { target: { value: "secret123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/?admin_access=denied");
+    });
+    expect(routerPush).not.toHaveBeenCalledWith("/admin/orders");
+  });
+});

--- a/tests/components/route-aware-chrome.test.tsx
+++ b/tests/components/route-aware-chrome.test.tsx
@@ -1,12 +1,26 @@
 import type { ReactNode } from "react"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { renderToString } from "react-dom/server"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 let mockedPathname = "/"
+const routerPush = vi.hoisted(() => vi.fn())
+const logoutMock = vi.hoisted(() => vi.fn())
+const authState = vi.hoisted(() => ({
+  isAuthenticated: true,
+  isLoading: false,
+}))
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockedPathname,
+  useRouter: () => ({ push: routerPush }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({
+    ...authState,
+    logout: logoutMock,
+  }),
 }))
 
 vi.mock("@/components/layout/header", () => ({
@@ -83,7 +97,11 @@ describe("isAdminChromeRoute", () => {
 
 describe("RouteAwareChrome", () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     mockedPathname = "/"
+    authState.isAuthenticated = true
+    authState.isLoading = false
+    logoutMock.mockResolvedValue(undefined)
   })
 
   it("renders a stable server shell before the client pathname is resolved", () => {
@@ -100,6 +118,7 @@ describe("RouteAwareChrome", () => {
     expect(markup).not.toContain("Contact")
     expect(markup).not.toContain("Edit mode")
     expect(markup).not.toContain("Editor panel")
+    expect(markup).not.toContain("Cerrar sesión")
   })
 
   it("renders the root editable storefront chrome exactly once on public storefront routes", () => {
@@ -126,8 +145,29 @@ describe("RouteAwareChrome", () => {
       expect(screen.queryByTestId("floating-contact-button")).not.toBeInTheDocument()
       expect(screen.queryByTestId("edit-mode-toggle")).not.toBeInTheDocument()
       expect(screen.queryByTestId("editor-panel")).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /cerrar sesión/i })).toBeInTheDocument()
     },
   )
+
+  it("logs out from admin chrome routes without restoring the storefront header", async () => {
+    renderChrome("/admin/orders")
+
+    fireEvent.click(screen.getByRole("button", { name: /cerrar sesión/i }))
+
+    await waitFor(() => {
+      expect(logoutMock).toHaveBeenCalledTimes(1)
+    })
+    expect(routerPush).toHaveBeenCalledWith("/")
+    expect(screen.queryByTestId("storefront-header")).not.toBeInTheDocument()
+  })
+
+  it("does not render admin session actions for anonymous admin visitors", () => {
+    authState.isAuthenticated = false
+
+    renderChrome("/admin/orders")
+
+    expect(screen.queryByRole("button", { name: /cerrar sesión/i })).not.toBeInTheDocument()
+  })
 
   it("hides only the root chrome on /admin while preserving an embedded preview header from the route children", () => {
     renderChrome(

--- a/tests/contexts/admin-permissions-context.test.tsx
+++ b/tests/contexts/admin-permissions-context.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIsCurrentUserAdmin = vi.hoisted(() => vi.fn());
+const mockGetCurrentUserRole = vi.hoisted(() => vi.fn());
+const authState = vi.hoisted(() => ({
+  isLoading: false,
+  isAuthenticated: true,
+  user: { id: "admin-1", email: "admin@example.com" },
+}));
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/lib/supabase/permissions-api", () => ({
+  isCurrentUserAdmin: () => mockIsCurrentUserAdmin(),
+  getCurrentUserRole: () => mockGetCurrentUserRole(),
+}));
+
+import {
+  AdminPermissionsProvider,
+  useAdminPermissions,
+} from "@/contexts/admin-permissions-context";
+
+function Harness() {
+  const { isAdmin, role, loading, hasChecked } = useAdminPermissions();
+
+  return (
+    <div>
+      <div data-testid="is-admin">{String(isAdmin)}</div>
+      <div data-testid="role">{role ?? "none"}</div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="has-checked">{String(hasChecked)}</div>
+    </div>
+  );
+}
+
+function renderHarness() {
+  return render(
+    <AdminPermissionsProvider>
+      <Harness />
+    </AdminPermissionsProvider>,
+  );
+}
+
+describe("AdminPermissionsProvider deny-until-verified fallback", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    authState.isLoading = false;
+    authState.isAuthenticated = true;
+    authState.user = { id: "admin-1", email: "admin@example.com" };
+    mockIsCurrentUserAdmin.mockResolvedValue(true);
+    mockGetCurrentUserRole.mockResolvedValue("admin");
+  });
+
+  it("keeps permissions loading until the authenticated user's admin role is verified", async () => {
+    let resolveAdmin!: (value: boolean) => void;
+    let resolveRole!: (value: string) => void;
+    mockIsCurrentUserAdmin.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAdmin = resolve;
+      }),
+    );
+    mockGetCurrentUserRole.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRole = resolve;
+      }),
+    );
+
+    renderHarness();
+
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    expect(screen.getByTestId("has-checked")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
+
+    resolveAdmin(true);
+    resolveRole("admin");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("has-checked")).toHaveTextContent("true");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    expect(screen.getByTestId("role")).toHaveTextContent("admin");
+  });
+
+  it("rechecks permissions when the authenticated user id changes so stale admin state cannot leak", async () => {
+    const { rerender } = renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("true");
+    expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(1);
+
+    mockIsCurrentUserAdmin.mockResolvedValue(false);
+    mockGetCurrentUserRole.mockResolvedValue("user");
+    authState.user = { id: "customer-1", email: "customer@example.com" };
+
+    rerender(
+      <AdminPermissionsProvider>
+        <Harness />
+      </AdminPermissionsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("has-checked")).toHaveTextContent("true");
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
+    expect(screen.getByTestId("role")).toHaveTextContent("user");
+  });
+});

--- a/tests/contexts/admin-permissions-context.test.tsx
+++ b/tests/contexts/admin-permissions-context.test.tsx
@@ -118,4 +118,52 @@ describe("AdminPermissionsProvider deny-until-verified fallback", () => {
     expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
     expect(screen.getByTestId("role")).toHaveTextContent("user");
   });
+
+  it("ignores a stale admin verification that resolves after the authenticated user changes", async () => {
+    let resolveFirstAdmin!: (value: boolean) => void;
+    let resolveFirstRole!: (value: string) => void;
+    mockIsCurrentUserAdmin
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstAdmin = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(false);
+    mockGetCurrentUserRole
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstRole = resolve;
+        }),
+      )
+      .mockResolvedValueOnce("user");
+
+    const { rerender } = renderHarness();
+
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    await waitFor(() => {
+      expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(1);
+    });
+
+    authState.user = { id: "customer-1", email: "customer@example.com" };
+
+    rerender(
+      <AdminPermissionsProvider>
+        <Harness />
+      </AdminPermissionsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockIsCurrentUserAdmin).toHaveBeenCalledTimes(2);
+    });
+
+    resolveFirstAdmin(true);
+    resolveFirstRole("admin");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("has-checked")).toHaveTextContent("true");
+    expect(screen.getByTestId("is-admin")).toHaveTextContent("false");
+    expect(screen.getByTestId("role")).toHaveTextContent("user");
+  });
 });

--- a/tests/proxy/admin-route-guard.test.ts
+++ b/tests/proxy/admin-route-guard.test.ts
@@ -33,13 +33,14 @@ function mockStoreFetch() {
 
 describe("proxy admin route guard", () => {
   let fetchMock: ReturnType<typeof mockStoreFetch>;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let restoreConsoleError: () => void;
 
   beforeEach(() => {
     vi.resetModules();
     fetchMock = mockStoreFetch();
     vi.stubGlobal("fetch", fetchMock);
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    restoreConsoleError = () => errorSpy.mockRestore();
     process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
     process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
@@ -51,7 +52,7 @@ describe("proxy admin route guard", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
-    errorSpy.mockRestore();
+    restoreConsoleError();
   });
 
   it("redirects a guest /admin/orders request before render with login intent", async () => {

--- a/tests/proxy/admin-route-guard.test.ts
+++ b/tests/proxy/admin-route-guard.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const defaultStore = {
+  id: "84f0a892-cf12-4826-befd-cf64e1235123",
+  subdomain: "default",
+  store_name: "Tienda Principal",
+  domain: "example.com",
+  is_active: true,
+  is_public: true,
+};
+
+const resolveAdminAccessMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin-access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin-access")>();
+
+  return {
+    ...actual,
+    resolveAdminAccess: resolveAdminAccessMock,
+  };
+});
+
+function makeRequest(pathname: string) {
+  return new NextRequest(`http://localhost:3000${pathname}`, {
+    headers: { host: "localhost:3000" },
+  });
+}
+
+function mockStoreFetch() {
+  return vi.fn(async () => new Response(JSON.stringify([defaultStore]), { status: 200 }));
+}
+
+describe("proxy admin route guard", () => {
+  let fetchMock: ReturnType<typeof mockStoreFetch>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = mockStoreFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+    delete process.env.DISABLE_SUBDOMAIN_MULTI_TENANT;
+    delete process.env.DEFAULT_STORE_ID;
+    resolveAdminAccessMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    errorSpy.mockRestore();
+  });
+
+  it("redirects a guest /admin/orders request before render with login intent", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "guest" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?auth=login&next=%2Fadmin%2Forders",
+    );
+  });
+
+  it("redirects a non-admin safely with denied feedback", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "non_admin", userId: "customer-1" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?admin_access=denied",
+    );
+  });
+
+  it("passes an admin through while preserving store headers and cookies", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "admin", userId: "admin-1" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-store-id")).toBe(defaultStore.id);
+    expect(response.headers.get("x-store-subdomain")).toBe("default");
+    expect(response.headers.get("set-cookie")).toContain(`store_id=${defaultStore.id}`);
+  });
+
+  it("treats an expired or missing user as a login redirect", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "guest", reason: "no_user" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?auth=login&next=%2Fadmin",
+    );
+  });
+
+  it("redirects lookup and service errors to safe error feedback", async () => {
+    resolveAdminAccessMock.mockResolvedValue({ status: "error", reason: "profile_lookup_failed" });
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(makeRequest("/admin/orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?admin_access=error",
+    );
+  });
+
+  it.each(["/", "/checkout", "/dashboard"])(
+    "leaves %s unaffected by the admin proxy gate",
+    async (path) => {
+      const { proxy } = await import("@/proxy");
+
+      const response = await proxy(makeRequest(path));
+
+      expect(resolveAdminAccessMock).not.toHaveBeenCalled();
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.headers.get("x-store-subdomain")).toBe("default");
+    },
+  );
+});

--- a/tests/security/admin-access.test.ts
+++ b/tests/security/admin-access.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const getUserMock = vi.fn();
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: getUserMock },
+  })),
+}));
+
+function makeRequest(pathname = "/admin/orders") {
+  return new NextRequest(`http://localhost:3000${pathname}`, {
+    headers: { host: "localhost:3000" },
+  });
+}
+
+describe("admin access resolver", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role");
+    getUserMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ["/admin/orders", "/admin/orders"],
+    ["/admin/orders?status=open", "/admin/orders?status=open"],
+    ["//evil.com/admin", null],
+    ["https://evil.com/admin", null],
+    ["/auth/callback?next=/admin", null],
+    ["/?admin_access=denied", null],
+  ])("normalizes safe admin return target %s", async (input, expected) => {
+    const { normalizeSafeAdminPath } = await import("@/lib/supabase/admin-access");
+
+    expect(normalizeSafeAdminPath(input)).toBe(expected);
+  });
+
+  it("returns guest when Supabase auth has no current user", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "guest",
+      reason: "no_user",
+    });
+  });
+
+  it("returns admin for a user with ecommerce.user_profiles.role admin", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify([{ role: "admin" }]), { status: 200 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "admin",
+      userId: "admin-1",
+    });
+  });
+
+  it("returns non_admin for an authenticated non-admin profile", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "customer-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify([{ role: "customer" }]), { status: 200 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "non_admin",
+      userId: "customer-1",
+    });
+  });
+
+  it("returns error when the service-role profile lookup fails", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } }, error: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ message: "boom" }), { status: 500 })),
+    );
+    const { resolveAdminAccess } = await import("@/lib/supabase/admin-access");
+
+    await expect(resolveAdminAccess(makeRequest())).resolves.toEqual({
+      status: "error",
+      userId: "admin-1",
+      reason: "profile_lookup_failed",
+    });
+  });
+});


### PR DESCRIPTION
Closes #35

## Summary
- Consolidates the previous issue #35 stacked chain (#55, #56, #57) into one reviewable PR against `New-Features`.
- Gates `/admin*` routes in proxy/server access resolution, preserves safe login return intent, and revalidates residual admin fallback state by user.
- Keeps the runtime/manual QA notes from the final slice in `docs/auth/issue-35-safe-role-redirects-runtime.md`.

## Changes
| File | Change |
|------|--------|
| `proxy.ts` | Adds admin-route gate and safe redirect behavior. |
| `lib/supabase/admin-access.ts` | Adds shared admin access resolver. |
| `lib/auth-return-intent.ts` | Adds safe return-intent parsing/building. |
| `app/auth/callback/page.tsx` | Preserves approved return intent through auth callback. |
| `components/layout/header.tsx` | Sends login users through safe return intent. |
| `contexts/admin-permissions-context.tsx` | Revalidates fallback permission state by user. |
| `tests/**` | Adds focused regression coverage for proxy, auth callback, header, admin access, and fallback context. |
| `docs/auth/issue-35-safe-role-redirects-runtime.md` | Documents runtime/manual QA expectations. |

## Test Plan
- [x] Consolidated from previously green PRs #55, #56, and #57.
- [x] `git diff --check origin/New-Features...HEAD`
- [x] Prior recorded full-suite evidence: `corepack pnpm test` passed 44 files / 263 tests after the final slice.
- [ ] Vercel/GitHub checks on this consolidated PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Supersedes #55, #56, and #57.
