### PR TITLE
feat(products): support five product images

### DIFF
--- a/app/admin/products/[id]/edit/page.tsx
+++ b/app/admin/products/[id]/edit/page.tsx
@@ -171,9 +171,9 @@ export default function EditProductPage() {
       return
     }
 
-    // Validar imágenes: máximo 3
-    if (images.length > 3) {
-      toast.error("Solo se permiten máximo 3 imágenes")
+    // Validar imágenes: máximo 5
+    if (images.length > 5) {
+      toast.error("Solo se permiten máximo 5 imágenes")
       return
     }
 
@@ -181,7 +181,7 @@ export default function EditProductPage() {
 
     try {
       // Separar la primera imagen (primary) de las adicionales
-      const primaryImage = images.length > 0 ? images[0] : undefined
+      const primaryImage = images.length > 0 ? images[0] : null
       const additionalImages = images.length > 1 ? images.slice(1) : []
 
       // Preparar metadata con ai_details si existe
@@ -217,7 +217,7 @@ export default function EditProductPage() {
           seo_description: formData.seo_description.trim() || undefined,
           tags: formData.tags ? formData.tags.split(',').map(tag => tag.trim()).filter(Boolean) : undefined,
           primary_image_url: primaryImage,
-          primary_image_alt: formData.item_name.trim(),
+          primary_image_alt: primaryImage ? formData.item_name.trim() : null,
           display_order: parseInt(formData.display_order) || 0,
           metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         },
@@ -567,7 +567,7 @@ export default function EditProductPage() {
                 <CardHeader>
                   <CardTitle>Imágenes del Producto</CardTitle>
                   <CardDescription>
-                    Máximo 3 imágenes. Cada imagen debe pesar 1 MB o menos.
+                    Máximo 5 imágenes. Cada imagen debe pesar 1 MB o menos.
                     La primera imagen será la imagen principal.
                   </CardDescription>
                 </CardHeader>
@@ -575,7 +575,7 @@ export default function EditProductPage() {
                   <MultiImageUpload
                     images={images}
                     onChange={setImages}
-                    maxImages={3}
+                    maxImages={5}
                     maxSizeMB={1}
                     context="product-images"
                     label="Imágenes del Producto"

--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -139,9 +139,9 @@ export default function CreateProductPage() {
       return
     }
 
-    // Validar imágenes: máximo 3
-    if (images.length > 3) {
-      toast.error("Solo se permiten máximo 3 imágenes")
+    // Validar imágenes: máximo 5
+    if (images.length > 5) {
+      toast.error("Solo se permiten máximo 5 imágenes")
       return
     }
 
@@ -541,7 +541,7 @@ export default function CreateProductPage() {
                 <CardHeader>
                   <CardTitle>Imágenes del Producto</CardTitle>
                   <CardDescription>
-                    Máximo 3 imágenes. Cada imagen debe pesar 1 MB o menos.
+                    Máximo 5 imágenes. Cada imagen debe pesar 1 MB o menos.
                     La primera imagen será la imagen principal.
                   </CardDescription>
                 </CardHeader>
@@ -549,7 +549,7 @@ export default function CreateProductPage() {
                   <MultiImageUpload
                     images={images}
                     onChange={setImages}
-                    maxImages={3}
+                    maxImages={5}
                     maxSizeMB={1}
                     context="product-images"
                     label="Imágenes del Producto"

--- a/components/admin/multi-image-upload.tsx
+++ b/components/admin/multi-image-upload.tsx
@@ -1,12 +1,16 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useId, useRef, useState } from "react"
+import Image from "next/image"
+import { Loader2, Upload, X } from "lucide-react"
+import { toast } from "sonner"
+
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
-import { Upload, X, Loader2 } from "lucide-react"
-import { uploadImage, deleteImage } from "@/lib/supabase/storage-api"
-import { toast } from "sonner"
-import Image from "next/image"
+import { deleteImage, uploadImage } from "@/lib/supabase/storage-api"
+
+const DEFAULT_MAX_PRODUCT_IMAGES = 5
+const DEFAULT_UPLOAD_CONTEXT = "product-images"
 
 interface MultiImageUploadProps {
   images: string[]
@@ -19,116 +23,187 @@ interface MultiImageUploadProps {
   resetToken?: number
 }
 
+type FileValidation = {
+  file: File
+  nextImages: string[]
+  maxImages: number
+  maxSizeMB: number
+  enforceLimit: boolean
+}
+
+function formatFileSizeMB(file: File) {
+  return (file.size / 1024 / 1024).toFixed(2)
+}
+
+function isValidUploadFile({
+  file,
+  nextImages,
+  maxImages,
+  maxSizeMB,
+  enforceLimit,
+}: FileValidation) {
+  if (!file.type.startsWith("image/")) {
+    toast.error(`${file.name}: selecciona un archivo de imagen válido`)
+    return false
+  }
+
+  const maxSize = maxSizeMB * 1024 * 1024
+  if (file.size > maxSize) {
+    toast.error(
+      `${file.name}: archivo demasiado grande. Tamaño máximo permitido: ${maxSizeMB}MB. Tu archivo: ${formatFileSizeMB(file)}MB`,
+      { duration: 5000 },
+    )
+    return false
+  }
+
+  if (enforceLimit && nextImages.length >= maxImages) {
+    toast.error(`${file.name}: solo se permiten máximo ${maxImages} imágenes`)
+    return false
+  }
+
+  return true
+}
+
 export function MultiImageUpload({
   images = [],
   onChange,
   label = "Imágenes",
-  maxImages = 3,
+  maxImages = DEFAULT_MAX_PRODUCT_IMAGES,
   context,
-  maxSizeMB = 1, // Por defecto 1 MB para imágenes de productos
+  maxSizeMB = 1,
   accept = "image/jpeg,image/jpg,image/png,image/webp,image/gif",
   resetToken = 0,
 }: MultiImageUploadProps) {
-  const [uploading, setUploading] = useState<number | null>(null)
+  const inputId = useId()
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const resetTokenRef = useRef(resetToken)
+  const [uploading, setUploading] = useState<number | null>(null)
 
   useEffect(() => {
     resetTokenRef.current = resetToken
   }, [resetToken])
 
-  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>, index?: number) => {
-    const file = event.target.files?.[0]
+  const uploadFiles = async (files: File[], replaceIndex?: number) => {
+    if (files.length === 0) return
+
     const uploadResetToken = resetTokenRef.current
-    if (!file) return
+    const replacementIndex = replaceIndex
+    const isReplacement = replacementIndex !== undefined
+    const selectedFiles = isReplacement ? files.slice(0, 1) : files
+    let nextImages = [...images]
+    let uploadedCount = 0
 
-    // Validar tipo
-    if (!file.type.startsWith("image/")) {
-      toast.error("Por favor selecciona un archivo de imagen válido")
-      return
-    }
-
-    // Validar tamaño - Para productos, máximo 1 MB
-    const maxSize = maxSizeMB * 1024 * 1024
-    const fileSizeMB = (file.size / 1024 / 1024).toFixed(2)
-    
-    if (file.size > maxSize) {
-      toast.error(
-        `El archivo es demasiado grande. Tamaño máximo permitido: ${maxSizeMB}MB. Tu archivo: ${fileSizeMB}MB`,
-        { duration: 5000 }
-      )
-      return
-    }
-
-    // Validar límite de imágenes
-    if (images.length >= maxImages && index === undefined) {
-      toast.error(`Solo se permiten máximo ${maxImages} imágenes`)
-      return
-    }
-
-    // Subir archivo
-    const uploadIndex = index !== undefined ? index : images.length
-    setUploading(uploadIndex)
-    try {
-      const result = await uploadImage(file, context || "product-images")
-
-      if (uploadResetToken !== resetTokenRef.current) {
-        return
+    for (const file of selectedFiles) {
+      if (
+        !isValidUploadFile({
+          file,
+          nextImages,
+          maxImages,
+          maxSizeMB,
+          enforceLimit: !isReplacement,
+        })
+      ) {
+        continue
       }
 
-      if (result.success && result.url) {
-        const newImages = [...images]
-        if (index !== undefined) {
-          // Reemplazar imagen existente
-          newImages[index] = result.url
-        } else {
-          // Agregar nueva imagen
-          newImages.push(result.url)
+      const uploadIndex = replacementIndex ?? nextImages.length
+      setUploading(uploadIndex)
+
+      try {
+        const result = await uploadImage(file, context || DEFAULT_UPLOAD_CONTEXT)
+
+        if (uploadResetToken !== resetTokenRef.current) {
+          return
         }
-        onChange(newImages.slice(0, maxImages)) // Asegurar que no exceda el límite
-        toast.success("Imagen subida correctamente")
-      } else {
-        toast.error(result.error || "Error al subir la imagen")
-      }
-    } catch (error) {
-      console.error("[MultiImageUpload] Error:", error)
-      toast.error("Error al subir la imagen")
-    } finally {
-      setUploading(null)
-      // Limpiar input
-      if (event.target) {
-        event.target.value = ""
+
+        if (result.success && result.url) {
+          if (replacementIndex !== undefined) {
+            nextImages[replacementIndex] = result.url
+          } else {
+            nextImages = [...nextImages, result.url].slice(0, maxImages)
+          }
+
+          onChange(nextImages)
+          uploadedCount++
+        } else {
+          toast.error(`${file.name}: ${result.error || "Error al subir la imagen"}`)
+        }
+      } catch (error) {
+        console.error("[MultiImageUpload] Error:", error)
+        toast.error(`${file.name}: error al subir la imagen`)
+      } finally {
+        setUploading(null)
       }
     }
+
+    if (uploadedCount === 1) {
+      toast.success("Imagen subida correctamente")
+      return
+    }
+
+    if (uploadedCount > 1) {
+      toast.success(`${uploadedCount} imágenes subidas correctamente`)
+    }
+  }
+
+  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>, index?: number) => {
+    const files = Array.from(event.target.files || [])
+    await uploadFiles(files, index)
+    event.target.value = ""
   }
 
   const handleRemove = async (index: number) => {
     const imageToRemove = images[index]
-    
-    // Si es una imagen de Supabase Storage, intentar eliminarla
+
     if (imageToRemove && imageToRemove.includes("supabase.co/storage")) {
       try {
         await deleteImage(imageToRemove)
         toast.success("Imagen eliminada")
       } catch (error) {
         console.error("[MultiImageUpload] Error al eliminar:", error)
-        // Continuar aunque falle la eliminación
       }
     }
 
-    const newImages = images.filter((_, i) => i !== index)
-    onChange(newImages)
+    onChange(images.filter((_, imageIndex) => imageIndex !== index))
   }
 
   const canAddMore = images.length < maxImages
+  const openFilePicker = () => {
+    fileInputRef.current?.click()
+  }
 
   return (
     <div className="space-y-4">
-      <Label>
-        {label} ({images.length}/{maxImages})
-      </Label>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Label>
+          {label} ({images.length}/{maxImages})
+        </Label>
+        <div>
+          <input
+            ref={fileInputRef}
+            id={inputId}
+            type="file"
+            accept={accept}
+            multiple
+            className="sr-only"
+            aria-label="Seleccionar imágenes"
+            onChange={(event) => handleFileSelect(event)}
+            disabled={!canAddMore}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={openFilePicker}
+            disabled={!canAddMore}
+          >
+            <Upload className="h-4 w-4 mr-2" />
+            Seleccionar imágenes
+          </Button>
+        </div>
+      </div>
 
-      {/* Grid de imágenes */}
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
         {Array.from({ length: maxImages }).map((_, index) => {
           const imageUrl = images[index]
           const isUploading = uploading === index
@@ -146,7 +221,6 @@ export function MultiImageUpload({
                     fill
                     className="object-cover"
                     onError={() => {
-                      // Si la imagen falla al cargar, eliminarla
                       handleRemove(index)
                     }}
                   />
@@ -157,10 +231,10 @@ export function MultiImageUpload({
                     className="absolute top-2 right-2 h-8 w-8"
                     onClick={() => handleRemove(index)}
                     disabled={isUploading}
+                    aria-label={`Eliminar imagen ${index + 1}`}
                   >
                     <X className="h-4 w-4" />
                   </Button>
-                  {/* Botón para reemplazar */}
                   <Button
                     type="button"
                     variant="secondary"
@@ -170,7 +244,9 @@ export function MultiImageUpload({
                       const input = document.createElement("input")
                       input.type = "file"
                       input.accept = accept
-                      input.onchange = (e) => handleFileSelect(e as any, index)
+                      input.onchange = (event) => {
+                        void handleFileSelect(event as unknown as React.ChangeEvent<HTMLInputElement>, index)
+                      }
                       input.click()
                     }}
                     disabled={isUploading}
@@ -198,21 +274,6 @@ export function MultiImageUpload({
                       <span className="text-xs text-muted-foreground text-center">
                         Imagen {index + 1}
                       </span>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="mt-2"
-                        onClick={() => {
-                          const input = document.createElement("input")
-                          input.type = "file"
-                          input.accept = accept
-                          input.onchange = (e) => handleFileSelect(e as any, index)
-                          input.click()
-                        }}
-                      >
-                        Subir
-                      </Button>
                     </>
                   ) : (
                     <span className="text-xs text-muted-foreground text-center">
@@ -226,7 +287,6 @@ export function MultiImageUpload({
         })}
       </div>
 
-      {/* Información */}
       <div className="space-y-1">
         <p className="text-xs text-muted-foreground">
           <span className="font-medium">Límite:</span> Máximo {maxImages} imágenes por producto

--- a/lib/supabase/products-api.ts
+++ b/lib/supabase/products-api.ts
@@ -18,6 +18,11 @@ import {
 } from './combos-api'
 import { buildProductImageRows } from './product-image-rows'
 
+const MAX_PRODUCT_IMAGES = 5
+const MAX_ADDITIONAL_PRODUCT_IMAGES = MAX_PRODUCT_IMAGES - 1
+const MAX_PRODUCT_IMAGES_ERROR =
+  `Solo se permiten máximo ${MAX_PRODUCT_IMAGES} imágenes por producto (1 principal + ${MAX_ADDITIONAL_PRODUCT_IMAGES} adicionales)`
+
 // Importación dinámica de getStoreId para evitar problemas con análisis estático de Next.js
 async function getStoreId(): Promise<string | null> {
   const { getStoreId: getStoreIdFn } = await import('@/lib/utils/store')
@@ -740,8 +745,8 @@ export interface CreateItemData {
   seo_description?: string
   metadata?: Record<string, any>
   tags?: string[]
-  primary_image_url?: string
-  primary_image_alt?: string
+  primary_image_url?: string | null
+  primary_image_alt?: string | null
   display_order?: number
   store_id?: string
 }
@@ -826,12 +831,11 @@ export async function createItem(
       }
     }
 
-    // Validar que solo haya máximo 3 imágenes en total (primary + additional)
-    const totalImagesCount = buildProductImageRows("count-only", data.item_name, data, additionalImages).length
-    if (totalImagesCount > 3) {
+    const totalImagesCount = buildProductImageRows('count-only', data.item_name, data, additionalImages).length
+    if (totalImagesCount > MAX_PRODUCT_IMAGES) {
       return {
         success: false,
-        error: 'Solo se permiten máximo 3 imágenes por producto (1 principal + 2 adicionales)',
+        error: MAX_PRODUCT_IMAGES_ERROR,
       }
     }
 
@@ -1011,8 +1015,8 @@ export interface UpdateItemData {
   seo_description?: string
   metadata?: Record<string, any>
   tags?: string[]
-  primary_image_url?: string
-  primary_image_alt?: string
+  primary_image_url?: string | null
+  primary_image_alt?: string | null
   display_order?: number
 }
 
@@ -1036,12 +1040,11 @@ export async function updateItem(
       }
     }
 
-    // Validar que solo haya máximo 3 imágenes en total (primary + additional)
-    const totalImagesCount = buildProductImageRows("count-only", data.item_name || "Producto", data, additionalImages).length
-    if (totalImagesCount > 3) {
+    const totalImagesCount = buildProductImageRows('count-only', data.item_name || 'Producto', data, additionalImages).length
+    if (totalImagesCount > MAX_PRODUCT_IMAGES) {
       return {
         success: false,
-        error: 'Solo se permiten máximo 3 imágenes por producto (1 principal + 2 adicionales)',
+        error: MAX_PRODUCT_IMAGES_ERROR,
       }
     }
 

--- a/tests/components/multi-image-upload.test.tsx
+++ b/tests/components/multi-image-upload.test.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable @next/next/no-img-element */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MultiImageUpload } from "@/components/admin/multi-image-upload";
+
+const { uploadImageMock, deleteImageMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  uploadImageMock: vi.fn(),
+  deleteImageMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+}));
+
+vi.mock("@/lib/supabase/storage-api", () => ({
+  uploadImage: uploadImageMock,
+  deleteImage: deleteImageMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+function imageFile(name: string, size = 16, type = "image/webp") {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+describe("MultiImageUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uploadImageMock.mockImplementation(async (file: File) => ({
+      success: true,
+      url: `https://cdn.example.com/${file.name}`,
+    }));
+  });
+
+  it("allows selecting up to five product images in one file picker action", async () => {
+    const onChange = vi.fn();
+    render(<MultiImageUpload images={[]} onChange={onChange} label="Imágenes" />);
+
+    const input = screen.getByLabelText(/seleccionar imágenes/i);
+    expect(input).toHaveAttribute("multiple");
+
+    await userEvent.upload(input, [
+      imageFile("uno.webp"),
+      imageFile("dos.webp"),
+      imageFile("tres.webp"),
+      imageFile("cuatro.webp"),
+      imageFile("cinco.webp"),
+    ]);
+
+    await waitFor(() => expect(uploadImageMock).toHaveBeenCalledTimes(5));
+    expect(onChange).toHaveBeenLastCalledWith([
+      "https://cdn.example.com/uno.webp",
+      "https://cdn.example.com/dos.webp",
+      "https://cdn.example.com/tres.webp",
+      "https://cdn.example.com/cuatro.webp",
+      "https://cdn.example.com/cinco.webp",
+    ]);
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("opens the hidden file input from the visible select button", () => {
+    const onChange = vi.fn();
+    render(<MultiImageUpload images={[]} onChange={onChange} label="Imágenes" />);
+
+    const input = screen.getByLabelText(/seleccionar imágenes/i);
+    const inputClick = vi.spyOn(input, "click").mockImplementation(() => undefined);
+
+    fireEvent.click(screen.getByRole("button", { name: /seleccionar imágenes/i }));
+
+    expect(inputClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports type, size, and limit validation by file without uploading invalid selections", async () => {
+    const onChange = vi.fn();
+    render(
+      <MultiImageUpload
+        images={["/a.webp", "/b.webp", "/c.webp", "/d.webp"]}
+        onChange={onChange}
+        label="Imágenes"
+        maxSizeMB={1}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/seleccionar imágenes/i), {
+      target: {
+        files: [
+          imageFile("ok.webp"),
+          new File(["not-image"], "notes.txt", { type: "text/plain" }),
+          imageFile("huge.webp", 1024 * 1024 + 1),
+          imageFile("extra.webp"),
+        ],
+      },
+    });
+
+    await waitFor(() => expect(uploadImageMock).toHaveBeenCalledTimes(1));
+    expect(uploadImageMock).toHaveBeenCalledWith(expect.objectContaining({ name: "ok.webp" }), "product-images");
+    expect(onChange).toHaveBeenLastCalledWith([
+      "/a.webp",
+      "/b.webp",
+      "/c.webp",
+      "/d.webp",
+      "https://cdn.example.com/ok.webp",
+    ]);
+    expect(toastErrorMock).toHaveBeenCalledWith(expect.stringContaining("notes.txt"));
+    expect(toastErrorMock).toHaveBeenCalledWith(expect.stringContaining("huge.webp"), expect.anything());
+    expect(toastErrorMock).toHaveBeenCalledWith(expect.stringContaining("extra.webp"));
+  });
+});

--- a/tests/products/latest-product-card.test.tsx
+++ b/tests/products/latest-product-card.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable @next/next/no-img-element */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LatestProductCard } from '@/components/products/latest-product-card'
+import type { Product } from '@/lib/shopify/types'
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, priority, ...props }: { src: string; alt: string; priority?: boolean }) => (
+    <img src={src} alt={alt} data-priority={priority ? 'true' : 'false'} {...props} />
+  ),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, prefetch: _prefetch, ...props }: { href: string; children: React.ReactNode; prefetch?: boolean }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/components/products/featured-product-label', () => ({
+  FeaturedProductLabel: ({ product }: { product: Product }) => (
+    <div data-testid="featured-product-label">{product.title}</div>
+  ),
+}))
+
+const productWithGallery: Product = {
+  id: 'product-1',
+  title: 'Café con galería',
+  handle: 'cafe-galeria',
+  description: 'Producto con 5 imágenes',
+  descriptionHtml: '<p>Producto con 5 imágenes</p>',
+  featuredImage: {
+    url: 'https://cdn.example.com/primary.webp',
+    altText: 'Imagen primaria del café',
+    height: 800,
+    width: 800,
+  },
+  images: [
+    { url: 'https://cdn.example.com/primary.webp', altText: 'Imagen primaria del café', height: 800, width: 800 },
+    { url: 'https://cdn.example.com/gallery-2.webp', altText: 'Galería 2', height: 800, width: 800 },
+    { url: 'https://cdn.example.com/gallery-3.webp', altText: 'Galería 3', height: 800, width: 800 },
+    { url: 'https://cdn.example.com/gallery-4.webp', altText: 'Galería 4', height: 800, width: 800 },
+    { url: 'https://cdn.example.com/gallery-5.webp', altText: 'Galería 5', height: 800, width: 800 },
+  ],
+  availableForSale: true,
+  currencyCode: 'COP',
+  priceRange: {
+    minVariantPrice: { amount: '12000', currencyCode: 'COP' },
+    maxVariantPrice: { amount: '12000', currencyCode: 'COP' },
+  },
+  compareAtPrice: null,
+  seo: {
+    title: 'Café con galería',
+    description: 'Producto con 5 imágenes',
+  },
+  options: [],
+  tags: [],
+  variants: [
+    {
+      id: 'variant-1',
+      title: 'Default',
+      availableForSale: true,
+      price: { amount: '12000', currencyCode: 'COP' },
+      selectedOptions: [],
+    },
+  ],
+}
+
+describe('LatestProductCard primary image behavior', () => {
+  it('uses the featured/primary image even when the product has a 5-image gallery', () => {
+    render(<LatestProductCard product={productWithGallery} />)
+
+    const primaryImage = screen.getByRole('img', { name: 'Imagen primaria del café' })
+    expect(primaryImage).toHaveAttribute('src', 'https://cdn.example.com/primary.webp')
+    expect(screen.queryByRole('img', { name: 'Galería 2' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/products/cafe-galeria')
+  })
+
+  it('keeps principal cards on the featured/primary image', () => {
+    render(<LatestProductCard product={productWithGallery} principal />)
+
+    const primaryImage = screen.getByRole('img', { name: 'Imagen primaria del café' })
+    expect(primaryImage).toHaveAttribute('src', 'https://cdn.example.com/primary.webp')
+    expect(primaryImage).toHaveAttribute('data-priority', 'true')
+  })
+})

--- a/tests/products/product-image-gallery.test.tsx
+++ b/tests/products/product-image-gallery.test.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable @next/next/no-img-element */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProductImageGallery } from "@/app/products/[slug]/components/product-image-gallery";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+}));
+
+vi.mock("embla-carousel-react", () => ({
+  default: () => [vi.fn(), { scrollPrev: vi.fn(), scrollNext: vi.fn(), scrollTo: vi.fn(), selectedScrollSnap: () => 0, on: vi.fn(), off: vi.fn() }],
+}));
+
+describe("ProductImageGallery", () => {
+  it("renders all five product images while keeping the first image primary", () => {
+    const images = Array.from({ length: 5 }, (_, index) => ({
+      url: `/product-${index + 1}.webp`,
+      alt: `Producto imagen ${index + 1}`,
+    }));
+
+    render(<ProductImageGallery images={images} />);
+
+    expect(screen.getByText("1/5")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /ver imagen/i })).toHaveLength(5);
+    expect(screen.getAllByAltText("Producto imagen 1")).toHaveLength(2);
+    expect(screen.getAllByAltText("Producto imagen 5")).toHaveLength(2);
+  });
+
+  it("shows an empty image state when no gallery images exist", () => {
+    render(<ProductImageGallery images={[]} />);
+
+    expect(screen.getByText("Sin imagen")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /ver imagen/i })).not.toBeInTheDocument();
+  });
+});

--- a/tests/products/products-api.contract.test.ts
+++ b/tests/products/products-api.contract.test.ts
@@ -235,6 +235,72 @@ describe("products-api contract", () => {
     ]);
   });
 
+  it("allows exactly five product images and persists their display order", async () => {
+    const state = new MockSupabaseState({
+      "store_items:select": [{ data: null, error: null }],
+      "store_items:insert": [
+        {
+          data: {
+            id: "item-5",
+            item_name: "Galería Cinco",
+            item_categories: null,
+          },
+          error: null,
+        },
+      ],
+      "item_images:insert": [{ error: null }],
+    });
+    getSupabaseEcommerceMock.mockReturnValue({ from: state.from });
+
+    const result = await createItem(
+      {
+        item_name: "Galería Cinco",
+        base_price: 12000,
+        primary_image_url: "https://example.com/1.webp",
+        primary_image_alt: "Galería Cinco",
+      },
+      [
+        "https://example.com/2.webp",
+        "https://example.com/3.webp",
+        "https://example.com/4.webp",
+        "https://example.com/5.webp",
+      ],
+    );
+
+    expect(result.success).toBe(true);
+    expect(state.inserts.item_images[0]).toEqual([
+      expect.objectContaining({ image_url: "https://example.com/1.webp", display_order: 1 }),
+      expect.objectContaining({ image_url: "https://example.com/2.webp", display_order: 2 }),
+      expect.objectContaining({ image_url: "https://example.com/3.webp", display_order: 3 }),
+      expect.objectContaining({ image_url: "https://example.com/4.webp", display_order: 4 }),
+      expect.objectContaining({ image_url: "https://example.com/5.webp", display_order: 5 }),
+    ]);
+  });
+
+  it("rejects more than five product images with a clear limit error", async () => {
+    const state = new MockSupabaseState({});
+    getSupabaseEcommerceMock.mockReturnValue({ from: state.from });
+
+    const result = await createItem(
+      {
+        item_name: "Demasiadas imágenes",
+        base_price: 12000,
+        primary_image_url: "https://example.com/1.webp",
+      },
+      [
+        "https://example.com/2.webp",
+        "https://example.com/3.webp",
+        "https://example.com/4.webp",
+        "https://example.com/5.webp",
+        "https://example.com/6.webp",
+      ],
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("máximo 5 imágenes");
+    expect(state.inserts.store_items).toBeUndefined();
+  });
+
   it("updates product slugs within the same store and refreshes normalized details", async () => {
     const state = new MockSupabaseState({
       "store_items_legacy:select": [
@@ -286,6 +352,45 @@ describe("products-api contract", () => {
       image_url: "https://example.com/new.webp",
       display_order: 1,
     });
+  });
+
+
+
+  it("removes every normalized product image when edit submits an empty gallery", async () => {
+    const state = new MockSupabaseState({
+      "store_items_legacy:select": [
+        {
+          data: {
+            id: "item-empty",
+            item_name: "Sin imágenes",
+            store_id: "store-1",
+            primary_image_url: "https://example.com/old.webp",
+          },
+          error: null,
+        },
+      ],
+      "store_items:update": [
+        {
+          data: { id: "item-empty", item_name: "Sin imágenes", item_categories: null },
+          error: null,
+        },
+      ],
+      "item_images:delete": [{ error: null }],
+    });
+    getSupabaseEcommerceMock.mockReturnValue({ from: state.from });
+
+    const result = await updateItem("item-empty", {
+      primary_image_url: null,
+      primary_image_alt: null,
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.updates.store_items[0]).toMatchObject({
+      primary_image_url: null,
+      primary_image_alt: null,
+    });
+    expect(state.deletes.item_images).toEqual([true]);
+    expect(state.inserts.item_images).toBeUndefined();
   });
 
   it("resolves the symbolic default store before filtering UUID store columns", async () => {


### PR DESCRIPTION
Closes #39

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Allows admin create/edit product flows to select and persist up to 5 product images with multi-file selection.
- Keeps the primary/featured image contract for cards while product detail gallery renders all images.
- Adds per-file validation, empty-gallery edit removal, and focused Strict TDD coverage.

## Changes
| File | Change |
|------|--------|
| `components/admin/multi-image-upload.tsx` | Defaults to 5 images, exposes accessible `multiple` file input, uploads sequentially, and reports per-file validation errors. |
| `app/admin/products/create/page.tsx` | Raises validation/uploader limit and helper copy from 3 to 5 images. |
| `app/admin/products/[id]/edit/page.tsx` | Raises limit/copy to 5 and submits nullable primary image values when gallery is cleared. |
| `lib/supabase/products-api.ts` | Allows exactly 5 images, rejects over 5, and clears normalized gallery rows on empty edit gallery. |
| `tests/components/multi-image-upload.test.tsx` | Covers five-file selection and per-file invalid/oversize/limit validation. |
| `tests/products/products-api.contract.test.ts` | Covers exactly-5 limit, over-limit rejection, and empty-gallery removal. |
| `tests/products/product-image-gallery.test.tsx` | Covers gallery rendering all 5 images and empty state. |
| `tests/products/latest-product-card.test.tsx` | Covers card primary/featured image behavior with a five-image gallery. |

## Supabase / migrations
- No Supabase schema migration required.
- No storage bucket or policy changes required.
- No RLS changes required.
- Existing `store_items.primary_image_*` plus `item_images` support one primary and four additional ordered images.

## Review size note
This PR is a documented single-PR size exception: the diff is over the 400-line review budget because Strict TDD required focused upload/API/gallery/card coverage, and the project direction is **1 PR per issue**.

## Test Plan
- [x] Focused tests: `node scripts/run-vitest.mjs tests/components/multi-image-upload.test.tsx tests/products/products-api.contract.test.ts tests/products/product-image-gallery.test.tsx tests/products/latest-product-card.test.tsx` (4 files / 14 tests)
- [x] Changed-file ESLint: `corepack pnpm exec eslint app/admin/products/[id]/edit/page.tsx app/admin/products/create/page.tsx components/admin/multi-image-upload.tsx lib/supabase/products-api.ts tests/components/multi-image-upload.test.tsx tests/products/products-api.contract.test.ts tests/products/product-image-gallery.test.tsx tests/products/latest-product-card.test.tsx --max-warnings=0`
- [x] Typecheck: `corepack pnpm typecheck`
- [x] Whitespace: `git diff --check`
- [x] Full suite before final copy-only fix: `node scripts/run-vitest.mjs` (42 files / 242 tests)
- [ ] Manual QA before merge: admin browser flow below

## Manual QA checklist before merge
1. Open `/admin/products/create` as admin and select 1-5 images in one picker action.
2. Confirm count reaches `5/5`, order is preserved for successful uploads, and invalid/oversize/over-limit files show filename-specific errors.
3. Save and confirm image 1 is primary and images 2-5 persist as gallery images.
4. Open an existing product in `/admin/products/[id]/edit`, replace and remove images, then save.
5. Clear all images in edit and confirm the product no longer has old primary/gallery images.
6. Open product detail and confirm gallery shows all persisted images.
7. Confirm latest/product cards still render the primary/featured image only.

## SDD / verification
- Apply artifact: `sdd/issue-39-multi-image-product-selection/apply-progress` (Engram observation 1463)
- Verify artifact: `sdd/issue-39-multi-image-product-selection/verify-report` (Engram observation 1474)
- Final SDD verdict: PASS

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:feature`
- [x] Ran relevant checks on modified files
- [x] Docs/issue notes include migration and manual QA details
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
