### PR TITLE
feat(products): consolidate configurable home cards

### DIFF
--- a/app/catalog/[category]/page.tsx
+++ b/app/catalog/[category]/page.tsx
@@ -97,6 +97,9 @@ async function CategoryContent({ categorySlug }: { categorySlug: string }) {
       name: item.item_name,
       category: category.category_name,
       price: formatPrice(item.base_price, item.currency_code),
+      compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+        ? formatPrice(item.compare_at_price, item.currency_code)
+        : undefined,
       image: item.primary_image_url || "/placeholder.svg",
       slug: item.item_slug || item.id,
     }))

--- a/app/catalog/earphones/page.tsx
+++ b/app/catalog/earphones/page.tsx
@@ -37,6 +37,9 @@ async function EarphonesContent() {
         name: item.item_name,
         category: item.category?.category_name || "Earphones",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -47,6 +47,9 @@ async function CategorySection({ categoryId, categoryName, storeId }: { category
       name: item.item_name,
       category: categoryName,
       price: formatPrice(item.base_price, item.currency_code),
+      compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+        ? formatPrice(item.compare_at_price, item.currency_code)
+        : undefined,
       image: item.primary_image_url || "/placeholder.svg",
       slug: item.item_slug || item.id,
     }))

--- a/app/catalog/projectors/page.tsx
+++ b/app/catalog/projectors/page.tsx
@@ -35,6 +35,9 @@ async function ProjectorsContent() {
         name: item.item_name,
         category: item.category?.category_name || "Projectors",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/speakers/page.tsx
+++ b/app/catalog/speakers/page.tsx
@@ -36,6 +36,9 @@ async function SpeakersContent() {
         name: item.item_name,
         category: item.category?.category_name || "Speakers",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/app/catalog/stands/page.tsx
+++ b/app/catalog/stands/page.tsx
@@ -35,6 +35,9 @@ async function StandsContent() {
         name: item.item_name,
         category: item.category?.category_name || "Stands",
         price: formatPrice(item.base_price, item.currency_code),
+        compareAtPrice: item.compare_at_price && Number(item.compare_at_price) > Number(item.base_price)
+          ? formatPrice(item.compare_at_price, item.currency_code)
+          : undefined,
         image: item.primary_image_url || "/placeholder.svg",
         slug: item.item_slug || item.id,
       }))

--- a/components/catalog/catalog-products-list.tsx
+++ b/components/catalog/catalog-products-list.tsx
@@ -1,21 +1,52 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { VisualProductCard } from "@/components/products/visual-product-card"
 import { useQuantityModal } from "@/hooks/use-quantity-modal"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 interface Product {
   id: string
   name: string
   category: string
   price: string
+  compareAtPrice?: string
   image: string
   slug?: string
 }
 
 interface CatalogProductsListProps {
   products: Product[]
+}
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+}
+
+function toCard(product: Product): CommerceProductCard {
+  const slug = product.slug || generateSlug(product.name)
+  return {
+    id: product.id,
+    title: product.name,
+    href: `/products/${slug}`,
+    imageUrl: product.image || undefined,
+    imageAlt: product.name,
+    category: product.category,
+    price: {
+      amount: 0,
+      currencyCode: "COP",
+      label: product.price,
+      compareAtLabel: product.compareAtPrice,
+      hasDiscount: Boolean(product.compareAtPrice),
+    },
+    badges: product.compareAtPrice ? [{ label: "Oferta", tone: "sale" }] : [],
+    ctaLabel: "Ver detalles",
+  }
 }
 
 export function CatalogProductsList({ products }: CatalogProductsListProps) {
@@ -32,86 +63,30 @@ export function CatalogProductsList({ products }: CatalogProductsListProps) {
   return (
     <>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8">
-        {products.map((product) => {
-          const productSlug = product.slug || product.name
-            .toLowerCase()
-            .normalize("NFD")
-            .replace(/[\u0300-\u036f]/g, "")
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/(^-|-$)/g, "")
-          
-          return (
-            <div
-              key={product.id}
-              className="group relative rounded-2xl overflow-hidden hover:shadow-xl transition-all duration-300"
-              style={{ backgroundColor: "var(--card)" }}
-            >
-              {/* Product Image */}
-              <Link href={`/products/${productSlug}`}>
-                <div
-                  className="aspect-square flex items-center justify-center p-6 relative overflow-hidden cursor-pointer"
-                  style={{ backgroundColor: "var(--background)" }}
-                >
-                  <img
-                    src={product.image || "/placeholder.svg"}
-                    alt={product.name}
-                    className="w-full h-full object-contain transition-transform duration-300 group-hover:scale-110"
-                  />
-                </div>
-              </Link>
-
-              {/* Product Info */}
-              <div className="p-4 md:p-6">
-                <p className="text-sm md:text-base font-inter font-medium mb-1" style={{ color: "var(--muted-foreground)" }}>
-                  {product.category}
-                </p>
-                <Link href={`/products/${productSlug}`}>
-                  <h3 className="text-lg md:text-xl font-inter font-semibold mb-3 hover:text-primary transition-colors cursor-pointer" style={{ color: "var(--card-foreground)" }}>
-                    {product.name}
-                  </h3>
-                </Link>
-                
-                {/* Pricing */}
-                <div className="flex items-center gap-3 mb-4">
-                  <span className="text-xl md:text-2xl font-inter font-bold" style={{ color: "var(--primary)" }}>
-                    {product.price}
-                  </span>
-                </div>
-
-                {/* Add to Cart Button */}
-                <Button
-                  className="w-full"
-                  style={{
-                    backgroundColor: "var(--primary)",
-                    color: "var(--primary-foreground)",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.opacity = "0.9"
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.opacity = "1"
-                  }}
-                  onClick={() => {
-                    openModal({
-                      id: product.id,
-                      name: product.name,
-                      price: product.price,
-                      image: product.image,
-                      category: product.category,
-                    })
-                  }}
-                >
-                  Agregar al carrito
-                </Button>
-              </div>
-            </div>
-          )
-        })}
+        {products.map((product) => (
+          <VisualProductCard
+            key={product.id}
+            product={toCard(product)}
+            actionSlot={(
+              <Button
+                className="w-full"
+                style={{ backgroundColor: "var(--primary)", color: "var(--primary-foreground)" }}
+                onClick={() => openModal({
+                  id: product.id,
+                  name: product.name,
+                  price: product.price,
+                  image: product.image,
+                  category: product.category,
+                })}
+              >
+                Agregar al carrito
+              </Button>
+            )}
+          />
+        ))}
       </div>
 
-      {/* Modal de cantidad */}
       {QuantityModalComponent}
     </>
   )
 }
-

--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import Link from "next/link"
+import { VisualProductCard } from "@/components/products/visual-product-card"
+import { normalizeCommercePrice } from "@/lib/products/adapter"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 interface Product {
   id: string
@@ -26,39 +25,25 @@ function generateSlug(name: string): string {
 
 export function ProductCard({ product }: { product: Product }) {
   const productSlug = product.slug || generateSlug(product.name)
+  const price = normalizeCommercePrice(product.price, "COP", product.originalPrice)
+  const card: CommerceProductCard = {
+    id: product.id,
+    title: product.name,
+    description: product.description,
+    href: `/products/${productSlug}`,
+    imageUrl: product.image || "/placeholder.svg",
+    imageAlt: product.name,
+    price,
+    badges: [
+      ...(product.badge ? [{ label: product.badge, tone: "default" as const }] : []),
+      ...(price.hasDiscount ? [{ label: "VENTA", tone: "sale" as const }] : []),
+    ],
+    ctaLabel: "Ver detalles",
+  }
   
   return (
-    <div className="bg-card rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-      <Link href={`/products/${productSlug}`} className="block">
-        <div className="relative aspect-square cursor-pointer">
-          <img src={product.image || "/placeholder.svg"} alt={product.name} className="w-full h-full object-cover" />
-          {product.badge && (
-            <Badge className="absolute top-2 right-2 bg-primary text-primary-foreground">{product.badge}</Badge>
-          )}
-          {product.originalPrice && <Badge className="absolute top-2 left-2 bg-destructive text-white">VENTA</Badge>}
-        </div>
-      </Link>
-      <div className="p-4">
-        <Link href={`/products/${productSlug}`}>
-          <h3 className="text-lg font-bold text-foreground mb-2 hover:text-primary transition-colors cursor-pointer">{product.name}</h3>
-        </Link>
-        <p className="text-sm text-muted-foreground mb-4">{product.description}</p>
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <span className="text-xl font-bold text-primary">${product.price.toLocaleString("es-CO")}</span>
-            {product.originalPrice && (
-              <span className="text-sm text-muted-foreground line-through ml-2">
-                ${product.originalPrice.toLocaleString("es-CO")}
-              </span>
-            )}
-          </div>
-        </div>
-        <Button className="w-full bg-primary hover:bg-primary/90 text-primary-foreground" asChild>
-          <Link href={`/products/${productSlug}`}>
-            Ver detalles
-          </Link>
-        </Button>
-      </div>
-    </div>
+    <VisualProductCard
+      product={card}
+    />
   )
 }

--- a/components/products/visual-product-card-image.tsx
+++ b/components/products/visual-product-card-image.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+/* eslint-disable @next/next/no-img-element -- Storefront product media can be tenant-provided remote URLs; Next image migration is outside this UI-slice scope. */
+import { useState } from "react"
+
+interface VisualProductCardImageProps {
+  src?: string
+  alt: string
+  title: string
+  isOverlay: boolean
+}
+
+export function VisualProductCardImage({
+  src,
+  alt,
+  title,
+  isOverlay,
+}: VisualProductCardImageProps) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null)
+
+  if (!src || failedImageUrl === src) {
+    return (
+      <div
+        role="img"
+        aria-label={`Sin imagen para ${title}`}
+        className="flex h-full w-full items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/40 px-4 text-center text-sm text-muted-foreground"
+      >
+        Sin imagen
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`h-full w-full ${isOverlay ? "object-cover transition-transform duration-300 group-hover:scale-105" : "object-contain"}`}
+      onError={() => {
+        setFailedImageUrl(src)
+      }}
+    />
+  )
+}

--- a/components/products/visual-product-card.tsx
+++ b/components/products/visual-product-card.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable @next/next/no-img-element -- Storefront product media can be tenant-provided remote URLs; Next image migration is outside this UI-slice scope. */
+import Link from "next/link"
+import type { ReactNode } from "react"
+import type { CommerceProductBadge, CommerceProductCard } from "@/lib/types/products"
+
+interface VisualProductCardProps {
+  product: CommerceProductCard
+  variant?: "grid" | "compact" | "overlay"
+  showCta?: boolean
+  favoriteSlot?: ReactNode
+  actionSlot?: ReactNode
+  className?: string
+}
+
+const badgeToneClass: Record<NonNullable<CommerceProductBadge["tone"]>, string> = {
+  default: "bg-primary text-primary-foreground",
+  sale: "bg-destructive text-white",
+  combo: "bg-primary text-primary-foreground",
+}
+
+export function VisualProductCard({
+  product,
+  variant = "grid",
+  showCta = true,
+  favoriteSlot,
+  actionSlot,
+  className = "",
+}: VisualProductCardProps) {
+  const isOverlay = variant === "overlay"
+  const imageAlt = product.imageAlt || product.title
+  const imageContent = product.imageUrl ? (
+    <img
+      src={product.imageUrl}
+      alt={imageAlt}
+      className={`h-full w-full ${isOverlay ? "object-cover transition-transform duration-300 group-hover:scale-105" : "object-contain"}`}
+    />
+  ) : (
+    <div
+      role="img"
+      aria-label={`Sin imagen para ${product.title}`}
+      className="flex h-full w-full items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/40 px-4 text-center text-sm text-muted-foreground"
+    >
+      Sin imagen
+    </div>
+  )
+
+  return (
+    <article
+      className={`group relative overflow-hidden rounded-2xl border border-border/60 bg-card text-card-foreground shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl focus-within:ring-2 focus-within:ring-primary/50 ${className}`}
+    >
+      <div className="absolute left-3 top-3 z-10 flex flex-wrap gap-2">
+        {product.badges.map((badge) => (
+          <span
+            key={`${badge.tone || "default"}-${badge.label}`}
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-sm ${badgeToneClass[badge.tone || "default"]}`}
+          >
+            {badge.label}
+          </span>
+        ))}
+      </div>
+
+      {favoriteSlot ? (
+        <div className="absolute right-3 top-3 z-20">{favoriteSlot}</div>
+      ) : null}
+
+      <Link
+        href={product.href}
+        className="block focus-visible:outline-none"
+        aria-label={`Ver ${product.title}`}
+      >
+        <div
+          className={`${isOverlay ? "aspect-[4/3]" : "aspect-square"} flex items-center justify-center bg-background p-4`}
+        >
+          {imageContent}
+        </div>
+      </Link>
+
+      <div className="space-y-3 p-4 sm:p-5">
+        {product.category ? (
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {product.category}
+          </p>
+        ) : null}
+
+        <Link href={product.href} className="block focus-visible:outline-none">
+          <h3 className="line-clamp-2 text-base font-semibold leading-snug transition-colors hover:text-primary md:text-lg">
+            {product.title}
+          </h3>
+        </Link>
+
+        {product.description ? (
+          <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+            {product.description}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="text-xl font-bold text-primary">{product.price.label}</span>
+          {product.price.compareAtLabel ? (
+            <span className="text-sm font-medium text-muted-foreground line-through">
+              {product.price.compareAtLabel}
+            </span>
+          ) : null}
+        </div>
+
+        {actionSlot ? <div>{actionSlot}</div> : null}
+
+        {showCta && product.ctaLabel ? (
+          <Link
+            href={product.href}
+            className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {product.ctaLabel}
+          </Link>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/components/products/visual-product-card.tsx
+++ b/components/products/visual-product-card.tsx
@@ -1,6 +1,6 @@
-/* eslint-disable @next/next/no-img-element -- Storefront product media can be tenant-provided remote URLs; Next image migration is outside this UI-slice scope. */
 import Link from "next/link"
 import type { ReactNode } from "react"
+import { VisualProductCardImage } from "@/components/products/visual-product-card-image"
 import type { CommerceProductBadge, CommerceProductCard } from "@/lib/types/products"
 
 interface VisualProductCardProps {
@@ -28,21 +28,6 @@ export function VisualProductCard({
 }: VisualProductCardProps) {
   const isOverlay = variant === "overlay"
   const imageAlt = product.imageAlt || product.title
-  const imageContent = product.imageUrl ? (
-    <img
-      src={product.imageUrl}
-      alt={imageAlt}
-      className={`h-full w-full ${isOverlay ? "object-cover transition-transform duration-300 group-hover:scale-105" : "object-contain"}`}
-    />
-  ) : (
-    <div
-      role="img"
-      aria-label={`Sin imagen para ${product.title}`}
-      className="flex h-full w-full items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/40 px-4 text-center text-sm text-muted-foreground"
-    >
-      Sin imagen
-    </div>
-  )
 
   return (
     <article
@@ -71,7 +56,12 @@ export function VisualProductCard({
         <div
           className={`${isOverlay ? "aspect-[4/3]" : "aspect-square"} flex items-center justify-center bg-background p-4`}
         >
-          {imageContent}
+          <VisualProductCardImage
+            src={product.imageUrl}
+            alt={imageAlt}
+            title={product.title}
+            isOverlay={isOverlay}
+          />
         </div>
       </Link>
 

--- a/components/sections/popular-items-wrapper.tsx
+++ b/components/sections/popular-items-wrapper.tsx
@@ -1,19 +1,18 @@
 import { PopularItems } from "./popular-items"
+import { toCommerceProductCard } from "@/lib/products/adapter"
 import { getFeaturedItems } from "@/lib/supabase/products-api"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 // Deshabilitar caché para asegurar que siempre se obtengan los productos más recientes
 export const revalidate = 0
 export const dynamic = 'force-dynamic'
 
 export async function PopularItemsWrapper() {
-  // Obtener productos destacados de la base de datos
-  let featuredProducts: Array<{ id: string; title: string; price: string; image: string; slug: string }> = []
-  
+  let featuredProducts: CommerceProductCard[] = []
+
   try {
-    // Primero intentar obtener productos destacados
     let items = await getFeaturedItems(10)
-    
-    // Si no hay productos destacados, obtener productos activos y disponibles
+
     if (items.length === 0) {
       const { getItems } = await import('@/lib/supabase/products-api')
       const result = await getItems({
@@ -25,43 +24,13 @@ export async function PopularItemsWrapper() {
       })
       items = result.items
     }
-    
-    // Mapear productos asegurando que todos tengan slug válido
+
     featuredProducts = items
-      .filter(item => item.item_slug || item.id) // Solo productos con slug o ID válido
-      .map(item => ({
-        id: item.id,
-        title: item.item_name,
-        price: item.compare_at_price && parseFloat(String(item.compare_at_price)) > parseFloat(String(item.base_price))
-          ? `Desde ${formatPrice(item.base_price, item.currency_code)}`
-          : `${formatPrice(item.base_price, item.currency_code)}`,
-        // Asegurar que siempre se use la URL completa de la imagen
-        image: item.primary_image_url && item.primary_image_url.trim() !== "" 
-          ? item.primary_image_url 
-          : "/placeholder.svg",
-        // Asegurar que siempre haya un slug válido (priorizar item_slug, luego ID)
-        slug: item.item_slug || item.id,
-      }))
-    
-    console.log('[PopularItemsWrapper] Productos obtenidos de BD:', featuredProducts.length, 'productos')
-    if (featuredProducts.length > 0) {
-      console.log('[PopularItemsWrapper] Primer producto:', featuredProducts[0]?.title, 'Slug:', featuredProducts[0]?.slug)
-    }
+      .filter(item => item.item_slug || item.id)
+      .map(toCommerceProductCard)
   } catch (error) {
     console.error('Error fetching products:', error)
   }
 
   return <PopularItems initialProducts={featuredProducts} />
 }
-
-// Helper para formatear precio
-function formatPrice(price: number | string, currencyCode: string = "COP"): string {
-  const numPrice = typeof price === 'string' ? parseFloat(price) : price
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(numPrice)
-}
-

--- a/components/sections/popular-items.tsx
+++ b/components/sections/popular-items.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner"
 import { QuantityModal } from "@/components/cart/quantity-modal"
 import { useLanguage } from "@/contexts/language-context"
 import { deferStateUpdate } from "@/lib/react/defer-state-update"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 // Helper para generar slug desde el título
 function generateSlug(title: string): string {
@@ -80,13 +81,16 @@ function ItemImageWithFallback({ src, alt }: { src: string; alt: string }) {
 }
 
 interface PopularItemsProps {
-  initialProducts?: Array<{
-    id: string
-    title: string
-    price: string
-    image: string
-    slug?: string
-  }>
+  initialProducts?: CommerceProductCard[]
+}
+
+type PopularCardItem = {
+  id?: string
+  title: string
+  price: string
+  compareAtPrice?: string
+  image?: string
+  slug?: string
 }
 
 export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
@@ -106,15 +110,6 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
   const title = edits.title ?? styleData.title ?? "Lo más vendido"
   const bgColor = edits.bgColor ?? styleData.bgColor
   const textColor = edits.textColor ?? styleData.textColor
-  
-  // Debug: Log para ver qué datos se están cargando
-  useEffect(() => {
-    console.log('[PopularItems] styleData:', styleData)
-    console.log('[PopularItems] edits:', edits)
-    console.log('[PopularItems] styleData.items:', styleData.items)
-    console.log('[PopularItems] edits.items:', edits.items)
-    console.log('[PopularItems] initialProducts:', initialProducts)
-  }, [styleData, edits, initialProducts])
   
   // Detectar si es tienda de repostería
   const isReposteria = store?.subdomain === 'reposteria'
@@ -218,18 +213,16 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
   const items = useMemo(() => {
     // PRIMERO: Usar productos de BD si existen (tienen prioridad para asegurar páginas reales)
     if (initialProducts && initialProducts.length > 0) {
-      console.log('[PopularItems] Usando productos de BD:', initialProducts.length, 'productos')
       return initialProducts.map((p, index) => ({
         title: p.title,
-        price: p.price,
-        // Usar la imagen del producto de BD si existe, solo usar imagen de repostería como fallback
-        image: p.image && p.image !== "/placeholder.svg" 
-          ? p.image 
-          : (isReposteria 
+        price: p.price.label,
+        compareAtPrice: p.price.compareAtLabel,
+        image: p.imageUrl && p.imageUrl !== "/placeholder.svg"
+          ? p.imageUrl
+          : (isReposteria
               ? (reposteriaImages[index % reposteriaImages.length] || "/placeholder.svg")
               : "/placeholder.svg"),
-        // Asegurar que siempre se use el slug de la BD (p.slug viene de item_slug o id)
-        slug: p.slug || p.id || generateSlug(p.title),
+        slug: p.href.replace(/^\/products\//, "") || p.id,
         id: p.id,
       }))
     }
@@ -239,16 +232,14 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
     const savedItems = edits.items ?? styleData.items
     if (savedItems && Array.isArray(savedItems) && savedItems.length > 0) {
       // Filtrar items guardados que tengan slug o ID válido
-      const validSavedItems = savedItems.filter((item: any) => item.slug || item.id)
+      const validSavedItems = savedItems.filter((item: PopularCardItem) => item.slug || item.id)
       if (validSavedItems.length > 0) {
-        console.log('[PopularItems] Usando items guardados válidos:', validSavedItems.length, 'items')
         return validSavedItems
       }
     }
     
     // TERCERO: Si no hay productos de BD ni items guardados válidos, usar defaults
     // (solo como último recurso, pero estos también tienen slugs ahora)
-    console.log('[PopularItems] Usando items por defecto (último recurso)')
     return defaultItems
   }, [defaultItems, edits.items, initialProducts, isReposteria, reposteriaImages, styleData.items])
   
@@ -327,7 +318,7 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
             className="w-full"
           >
             <CarouselContent className="-ml-2 md:-ml-4">
-              {items.map((item: any, index: number) => {
+              {items.map((item: PopularCardItem, index: number) => {
                 // Priorizar: slug de BD > id > slug generado desde título
                 const itemSlug = item.slug || item.id || generateSlug(item.title)
                 const itemId = item.id || initialProducts?.[index]?.id || `popular-${index}`
@@ -368,7 +359,7 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
                               id: itemId,
                               name: item.title,
                               price: item.price,
-                              image: item.image,
+                              image: item.image || "/placeholder.svg",
                             })
                             setQuantityModalOpen(true)
                           }}
@@ -396,6 +387,9 @@ export function PopularItems({ initialProducts }: PopularItemsProps = {}) {
                         <Link href={`/products/${itemSlug}`} className="pointer-events-auto block">
                           <h3 className="text-white text-xl md:text-[31.1153px] font-inter font-medium mb-2 hover:underline">{item.title}</h3>
                           <p className="text-white/90 text-sm md:text-[15.447px] font-inter font-medium">{item.price}</p>
+                          {item.compareAtPrice && (
+                            <p className="text-white/70 text-xs md:text-sm font-inter font-medium line-through">{item.compareAtPrice}</p>
+                          )}
                         </Link>
                       </div>
                     </div>

--- a/components/sections/products-grid-wrapper.tsx
+++ b/components/sections/products-grid-wrapper.tsx
@@ -1,9 +1,11 @@
 import { ProductsGrid } from "./products-grid"
+import { toCommerceProductCard } from "@/lib/products/adapter"
 import { getItems } from "@/lib/supabase/products-api"
+import type { CommerceProductCard } from "@/lib/types/products"
 
 export async function ProductsGridWrapper() {
   // Obtener productos de la base de datos
-  let products: Array<{ id: string; name: string; category: string; price: string; image: string; slug: string }> = []
+  let products: CommerceProductCard[] = []
   
   try {
     const result = await getItems({
@@ -14,29 +16,10 @@ export async function ProductsGridWrapper() {
       order_direction: 'asc',
     })
     
-    products = result.items.map(item => ({
-      id: item.id,
-      name: item.item_name,
-      category: item.category?.category_name || "Sin categoría",
-      price: formatPrice(item.base_price, item.currency_code),
-      image: item.primary_image_url || "/placeholder.svg",
-      slug: item.item_slug || item.id,
-    }))
+    products = result.items.map(toCommerceProductCard)
   } catch (error) {
     console.error('Error fetching products:', error)
   }
 
   return <ProductsGrid initialProducts={products} />
 }
-
-// Helper para formatear precio
-function formatPrice(price: number | string, currencyCode: string = "COP"): string {
-  const numPrice = typeof price === 'string' ? parseFloat(price) : price
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(numPrice)
-}
-

--- a/components/sections/products-grid.tsx
+++ b/components/sections/products-grid.tsx
@@ -1,11 +1,11 @@
-/* eslint-disable @next/next/no-img-element -- Existing dynamic storefront images intentionally use native img in these legacy components; converting all to next/image is outside the global-gates cleanup risk budget. */
 "use client"
 
-import Link from "next/link"
 import { useComponentStyle } from "@/contexts/styles-context"
 import { useAdmin } from "@/contexts/admin-context"
 import { useStore } from "@/contexts/store-context"
-import { useState } from "react"
+import { VisualProductCard } from "@/components/products/visual-product-card"
+import { normalizeCommercePrice } from "@/lib/products/adapter"
+import type { CommerceProductBadge, CommerceProductCard, CommerceProductPrice } from "@/lib/types/products"
 
 // Helper para generar slug desde el nombre
 function generateSlug(name: string): string {
@@ -17,52 +17,58 @@ function generateSlug(name: string): string {
     .replace(/(^-|-$)/g, "")
 }
 
-// Componente Image con fallback automático a placeholder
-function ProductImageWithFallback({ src, alt }: { src: string; alt: string }) {
-  const [imgSrc, setImgSrc] = useState(src)
-  const [hasError, setHasError] = useState(false)
-
-  const handleError = () => {
-    if (!hasError && imgSrc !== "/placeholder.svg") {
-      setHasError(true)
-      setImgSrc("/placeholder.svg")
-    }
-  }
-
-  // Si ya hubo error, mostrar placeholder directamente
-  if (hasError || imgSrc === "/placeholder.svg") {
-    return (
-      <img
-        src="/placeholder.svg"
-        alt={alt}
-        className="w-full h-full object-contain"
-        onError={(e) => {
-          // Prevenir loops infinitos
-          e.currentTarget.src = "/placeholder.svg"
-        }}
-      />
-    )
-  }
-
-  return (
-    <img
-      src={imgSrc}
-      alt={alt}
-      className="w-full h-full object-contain"
-      onError={handleError}
-    />
-  )
+type EditableProduct = Partial<CommerceProductCard> & {
+  name?: string
+  title?: string
+  slug?: string
+  image?: string
+  imageUrl?: string
+  price?: string | number | CommerceProductPrice
+  originalPrice?: number
+  compareAtPrice?: number
+  badge?: string
+  badges?: CommerceProductBadge[]
 }
 
 interface ProductsGridProps {
-  initialProducts?: Array<{
-    id: string
-    name: string
-    category: string
-    price: string
-    image: string
-    slug?: string
-  }>
+  initialProducts?: CommerceProductCard[]
+}
+
+function isCommercePrice(price: EditableProduct["price"]): price is CommerceProductPrice {
+  return Boolean(price && typeof price === "object" && "label" in price)
+}
+
+function toCard(product: EditableProduct, index: number): CommerceProductCard {
+  const title = product.title || product.name || `Producto ${index + 1}`
+  const slug = product.slug || generateSlug(title)
+  const price = isCommercePrice(product.price)
+    ? product.price
+    : typeof product.price === "number"
+      ? normalizeCommercePrice(product.price, "COP", product.originalPrice ?? product.compareAtPrice)
+      : {
+          amount: 0,
+          currencyCode: "COP",
+          label: product.price || "",
+          hasDiscount: false,
+        }
+  const saleBadge = price.hasDiscount ? [{ label: "Oferta", tone: "sale" as const }] : []
+
+  return {
+    id: product.id || `product-${index}`,
+    title,
+    description: product.description,
+    href: product.href || `/products/${slug}`,
+    imageUrl: product.imageUrl || product.image || undefined,
+    imageAlt: product.imageAlt || title,
+    category: product.category,
+    price,
+    badges: product.badges || [
+      ...(product.badge ? [{ label: product.badge, tone: "default" as const }] : []),
+      ...saleBadge,
+    ],
+    ctaLabel: product.ctaLabel || "Ver detalles",
+    availableForSale: product.availableForSale,
+  }
 }
 
 export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
@@ -71,7 +77,7 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
     title: "Productos populares",
   })
   const { componentEdits } = useAdmin()
-  
+
   // Combinar estilos de BD con ediciones locales para mostrar cambios en tiempo real
   const edits = componentEdits.get("products") || {}
   const title = edits.title ?? styleData.title ?? "Productos populares"
@@ -85,18 +91,21 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
   // Si es repostería, usar imágenes de repostería, si no, usar imágenes de tecnología
   const defaultProducts = isReposteria ? [
     {
+      id: "cupcakes-decorados",
       name: "Cupcakes Decorados",
       category: "Cupcakes",
       price: "$25.00",
       image: "/reposteria/cupcakes-decorados.jpg",
     },
     {
+      id: "tarta-berries",
       name: "Tarta de Berries",
       category: "Tartas",
       price: "$45.00",
       image: "/reposteria/tarta-berries.jpg",
     },
     {
+      id: "macarons-artesanales",
       name: "Macarons Artesanales",
       category: "Macarons",
       price: "$18.00",
@@ -104,25 +113,28 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
     },
   ] : [
     {
+      id: "beshow-volcano",
       name: "BeShow Volcano",
       category: "Proyectores",
       price: "$1,420.00",
       image: "/white-projector.jpg",
     },
     {
+      id: "soporte-laptop-desk-muo-g",
       name: "Soporte para Laptop Desk MUO-g",
       category: "Soportes",
       price: "$82.00",
       image: "/laptop-stand.png",
     },
     {
+      id: "beshow-volcano-alt",
       name: "BeShow Volcano",
       category: "Proyectores",
       price: "$1,420.00",
       image: "/white-projector.jpg",
     },
   ]
-  
+
   // Imágenes de repostería para reemplazar cuando hay productos de BD
   const reposteriaImages = [
     "/reposteria/cupcakes-decorados.jpg",
@@ -138,15 +150,16 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
   const products = initialProducts && initialProducts.length > 0
     ? initialProducts.map((p, index) => ({
         ...p,
-        image: isReposteria 
-          ? (reposteriaImages[index % reposteriaImages.length] || p.image)
-          : p.image,
+        imageUrl: isReposteria
+          ? (reposteriaImages[index % reposteriaImages.length] || p.imageUrl)
+          : p.imageUrl,
       }))
     : (edits.products ?? styleData.products ?? defaultProducts)
+  const productCards = products.map((product: EditableProduct, index: number) => toCard(product, index))
 
   return (
-    <section 
-      data-component="products" 
+    <section
+      data-component="products"
       className="py-6 sm:py-8 md:py-12 px-4 sm:px-6"
       style={{
         ...(bgColor && { backgroundColor: bgColor }),
@@ -154,46 +167,17 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
       }}
     >
       <div className="container mx-auto">
-        <h2 
-          className="text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-[51px] font-inter font-normal mb-4 sm:mb-6 md:mb-8" 
+        <h2
+          className="text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-[51px] font-inter font-normal mb-4 sm:mb-6 md:mb-8"
           style={{ color: textColor || "var(--foreground)" }}
         >
           {title}
         </h2>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-5 md:gap-6">
-          {products.map((product: any, index: number) => {
-            const productSlug = product.slug || generateSlug(product.name)
-            const productId = initialProducts?.[index]?.id || `product-${index}`
-            return (
-              <Link 
-                key={productId} 
-                href={`/products/${productSlug}`}
-                className="rounded-2xl overflow-hidden hover:shadow-lg transition-shadow cursor-pointer block"
-                style={{ backgroundColor: "var(--card)" }}
-              >
-                <div className="p-3 sm:p-4">
-                  <h3 className="font-inter font-normal text-sm sm:text-base md:text-[17.4854px] mb-1 hover:text-primary transition-colors" style={{ color: "var(--card-foreground)" }}>
-                    {product.name}
-                  </h3>
-                  <p className="text-xs sm:text-sm md:text-[13.9775px] font-inter font-normal mb-2" style={{ color: "var(--muted-foreground)" }}>{product.category}</p>
-                  <p className="text-base sm:text-lg md:text-[20.5864px] font-inter font-normal" style={{ color: "var(--card-foreground)" }}>
-                    {product.price}
-                  </p>
-                </div>
-
-                <div 
-                  className="aspect-square flex items-center justify-center p-3 sm:p-4"
-                  style={{ backgroundColor: "var(--background)" }}
-                >
-                  <ProductImageWithFallback
-                    src={product.image || "/placeholder.svg"}
-                    alt={product.name}
-                  />
-                </div>
-              </Link>
-            )
-          })}
+          {productCards.map((product) => (
+            <VisualProductCard key={product.id} product={product} />
+          ))}
         </div>
       </div>
     </section>

--- a/lib/products/adapter.ts
+++ b/lib/products/adapter.ts
@@ -4,6 +4,9 @@
  */
 
 import type {
+  CommerceProductBadge,
+  CommerceProductCard,
+  CommerceProductPrice,
   StoreItemWithDetails,
   ItemCategory,
   ItemOption,
@@ -15,6 +18,75 @@ function formatMoney(amount: number, currencyCode: string = 'COP'): Money {
   return {
     amount: amount.toString(),
     currencyCode,
+  };
+}
+
+export function formatCommercePrice(amount: number, currencyCode: string = 'COP'): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: currencyCode,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function normalizeCommercePrice(
+  amount: number,
+  currencyCode: string = 'COP',
+  compareAtAmount?: number | null,
+): CommerceProductPrice {
+  const hasDiscount = typeof compareAtAmount === 'number' && compareAtAmount > amount;
+
+  return {
+    amount,
+    currencyCode,
+    label: formatCommercePrice(amount, currencyCode),
+    compareAtAmount: hasDiscount ? compareAtAmount : undefined,
+    compareAtLabel: hasDiscount ? formatCommercePrice(compareAtAmount, currencyCode) : undefined,
+    hasDiscount,
+  };
+}
+
+function getCommerceImageUrl(item: StoreItemWithDetails): string {
+  if (item.primary_image_url && item.primary_image_url.trim() !== '') {
+    return item.primary_image_url;
+  }
+
+  const firstImage = item.images?.find((image) => image.image_url?.trim());
+  return firstImage?.image_url || '/placeholder.svg';
+}
+
+function getCommerceBadges(item: StoreItemWithDetails, price: CommerceProductPrice): CommerceProductBadge[] {
+  if (item.item_kind === 'combo') {
+    return [{ label: 'Combo', tone: 'combo' }];
+  }
+
+  if (price.hasDiscount) {
+    return [{ label: 'Oferta', tone: 'sale' }];
+  }
+
+  return [];
+}
+
+export function toCommerceProductCard(item: StoreItemWithDetails): CommerceProductCard {
+  const price = normalizeCommercePrice(
+    item.base_price,
+    item.currency_code || 'COP',
+    item.compare_at_price,
+  );
+
+  return {
+    id: item.id,
+    title: item.item_name,
+    description: item.item_description,
+    href: `/products/${item.item_slug || item.id}`,
+    imageUrl: getCommerceImageUrl(item),
+    imageAlt: item.primary_image_alt || item.item_name,
+    category: item.category?.category_name,
+    price,
+    badges: getCommerceBadges(item, price),
+    ctaLabel: 'Ver detalles',
+    availableForSale: item.is_available_for_sale && item.is_active,
   };
 }
 
@@ -257,4 +329,3 @@ export function adaptSupabaseProducts(items: StoreItemWithDetails[]): Product[] 
 export function adaptSupabaseCategories(categories: ItemCategory[]): Collection[] {
   return categories.map(adaptSupabaseCategory);
 }
-

--- a/lib/types/products.ts
+++ b/lib/types/products.ts
@@ -95,6 +95,34 @@ export interface StoreItemWithDetails extends StoreItem {
   combo?: ComboCatalogDetails
 }
 
+export interface CommerceProductPrice {
+  amount: number
+  currencyCode: string
+  label: string
+  compareAtAmount?: number
+  compareAtLabel?: string
+  hasDiscount: boolean
+}
+
+export interface CommerceProductBadge {
+  label: string
+  tone?: 'default' | 'sale' | 'combo'
+}
+
+export interface CommerceProductCard {
+  id: string
+  title: string
+  description?: string
+  href: string
+  imageUrl?: string
+  imageAlt: string
+  category?: string
+  price: CommerceProductPrice
+  badges: CommerceProductBadge[]
+  ctaLabel?: string
+  availableForSale?: boolean
+}
+
 export interface GetItemsParams {
   store_id?: string // ID de la tienda para filtrar productos
   item_kind?: 'all' | 'products' | 'combos'
@@ -115,7 +143,6 @@ export interface GetItemsResult {
   total: number
   has_more: boolean
 }
-
 
 
 

--- a/tests/components/catalog-products-list.test.tsx
+++ b/tests/components/catalog-products-list.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CatalogProductsList } from '@/components/catalog/catalog-products-list'
+
+const mockOpenModal = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/hooks/use-quantity-modal', () => ({
+  useQuantityModal: () => ({ openModal: mockOpenModal, QuantityModalComponent: <div data-testid="quantity-modal" /> }),
+}))
+
+describe('CatalogProductsList', () => {
+  it('renders the shared card price pattern and keeps quantity modal payloads', () => {
+    render(
+      <CatalogProductsList
+        products={[{
+          id: 'catalog-1',
+          name: 'Cámara 4K',
+          category: 'Video',
+          price: '$99',
+          compareAtPrice: '$129',
+          image: '',
+          slug: 'camara-4k',
+        }]}
+      />,
+    )
+
+    expect(screen.getByText('Cámara 4K')).toBeInTheDocument()
+    expect(screen.getByText('$99')).toBeInTheDocument()
+    expect(screen.getByText('$129')).toHaveClass('line-through')
+    expect(screen.getByRole('img', { name: /sin imagen para cámara 4k/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /agregar al carrito/i }))
+    expect(mockOpenModal).toHaveBeenCalledWith(expect.objectContaining({ id: 'catalog-1', name: 'Cámara 4K', price: '$99' }))
+  })
+})

--- a/tests/components/popular-items.test.tsx
+++ b/tests/components/popular-items.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PopularItems } from '@/components/sections/popular-items'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+const mockUseStore = vi.fn()
+const mockUseComponentStyle = vi.fn()
+const mockUseAdmin = vi.fn()
+const mockAddToCart = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/contexts/store-context', () => ({ useStore: () => mockUseStore() }))
+vi.mock('@/contexts/styles-context', () => ({ useComponentStyle: (...args: unknown[]) => mockUseComponentStyle(...args) }))
+vi.mock('@/contexts/admin-context', () => ({ useAdmin: () => mockUseAdmin() }))
+vi.mock('@/contexts/cart-context', () => ({ useCart: () => ({ addToCart: mockAddToCart }) }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn() } }))
+vi.mock('@/contexts/language-context', () => ({
+  useLanguage: () => ({
+    language: 'es',
+    t: {
+      products: { addToCart: 'Agregar al carrito', addToCartDescription: '{quantity} {unit} de {name} {verb} agregado{plural}' },
+      wishlist: { viewDetails: 'Ver detalles', addedToCart: 'Agregado' },
+    },
+  }),
+}))
+vi.mock('@/components/ui/carousel', () => ({
+  Carousel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselNext: () => <button type="button">Siguiente</button>,
+  CarouselPrevious: () => <button type="button">Anterior</button>,
+}))
+vi.mock('@/components/cart/quantity-modal', () => ({
+  QuantityModal: ({ open, productName }: { open: boolean; productName: string }) => open ? <div role="dialog">Cantidad {productName}</div> : null,
+}))
+
+const product: CommerceProductCard = {
+  id: 'popular-1',
+  title: 'Speaker Pro',
+  href: '/products/speaker-pro',
+  imageAlt: 'Speaker Pro',
+  category: 'Audio',
+  price: {
+    amount: 99000,
+    currencyCode: 'COP',
+    label: '$ 99.000',
+    compareAtAmount: 129000,
+    compareAtLabel: '$ 129.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('PopularItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseStore.mockReturnValue({ store: { subdomain: 'default' } })
+    mockUseComponentStyle.mockReturnValue({ styles: { title: 'Lo más vendido' } })
+    mockUseAdmin.mockReturnValue({ componentEdits: new Map() })
+  })
+
+  it('renders shared DTO cards with compare price and preserves add-to-cart modal flow', () => {
+    render(<PopularItems initialProducts={[product]} />)
+
+    expect(screen.getByRole('heading', { name: 'Lo más vendido' })).toBeInTheDocument()
+    expect(screen.getByText('Speaker Pro')).toBeInTheDocument()
+    expect(screen.getByText(/99\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toHaveClass('line-through')
+    expect(screen.getByRole('img', { name: 'Speaker Pro' })).toHaveAttribute('src', '/placeholder.svg')
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', '/products/speaker-pro')
+
+    fireEvent.click(screen.getByRole('button', { name: /agregar al carrito/i }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('Cantidad Speaker Pro')
+  })
+})

--- a/tests/components/products-grid.test.tsx
+++ b/tests/components/products-grid.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProductsGrid } from '@/components/sections/products-grid'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+const mockUseStore = vi.fn()
+const mockUseComponentStyle = vi.fn()
+const mockUseAdmin = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/contexts/store-context', () => ({
+  useStore: () => mockUseStore(),
+}))
+
+vi.mock('@/contexts/styles-context', () => ({
+  useComponentStyle: (...args: unknown[]) => mockUseComponentStyle(...args),
+}))
+
+vi.mock('@/contexts/admin-context', () => ({
+  useAdmin: () => mockUseAdmin(),
+}))
+
+const dtoProduct: CommerceProductCard = {
+  id: 'product-1',
+  title: 'Auriculares Premium',
+  href: '/products/auriculares-premium',
+  imageAlt: 'Auriculares Premium',
+  category: 'Audio',
+  price: {
+    amount: 129000,
+    currencyCode: 'COP',
+    label: '$ 129.000',
+    compareAtAmount: 159000,
+    compareAtLabel: '$ 159.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('ProductsGrid', () => {
+  beforeEach(() => {
+    mockUseStore.mockReturnValue({ store: { subdomain: 'default' } })
+    mockUseComponentStyle.mockReturnValue({ styles: { title: 'Productos destacados' } })
+    mockUseAdmin.mockReturnValue({ componentEdits: new Map() })
+  })
+
+  it('renders shared DTO products with compare price, badges, CTA, and no-image fallback', () => {
+    render(<ProductsGrid initialProducts={[dtoProduct]} />)
+
+    expect(screen.getByRole('heading', { name: 'Productos destacados' })).toBeInTheDocument()
+    expect(screen.getByText('Auriculares Premium')).toBeInTheDocument()
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/159\.000/)).toHaveClass('line-through')
+    expect(screen.getByText('Oferta')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /sin imagen para auriculares premium/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', '/products/auriculares-premium')
+  })
+
+  it('preserves admin-edited legacy product records and generated slugs', () => {
+    mockUseAdmin.mockReturnValue({
+      componentEdits: new Map([
+        ['products', {
+          title: 'Ofertas editadas',
+          products: [{ id: 'edited-1', name: 'Cámara 4K', category: 'Video', price: '$99', image: '' }],
+        }],
+      ]),
+    })
+
+    render(<ProductsGrid />)
+
+    expect(screen.getByRole('heading', { name: 'Ofertas editadas' })).toBeInTheDocument()
+    expect(screen.getByText('Cámara 4K')).toBeInTheDocument()
+    expect(screen.getByText('$99')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver cámara 4k/i })).toHaveAttribute('href', '/products/camara-4k')
+  })
+})

--- a/tests/components/visual-product-card.test.tsx
+++ b/tests/components/visual-product-card.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { VisualProductCard } from '@/components/products/visual-product-card'
+import type { CommerceProductCard } from '@/lib/types/products'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+const product: CommerceProductCard = {
+  id: 'product-1',
+  title: 'Auriculares Premium',
+  description: 'Audio inalámbrico',
+  href: '/products/auriculares-premium',
+  imageUrl: '/products/headphones.png',
+  imageAlt: 'Auriculares negros',
+  category: 'Audio',
+  price: {
+    amount: 129000,
+    currencyCode: 'COP',
+    label: '$ 129.000',
+    compareAtAmount: 159000,
+    compareAtLabel: '$ 159.000',
+    hasDiscount: true,
+  },
+  badges: [{ label: 'Oferta', tone: 'sale' }],
+  ctaLabel: 'Ver detalles',
+}
+
+describe('VisualProductCard', () => {
+  it('renders the shared product card content with accessible links and price semantics', () => {
+    render(<VisualProductCard product={product} />)
+
+    expect(screen.getByRole('link', { name: /ver auriculares premium/i })).toHaveAttribute('href', product.href)
+    expect(screen.getByRole('img', { name: 'Auriculares negros' })).toHaveAttribute('src', product.imageUrl)
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    expect(screen.getByText('Auriculares Premium')).toBeInTheDocument()
+    expect(screen.getByText(/129\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/159\.000/)).toHaveClass('line-through')
+    expect(screen.getByText('Oferta')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ver detalles/i })).toHaveAttribute('href', product.href)
+  })
+
+  it('uses a no-image fallback and omits optional compare, category, badge, and CTA content cleanly', () => {
+    render(
+      <VisualProductCard
+        product={{
+          ...product,
+          category: undefined,
+          imageUrl: undefined,
+          imageAlt: 'Auriculares Premium',
+          price: {
+            amount: 129000,
+            currencyCode: 'COP',
+            label: '$ 129.000',
+            hasDiscount: false,
+          },
+          badges: [],
+          ctaLabel: undefined,
+        }}
+        showCta={false}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: /sin imagen para auriculares premium/i })).toBeInTheDocument()
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+    expect(screen.queryByText(/159\.000/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Oferta')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /ver detalles/i })).not.toBeInTheDocument()
+  })
+
+  it('places favorite and custom action slots without nesting them in the product link', () => {
+    render(
+      <VisualProductCard
+        product={product}
+        favoriteSlot={<button type="button" aria-label="Agregar a favoritos" />}
+        actionSlot={<button type="button">Agregar al carrito</button>}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /agregar a favoritos/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /agregar al carrito/i })).toBeInTheDocument()
+  })
+})

--- a/tests/components/visual-product-card.test.tsx
+++ b/tests/components/visual-product-card.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { VisualProductCard } from '@/components/products/visual-product-card'
 import type { CommerceProductCard } from '@/lib/types/products'
@@ -69,6 +69,14 @@ describe('VisualProductCard', () => {
     expect(screen.queryByText(/159\.000/)).not.toBeInTheDocument()
     expect(screen.queryByText('Oferta')).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /ver detalles/i })).not.toBeInTheDocument()
+  })
+
+  it('falls back when a tenant-provided image URL fails to load', () => {
+    render(<VisualProductCard product={product} />)
+
+    fireEvent.error(screen.getByRole('img', { name: 'Auriculares negros' }))
+
+    expect(screen.getByRole('img', { name: /sin imagen para auriculares premium/i })).toBeInTheDocument()
   })
 
   it('places favorite and custom action slots without nesting them in the product link', () => {

--- a/tests/products/product-card-adapter.test.ts
+++ b/tests/products/product-card-adapter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeCommercePrice,
+  toCommerceProductCard,
+} from '@/lib/products/adapter'
+import type { StoreItemWithDetails } from '@/lib/types/products'
+
+function makeItem(overrides: Partial<StoreItemWithDetails> = {}): StoreItemWithDetails {
+  return {
+    id: 'product-1',
+    item_name: 'Auriculares Premium',
+    item_description: 'Audio inalámbrico',
+    category_id: 'cat-1',
+    base_price: 129000,
+    compare_at_price: 159000,
+    currency_code: 'COP',
+    is_active: true,
+    is_featured: true,
+    is_available_for_sale: true,
+    track_inventory: false,
+    inventory_quantity: 10,
+    low_stock_threshold: 2,
+    item_slug: 'auriculares-premium',
+    primary_image_url: '/products/headphones.png',
+    primary_image_alt: 'Auriculares negros',
+    display_order: 1,
+    view_count: 0,
+    created_at: '2026-05-14T00:00:00Z',
+    updated_at: '2026-05-14T00:00:00Z',
+    category: {
+      id: 'cat-1',
+      category_name: 'Audio',
+      display_order: 1,
+      is_active: true,
+      created_at: '2026-05-14T00:00:00Z',
+      updated_at: '2026-05-14T00:00:00Z',
+    },
+    ...overrides,
+  }
+}
+
+describe('commerce product card adapters', () => {
+  it('normalizes Supabase product data into the shared card DTO', () => {
+    const card = toCommerceProductCard(makeItem())
+
+    expect(card).toMatchObject({
+      id: 'product-1',
+      title: 'Auriculares Premium',
+      description: 'Audio inalámbrico',
+      href: '/products/auriculares-premium',
+      imageUrl: '/products/headphones.png',
+      imageAlt: 'Auriculares negros',
+      category: 'Audio',
+      availableForSale: true,
+    })
+    expect(card.price.label).toBe('$ 129.000')
+    expect(card.price.compareAtLabel).toBe('$ 159.000')
+    expect(card.price.hasDiscount).toBe(true)
+    expect(card.badges).toEqual([{ label: 'Oferta', tone: 'sale' }])
+  })
+
+  it('omits misleading discount treatment when compare-at is not greater than base price', () => {
+    expect(normalizeCommercePrice(129000, 'COP', 129000)).toMatchObject({
+      label: '$ 129.000',
+      compareAtLabel: undefined,
+      hasDiscount: false,
+    })
+
+    const card = toCommerceProductCard(makeItem({ compare_at_price: 99000 }))
+    expect(card.price.compareAtLabel).toBeUndefined()
+    expect(card.badges).toEqual([])
+  })
+
+  it('falls back to id href, placeholder image, and combo badge when optional data is absent', () => {
+    const card = toCommerceProductCard(
+      makeItem({
+        item_slug: undefined,
+        primary_image_url: undefined,
+        primary_image_alt: undefined,
+        compare_at_price: undefined,
+        category: undefined,
+        item_kind: 'combo',
+        combo: {} as StoreItemWithDetails['combo'],
+      }),
+    )
+
+    expect(card.href).toBe('/products/product-1')
+    expect(card.imageUrl).toBe('/placeholder.svg')
+    expect(card.imageAlt).toBe('Auriculares Premium')
+    expect(card.category).toBeUndefined()
+    expect(card.badges).toEqual([{ label: 'Combo', tone: 'combo' }])
+  })
+})


### PR DESCRIPTION
Closes #36

## Summary
- Consolidates the previous issue #36 stacked chain (#58, #59, #60) into one reviewable PR against `New-Features`.
- Adds the shared visual product card foundation and migrates home grid, popular items, and catalog card surfaces to the aligned configurable visual contract.
- Keeps the focused regression tests from all slices in one PR so QA can validate issue #36 end-to-end from one preview.

## Changes
| File | Change |
|------|--------|
| `components/products/visual-product-card.tsx` | Adds shared visual card shell. |
| `lib/products/adapter.ts` / `lib/types/products.ts` | Adds product card DTO/adapters. |
| `components/sections/products-grid*` | Migrates home grid cards. |
| `components/sections/popular-items*` | Aligns popular item cards. |
| `components/catalog/catalog-products-list.tsx` and catalog pages | Aligns catalog card data flow. |
| `tests/**` | Adds/keeps regression coverage for adapters and card surfaces. |

## Test Plan
- [x] Consolidated from previously green PRs #58, #59, and #60.
- [x] `git diff --check origin/New-Features...HEAD`
- [x] Prior recorded verification passed for the complete chained implementation.
- [ ] Vercel/GitHub checks on this consolidated PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Supersedes #58, #59, and #60.
