### PR TITLE
fix(admin): reset product create form

### DIFF
--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAdminPermissions } from "@/contexts/admin-permissions-context"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -28,34 +28,40 @@ import type { ItemCategory } from "@/lib/types/products"
 import { MultiImageUpload } from "@/components/admin/multi-image-upload"
 import { toast } from "sonner"
 
+const initialProductFormData = {
+  item_name: "",
+  item_code: "",
+  item_description: "",
+  ai_details: "",
+  category_id: "",
+  base_price: "",
+  compare_at_price: "",
+  currency_code: "COP",
+  is_active: true,
+  is_featured: false,
+  is_available_for_sale: true,
+  track_inventory: false,
+  inventory_quantity: "0",
+  low_stock_threshold: "10",
+  seo_title: "",
+  seo_description: "",
+  tags: "",
+  display_order: "0",
+}
+
+type CreateSubmitIntent = "list" | "another"
+
 export default function CreateProductPage() {
   const { isAdmin, loading } = useAdminPermissions()
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const submitLockRef = useRef(false)
   const [categories, setCategories] = useState<ItemCategory[]>([])
   const [loadingCategories, setLoadingCategories] = useState(true)
   
   // Form state
-  const [formData, setFormData] = useState({
-    item_name: "",
-    item_code: "",
-    item_description: "",
-    ai_details: "",
-    category_id: "",
-    base_price: "",
-    compare_at_price: "",
-    currency_code: "COP",
-    is_active: true,
-    is_featured: false,
-    is_available_for_sale: true,
-    track_inventory: false,
-    inventory_quantity: "0",
-    low_stock_threshold: "10",
-    seo_title: "",
-    seo_description: "",
-    tags: "",
-    display_order: "0",
-  })
+  const [formData, setFormData] = useState(initialProductFormData)
+  const [imageResetToken, setImageResetToken] = useState(0)
   
   const [images, setImages] = useState<string[]>([])
 
@@ -86,8 +92,18 @@ export default function CreateProductPage() {
     }
   }, [isAdmin])
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const resetFormForNextProduct = () => {
+    setFormData({ ...initialProductFormData })
+    setImages([])
+    setImageResetToken((token) => token + 1)
+  }
+
+  const handleSubmit = async (e: React.FormEvent, intent: CreateSubmitIntent = "list") => {
     e.preventDefault()
+
+    if (submitLockRef.current) {
+      return
+    }
     
     if (!formData.item_name.trim()) {
       toast.error("El nombre del producto es requerido")
@@ -112,6 +128,7 @@ export default function CreateProductPage() {
       return
     }
 
+    submitLockRef.current = true
     setIsSubmitting(true)
 
     try {
@@ -152,8 +169,13 @@ export default function CreateProductPage() {
       )
 
       if (result.success && result.item) {
-        toast.success("Producto creado exitosamente")
-        router.push(`/admin/products`)
+        if (intent === "another") {
+          resetFormForNextProduct()
+          toast.success("Producto creado exitosamente. Puedes crear otro producto.")
+        } else {
+          toast.success("Producto creado exitosamente")
+          router.push(`/admin/products`)
+        }
       } else {
         toast.error(result.error || "Error al crear el producto")
       }
@@ -161,6 +183,7 @@ export default function CreateProductPage() {
       console.error("[Create Product] Error:", error)
       toast.error(error.message || "Error inesperado al crear el producto")
     } finally {
+      submitLockRef.current = false
       setIsSubmitting(false)
     }
   }
@@ -250,7 +273,7 @@ export default function CreateProductPage() {
 
       {/* Main Content */}
       <main className="container mx-auto px-4 py-8 max-w-full overflow-x-hidden">
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={(event) => handleSubmit(event, "list")}>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Columna Principal */}
             <div className="lg:col-span-2 space-y-6">
@@ -513,6 +536,7 @@ export default function CreateProductPage() {
                     maxSizeMB={1}
                     context="product-images"
                     label="Imágenes del Producto"
+                    resetToken={imageResetToken}
                   />
                 </CardContent>
               </Card>
@@ -576,7 +600,7 @@ export default function CreateProductPage() {
               </Card>
 
               {/* Botones de Acción */}
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row gap-2">
                 <Button
                   type="submit"
                   className="flex-1"
@@ -591,6 +615,25 @@ export default function CreateProductPage() {
                     <>
                       <Save className="h-4 w-4 mr-2" />
                       Crear Producto
+                    </>
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="flex-1"
+                  disabled={isSubmitting}
+                  onClick={(event) => handleSubmit(event, "another")}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Creando...
+                    </>
+                  ) : (
+                    <>
+                      <Save className="h-4 w-4 mr-2" />
+                      Guardar y crear otro
                     </>
                   )}
                 </Button>

--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -49,7 +49,16 @@ const initialProductFormData = {
   display_order: "0",
 }
 
-type CreateSubmitIntent = "list" | "another"
+const createSubmitIntent = {
+  list: "list",
+  another: "another",
+} as const
+
+type CreateSubmitIntent = (typeof createSubmitIntent)[keyof typeof createSubmitIntent]
+
+type SubmitEventWithSubmitter = Event & {
+  submitter?: HTMLElement | null
+}
 
 export default function CreateProductPage() {
   const { isAdmin, loading } = useAdminPermissions()
@@ -98,8 +107,16 @@ export default function CreateProductPage() {
     setImageResetToken((token) => token + 1)
   }
 
-  const handleSubmit = async (e: React.FormEvent, intent: CreateSubmitIntent = "list") => {
-    e.preventDefault()
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    const form = event.currentTarget
+    const intent = submitIntentFromEvent(event)
+
+    event.preventDefault()
+
+    if (!form.checkValidity()) {
+      form.reportValidity()
+      return
+    }
 
     if (submitLockRef.current) {
       return
@@ -169,7 +186,7 @@ export default function CreateProductPage() {
       )
 
       if (result.success && result.item) {
-        if (intent === "another") {
+        if (intent === createSubmitIntent.another) {
           resetFormForNextProduct()
           toast.success("Producto creado exitosamente. Puedes crear otro producto.")
         } else {
@@ -273,7 +290,7 @@ export default function CreateProductPage() {
 
       {/* Main Content */}
       <main className="container mx-auto px-4 py-8 max-w-full overflow-x-hidden">
-        <form onSubmit={(event) => handleSubmit(event, "list")}>
+        <form onSubmit={handleSubmit}>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Columna Principal */}
             <div className="lg:col-span-2 space-y-6">
@@ -603,6 +620,8 @@ export default function CreateProductPage() {
               <div className="flex flex-col sm:flex-row gap-2">
                 <Button
                   type="submit"
+                  name="createSubmitIntent"
+                  value={createSubmitIntent.list}
                   className="flex-1"
                   disabled={isSubmitting}
                 >
@@ -619,11 +638,12 @@ export default function CreateProductPage() {
                   )}
                 </Button>
                 <Button
-                  type="button"
+                  type="submit"
+                  name="createSubmitIntent"
+                  value={createSubmitIntent.another}
                   variant="outline"
                   className="flex-1"
                   disabled={isSubmitting}
-                  onClick={(event) => handleSubmit(event, "another")}
                 >
                   {isSubmitting ? (
                     <>
@@ -653,4 +673,12 @@ export default function CreateProductPage() {
   )
 }
 
+function submitIntentFromEvent(event: React.FormEvent<HTMLFormElement>): CreateSubmitIntent {
+  const submitter = (event.nativeEvent as SubmitEventWithSubmitter).submitter
 
+  if (submitter instanceof HTMLButtonElement && submitter.value === createSubmitIntent.another) {
+    return createSubmitIntent.another
+  }
+
+  return createSubmitIntent.list
+}

--- a/components/admin/multi-image-upload.tsx
+++ b/components/admin/multi-image-upload.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Upload, X, Loader2 } from "lucide-react"
@@ -16,6 +16,7 @@ interface MultiImageUploadProps {
   context?: string
   maxSizeMB?: number
   accept?: string
+  resetToken?: number
 }
 
 export function MultiImageUpload({
@@ -26,10 +27,18 @@ export function MultiImageUpload({
   context,
   maxSizeMB = 1, // Por defecto 1 MB para imágenes de productos
   accept = "image/jpeg,image/jpg,image/png,image/webp,image/gif",
+  resetToken = 0,
 }: MultiImageUploadProps) {
   const [uploading, setUploading] = useState<number | null>(null)
+  const resetTokenRef = useRef(resetToken)
+
+  useEffect(() => {
+    resetTokenRef.current = resetToken
+  }, [resetToken])
+
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>, index?: number) => {
     const file = event.target.files?.[0]
+    const uploadResetToken = resetTokenRef.current
     if (!file) return
 
     // Validar tipo
@@ -61,6 +70,10 @@ export function MultiImageUpload({
     setUploading(uploadIndex)
     try {
       const result = await uploadImage(file, context || "product-images")
+
+      if (uploadResetToken !== resetTokenRef.current) {
+        return
+      }
 
       if (result.success && result.url) {
         const newImages = [...images]

--- a/lib/supabase/product-image-rows.ts
+++ b/lib/supabase/product-image-rows.ts
@@ -1,0 +1,50 @@
+const PRODUCT_IMAGE_TYPE = 'product'
+
+export type ProductImageInput = {
+  primary_image_url?: string | null
+  primary_image_alt?: string | null
+}
+
+export type ProductImageRow = {
+  item_id: string
+  image_url: string
+  image_alt: string
+  display_order: number
+  image_type: typeof PRODUCT_IMAGE_TYPE
+}
+
+export function buildProductImageRows(
+  itemId: string,
+  itemName: string,
+  input: ProductImageInput,
+  additionalImages: string[] = []
+): ProductImageRow[] {
+  const rows: ProductImageRow[] = []
+
+  const primaryImageUrl = input.primary_image_url?.trim()
+
+  if (primaryImageUrl) {
+    rows.push({
+      item_id: itemId,
+      image_url: primaryImageUrl,
+      image_alt: input.primary_image_alt || itemName,
+      display_order: 1,
+      image_type: PRODUCT_IMAGE_TYPE,
+    })
+  }
+
+  rows.push(
+    ...additionalImages
+      .map((url) => url.trim())
+      .filter(Boolean)
+      .map((url, index) => ({
+        item_id: itemId,
+        image_url: url,
+        image_alt: `${itemName} - Imagen ${index + 2}`,
+        display_order: index + 2,
+        image_type: PRODUCT_IMAGE_TYPE,
+      }))
+  )
+
+  return rows
+}

--- a/lib/supabase/products-api.ts
+++ b/lib/supabase/products-api.ts
@@ -16,6 +16,7 @@ import {
   getComboStock as getDerivedComboStock,
   listCombos,
 } from './combos-api'
+import { buildProductImageRows } from './product-image-rows'
 
 // Importación dinámica de getStoreId para evitar problemas con análisis estático de Next.js
 async function getStoreId(): Promise<string | null> {
@@ -751,47 +752,6 @@ export interface CreateItemResult {
   item?: StoreItemWithDetails
 }
 
-type ProductImageInput = {
-  primary_image_url?: string | null
-  primary_image_alt?: string | null
-}
-
-function buildProductImageRows(
-  itemId: string,
-  itemName: string,
-  input: ProductImageInput,
-  additionalImages: string[] = []
-) {
-  const rows: Array<Record<string, any>> = []
-
-  const primaryImageUrl = input.primary_image_url?.trim()
-
-  if (primaryImageUrl) {
-    rows.push({
-      item_id: itemId,
-      image_url: primaryImageUrl,
-      image_alt: input.primary_image_alt || itemName,
-      display_order: 1,
-      image_type: 'product',
-    })
-  }
-
-  rows.push(
-    ...additionalImages
-      .map((url) => url.trim())
-      .filter(Boolean)
-      .map((url, index) => ({
-        item_id: itemId,
-        image_url: url,
-        image_alt: `${itemName} - Imagen ${index + 2}`,
-        display_order: index + 2,
-        image_type: 'product',
-      }))
-  )
-
-  return rows
-}
-
 async function syncProductNormalizedDetails(
   supabase: ReturnType<typeof getSupabaseEcommerce>,
   item: { id: string; item_name: string },
@@ -851,10 +811,6 @@ async function syncProductNormalizedDetails(
       console.warn('[Products] No se pudo sincronizar item_images:', error)
     }
   }
-}
-
-export const __productsApiTestUtils = {
-  buildProductImageRows,
 }
 
 export async function createItem(

--- a/lib/supabase/products-api.ts
+++ b/lib/supabase/products-api.ts
@@ -764,10 +764,12 @@ function buildProductImageRows(
 ) {
   const rows: Array<Record<string, any>> = []
 
-  if (input.primary_image_url) {
+  const primaryImageUrl = input.primary_image_url?.trim()
+
+  if (primaryImageUrl) {
     rows.push({
       item_id: itemId,
-      image_url: input.primary_image_url,
+      image_url: primaryImageUrl,
       image_alt: input.primary_image_alt || itemName,
       display_order: 1,
       image_type: 'product',
@@ -775,13 +777,16 @@ function buildProductImageRows(
   }
 
   rows.push(
-    ...additionalImages.map((url, index) => ({
-      item_id: itemId,
-      image_url: url,
-      image_alt: `${itemName} - Imagen ${index + 2}`,
-      display_order: index + 2,
-      image_type: 'product',
-    }))
+    ...additionalImages
+      .map((url) => url.trim())
+      .filter(Boolean)
+      .map((url, index) => ({
+        item_id: itemId,
+        image_url: url,
+        image_alt: `${itemName} - Imagen ${index + 2}`,
+        display_order: index + 2,
+        image_type: 'product',
+      }))
   )
 
   return rows
@@ -866,7 +871,7 @@ export async function createItem(
     }
 
     // Validar que solo haya máximo 3 imágenes en total (primary + additional)
-    const totalImagesCount = (data.primary_image_url ? 1 : 0) + additionalImages.length
+    const totalImagesCount = buildProductImageRows("count-only", data.item_name, data, additionalImages).length
     if (totalImagesCount > 3) {
       return {
         success: false,
@@ -1076,7 +1081,7 @@ export async function updateItem(
     }
 
     // Validar que solo haya máximo 3 imágenes en total (primary + additional)
-    const totalImagesCount = (data.primary_image_url ? 1 : 0) + additionalImages.length
+    const totalImagesCount = buildProductImageRows("count-only", data.item_name || "Producto", data, additionalImages).length
     if (totalImagesCount > 3) {
       return {
         success: false,

--- a/tests/products/products-api.contract.test.ts
+++ b/tests/products/products-api.contract.test.ts
@@ -7,6 +7,7 @@ import {
   getVariantStock,
   incrementItemViewCount,
   updateItem,
+  __productsApiTestUtils,
 } from "@/lib/supabase/products-api";
 
 const { getSupabaseEcommerceMock, getStoreIdMock } = vi.hoisted(() => ({
@@ -208,6 +209,25 @@ describe("products-api contract", () => {
       {
         item_id: "item-1",
         image_url: "https://example.com/extra.webp",
+        image_alt: "Café Especial - Imagen 2",
+        display_order: 2,
+        image_type: "product",
+      },
+    ]);
+  });
+
+  it("normalizes empty product image values before syncing item_images", () => {
+    expect(
+      __productsApiTestUtils.buildProductImageRows(
+        "item-1",
+        "Café Especial",
+        { primary_image_url: "", primary_image_alt: "Alt vacío" },
+        ["", "  ", "https://example.com/valid.webp"],
+      ),
+    ).toEqual([
+      {
+        item_id: "item-1",
+        image_url: "https://example.com/valid.webp",
         image_alt: "Café Especial - Imagen 2",
         display_order: 2,
         image_type: "product",

--- a/tests/products/products-api.contract.test.ts
+++ b/tests/products/products-api.contract.test.ts
@@ -7,8 +7,8 @@ import {
   getVariantStock,
   incrementItemViewCount,
   updateItem,
-  __productsApiTestUtils,
 } from "@/lib/supabase/products-api";
+import { buildProductImageRows } from "@/lib/supabase/product-image-rows";
 
 const { getSupabaseEcommerceMock, getStoreIdMock } = vi.hoisted(() => ({
   getSupabaseEcommerceMock: vi.fn(),
@@ -218,7 +218,7 @@ describe("products-api contract", () => {
 
   it("normalizes empty product image values before syncing item_images", () => {
     expect(
-      __productsApiTestUtils.buildProductImageRows(
+      buildProductImageRows(
         "item-1",
         "Café Especial",
         { primary_image_url: "", primary_image_alt: "Alt vacío" },

--- a/tests/security/admin-products-form-reset.test.tsx
+++ b/tests/security/admin-products-form-reset.test.tsx
@@ -186,6 +186,28 @@ describe("admin product create form reset", () => {
     );
   });
 
+  it("requires valid native form fields before Guardar y crear otro creates a product", async () => {
+    render(createElement(CreateProductPage));
+
+    fireEvent.change(screen.getByLabelText(/nombre del producto/i), {
+      target: { value: "Café Especial" },
+    });
+    fireEvent.change(screen.getByLabelText(/precio base/i), {
+      target: { value: "12000" },
+    });
+    fireEvent.change(screen.getByLabelText(/cantidad en stock/i), {
+      target: { value: "" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /guardar y crear otro/i }));
+    });
+
+    expect(mockCreateItem).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
   it("navigates after Guardar and a later create page mount starts with defaults", async () => {
     const { unmount } = render(createElement(CreateProductPage));
 

--- a/tests/security/admin-products-form-reset.test.tsx
+++ b/tests/security/admin-products-form-reset.test.tsx
@@ -1,0 +1,237 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CreateProductPage from "@/app/admin/products/create/page";
+
+const mockUseAdminPermissions = vi.fn();
+const mockPush = vi.fn();
+const mockCreateItem = vi.fn();
+const mockGetCategories = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("@/contexts/admin-permissions-context", () => ({
+  useAdminPermissions: () => mockUseAdminPermissions(),
+}));
+
+vi.mock("@/lib/supabase/products-api", () => ({
+  createItem: (...args: unknown[]) => mockCreateItem(...args),
+  getCategories: (...args: unknown[]) => mockGetCategories(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) =>
+    createElement("a", { href }, children),
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => createElement("span");
+
+  return {
+    ArrowLeft: Icon,
+    Loader2: Icon,
+    Save: Icon,
+    ShieldAlert: Icon,
+  };
+});
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children, value, onValueChange }: { children: ReactNode; value?: string; onValueChange?: (value: string) => void }) =>
+    createElement("div", { "data-value": value },
+      children,
+      createElement("button", {
+        type: "button",
+        onClick: () => onValueChange?.("category-1"),
+      }, "Elegir categoría de prueba"),
+    ),
+  SelectContent: ({ children }: { children: ReactNode }) =>
+    createElement("div", {}, children),
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) =>
+    createElement("div", { "data-value": value }, children),
+  SelectTrigger: ({ children }: { children: ReactNode }) =>
+    createElement("button", { type: "button" }, children),
+  SelectValue: ({ placeholder }: { placeholder?: string }) =>
+    createElement("span", {}, placeholder),
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    id,
+    checked,
+    onCheckedChange,
+  }: {
+    id: string;
+    checked: boolean;
+    onCheckedChange: (value: boolean) => void;
+  }) =>
+    createElement("input", {
+      id,
+      type: "checkbox",
+      checked,
+      onChange: (event: Event) =>
+        onCheckedChange((event.target as HTMLInputElement).checked),
+    }),
+}));
+
+vi.mock("@/components/admin/multi-image-upload", () => ({
+  MultiImageUpload: ({
+    images,
+    onChange,
+  }: {
+    images: string[];
+    onChange: (images: string[]) => void;
+  }) =>
+    createElement(
+      "section",
+      { "aria-label": "mock-image-upload" },
+      createElement("output", { "data-testid": "selected-images" }, images.join("|")),
+      createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () =>
+            onChange([
+              "https://cdn.example.com/first.webp",
+              "https://cdn.example.com/second.webp",
+            ]),
+        },
+        "Agregar imágenes de prueba",
+      ),
+    ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function setupSuccessfulCreate() {
+  mockUseAdminPermissions.mockReturnValue({ isAdmin: true, loading: false });
+  mockGetCategories.mockResolvedValue([
+    { id: "category-1", category_name: "Cafés" },
+  ]);
+  mockCreateItem.mockResolvedValue({
+    success: true,
+    item: { id: "item-1", item_name: "Café Especial" },
+  });
+}
+
+async function fillRequiredProductFields() {
+  fireEvent.change(screen.getByLabelText(/nombre del producto/i), {
+    target: { value: "Café Especial" },
+  });
+  fireEvent.change(screen.getByLabelText(/precio base/i), {
+    target: { value: "12000" },
+  });
+  fireEvent.change(screen.getByLabelText(/descripción$/i), {
+    target: { value: "Café molido premium" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Agregar imágenes de prueba" }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId("selected-images")).toHaveTextContent(
+      "first.webp|https://cdn.example.com/second.webp",
+    ),
+  );
+}
+
+describe("admin product create form reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupSuccessfulCreate();
+  });
+
+  it("clears form values and selected images after Guardar y crear otro", async () => {
+    render(createElement(CreateProductPage));
+
+    await fillRequiredProductFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /guardar y crear otro/i }));
+    });
+
+    await waitFor(() => expect(mockCreateItem).toHaveBeenCalledTimes(1));
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Producto creado exitosamente. Puedes crear otro producto.",
+    );
+    expect(screen.getByLabelText(/nombre del producto/i)).toHaveValue("");
+    expect(screen.getByLabelText(/precio base/i)).toHaveValue(null);
+    expect(screen.getByLabelText(/descripción$/i)).toHaveValue("");
+    expect(screen.getByTestId("selected-images")).toHaveTextContent("");
+
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item_name: "Café Especial",
+        primary_image_url: "https://cdn.example.com/first.webp",
+      }),
+      ["https://cdn.example.com/second.webp"],
+    );
+  });
+
+  it("navigates after Guardar and a later create page mount starts with defaults", async () => {
+    const { unmount } = render(createElement(CreateProductPage));
+
+    await fillRequiredProductFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^crear producto$/i }));
+    });
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/admin/products"));
+
+    unmount();
+    await act(async () => {
+      render(createElement(CreateProductPage));
+    });
+
+    expect(screen.getByLabelText(/nombre del producto/i)).toHaveValue("");
+    expect(screen.getByLabelText(/precio base/i)).toHaveValue(null);
+    expect(screen.getByTestId("selected-images")).toHaveTextContent("");
+  });
+
+  it("keeps a double click on save from creating duplicate products", async () => {
+    let resolveCreate: (value: unknown) => void = () => undefined;
+    mockCreateItem.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+
+    render(createElement(CreateProductPage));
+
+    await fillRequiredProductFields();
+
+    const actions = screen.getByRole("button", { name: /^crear producto$/i }).closest("div");
+    expect(actions).not.toBeNull();
+    const saveButton = within(actions as HTMLElement).getByRole("button", {
+      name: /^crear producto$/i,
+    });
+
+    fireEvent.click(saveButton);
+    fireEvent.click(saveButton);
+
+    expect(mockCreateItem).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate({ success: true, item: { id: "item-1" } });
+    });
+  });
+});


### PR DESCRIPTION
Closes #38

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds an explicit **Guardar y crear otro** flow that resets create-product fields, selected images, and upload state back to defaults.
- Keeps normal **Crear Producto** navigation to `/admin/products` and guards same-tick double submits from creating duplicates.
- Normalizes blank product image URLs before existing `item_images` sync so stale/empty image values are not persisted.

## Changes
| File | Change |
|------|--------|
| `app/admin/products/create/page.tsx` | Centralized default form state, added submit intent, reset helper, image reset token, and duplicate-submit lock. |
| `components/admin/multi-image-upload.tsx` | Added optional `resetToken` guard so stale in-flight uploads cannot repopulate a reset form. |
| `lib/supabase/products-api.ts` | Trims/filters blank image URLs before image count validation and sync. |
| `tests/security/admin-products-form-reset.test.tsx` | Adds regression coverage for reset, clean remount, selected image clearing, and duplicate-submit prevention. |
| `tests/products/products-api.contract.test.ts` | Adds contract coverage for blank image URL normalization. |

## Supabase / migrations
- No Supabase schema migration required.
- No storage bucket changes required.
- No RLS changes required.
- Existing `store_items` / `item_images` writes are reused; only blank image URL payload normalization changed.

## Test Plan
- [x] Focused tests: `node scripts/run-vitest.mjs tests/security/admin-products-form-reset.test.tsx tests/products/products-api.contract.test.ts` (2 files / 9 tests)
- [x] Changed-file ESLint: `corepack pnpm exec eslint app/admin/products/create/page.tsx components/admin/multi-image-upload.tsx lib/supabase/products-api.ts tests/security/admin-products-form-reset.test.tsx tests/products/products-api.contract.test.ts --max-warnings=0`
- [x] Typecheck: `corepack pnpm typecheck`
- [x] Whitespace: `git diff --check`
- [x] Full suite: `node scripts/run-vitest.mjs` (40 files / 237 tests)
- [ ] Manual QA before merge: admin browser flow below

## Manual QA checklist before merge
1. Open `/admin/products/create` as admin.
2. Fill required fields, upload/select images, click **Guardar y crear otro**.
3. Confirm all fields return to defaults and no old thumbnails remain.
4. Fill a second product and confirm only the new images are submitted.
5. Fill a product, double-click **Crear Producto**, and confirm only one product is created and navigation returns to `/admin/products`.
6. Reopen `/admin/products/create` from the list and confirm it starts empty/default.

## SDD / verification
- Apply artifact: `sdd/issue-38-reliable-product-form-reset/apply-progress` (Engram observation 1450)
- Verify artifact: `sdd/issue-38-reliable-product-form-reset/verify-report` (Engram observation 1454)
- Final SDD verdict: PASS WITH WARNINGS (manual QA pending; coverage provider `@vitest/coverage-v8` not installed)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Ran relevant checks on modified files
- [x] Docs/issue notes include migration and manual QA details
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
