### PR TITLE
fix(marketing): surface popup publishability

### DIFF
--- a/app/admin/home-discount-popup/page.tsx
+++ b/app/admin/home-discount-popup/page.tsx
@@ -32,6 +32,7 @@ import { deferStateUpdate } from "@/lib/react/defer-state-update";
 import {
   normalizeHomeDiscountPopupConfig,
   parseDateTimeLocalValue,
+  validateHomeDiscountPopupAdminStatus,
   type HomeDiscountPopupConfig,
   type HomeDiscountPopupCtaMode,
   toDateTimeLocalValue,
@@ -237,6 +238,7 @@ export default function HomeDiscountPopupConfigPage() {
     imageUrl: previewImageUrl ?? config.imageUrl,
     fingerprint: "admin-preview",
   };
+  const adminStatus = validateHomeDiscountPopupAdminStatus(config);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-muted">
@@ -265,6 +267,26 @@ export default function HomeDiscountPopupConfigPage() {
           </div>
         ) : (
           <>
+            {config.active && !adminStatus.publishable ? (
+              <div
+                role="alert"
+                className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950"
+              >
+                <p className="font-semibold">
+                  La promo activa no se publicará hasta corregir la
+                  configuración.
+                </p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {adminStatus.issues.map((issue) => (
+                    <li key={issue.code}>
+                      <span>{issue.message}</span>
+                      <span> {issue.action}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">

--- a/lib/home-discount-popup.ts
+++ b/lib/home-discount-popup.ts
@@ -35,6 +35,28 @@ export interface HomeDiscountPopupEligibilityResult {
   reason?: "inactive" | "route" | "schedule" | "cooldown" | "invalid_cta";
 }
 
+export type HomeDiscountPopupAdminIssueCode =
+  | "inactive"
+  | "missing_title"
+  | "missing_text"
+  | "missing_cta_text"
+  | "missing_coupon"
+  | "missing_redirect_url"
+  | "invalid_date_range"
+  | "not_started"
+  | "expired";
+
+export interface HomeDiscountPopupAdminIssue {
+  code: HomeDiscountPopupAdminIssueCode;
+  message: string;
+  action: string;
+}
+
+export interface HomeDiscountPopupAdminStatus {
+  publishable: boolean;
+  issues: HomeDiscountPopupAdminIssue[];
+}
+
 const DEFAULT_DELAY_SECONDS = 4;
 const DEFAULT_FREQUENCY_HOURS = 24;
 const DEFAULT_VISIBLE_DURATION_SECONDS = 15;
@@ -332,5 +354,95 @@ export function projectPublicHomeDiscountPopupConfig(
   return {
     ...config,
     fingerprint: getHomeDiscountPopupFingerprint(config),
+  };
+}
+
+export function validateHomeDiscountPopupAdminStatus(
+  config: HomeDiscountPopupConfig,
+  now: Date = new Date(),
+): HomeDiscountPopupAdminStatus {
+  const issues: HomeDiscountPopupAdminIssue[] = [];
+
+  if (!config.active) {
+    issues.push({
+      code: "inactive",
+      message: "El popup está desactivado.",
+      action: "Activa el popup cuando quieras publicarlo en la home.",
+    });
+  }
+
+  if (!config.title) {
+    issues.push({
+      code: "missing_title",
+      message: "Falta el título del popup.",
+      action: "Agrega un título visible para la campaña.",
+    });
+  }
+
+  if (!config.text) {
+    issues.push({
+      code: "missing_text",
+      message: "Falta el mensaje principal.",
+      action: "Agrega el texto que verá el visitante.",
+    });
+  }
+
+  if (!config.ctaText) {
+    issues.push({
+      code: "missing_cta_text",
+      message: "Falta el texto del CTA.",
+      action: "Agrega el texto del botón de la promo.",
+    });
+  }
+
+  if (config.ctaMode === "redirect" && !config.ctaUrl) {
+    issues.push({
+      code: "missing_redirect_url",
+      message: "El CTA de redirección no tiene una URL válida.",
+      action: "Agrega una URL HTTPS para publicar este CTA.",
+    });
+  }
+
+  if (config.ctaMode === "copy_coupon" && !config.coupon) {
+    issues.push({
+      code: "missing_coupon",
+      message: "El CTA de copiar cupón no tiene código.",
+      action: "Agrega un cupón o cambia el CTA a redirección con URL HTTPS.",
+    });
+  }
+
+  const startsAt = config.startsAt ? new Date(config.startsAt) : null;
+  const endsAt = config.endsAt ? new Date(config.endsAt) : null;
+
+  if (startsAt && endsAt && startsAt.getTime() > endsAt.getTime()) {
+    issues.push({
+      code: "invalid_date_range",
+      message: "La fecha de inicio es posterior a la fecha de fin.",
+      action:
+        "Corrige las fechas de vigencia para que el inicio sea anterior al fin.",
+    });
+  } else if (config.active) {
+    const timestamp = now.getTime();
+
+    if (startsAt && timestamp < startsAt.getTime()) {
+      issues.push({
+        code: "not_started",
+        message: "La campaña aún no comenzó.",
+        action: "Ajusta la fecha de inicio si quieres publicarla ahora.",
+      });
+    }
+
+    if (endsAt && timestamp > endsAt.getTime()) {
+      issues.push({
+        code: "expired",
+        message: "La campaña ya finalizó.",
+        action: "Extiende la fecha de fin o desactiva esta campaña.",
+      });
+    }
+  }
+
+  return {
+    publishable: config.active && issues.length === 0,
+    issues,
   };
 }

--- a/lib/home-discount-popup.ts
+++ b/lib/home-discount-popup.ts
@@ -145,9 +145,13 @@ function normalizeCtaMode(value: unknown): HomeDiscountPopupCtaMode {
   return value === "redirect" ? "redirect" : "copy_coupon";
 }
 
+function hasValidRedirectCtaUrl(config: HomeDiscountPopupConfig): boolean {
+  return Boolean(sanitizePublicUrl(config.ctaUrl));
+}
+
 function hasValidCta(config: HomeDiscountPopupConfig): boolean {
   if (config.ctaMode === "redirect") {
-    return Boolean(config.ctaUrl);
+    return hasValidRedirectCtaUrl(config);
   }
 
   return Boolean(config.coupon);
@@ -395,7 +399,7 @@ export function validateHomeDiscountPopupAdminStatus(
     });
   }
 
-  if (config.ctaMode === "redirect" && !config.ctaUrl) {
+  if (config.ctaMode === "redirect" && !hasValidRedirectCtaUrl(config)) {
     issues.push({
       code: "missing_redirect_url",
       message: "El CTA de redirección no tiene una URL válida.",

--- a/tests/components/home-discount-popup.test.tsx
+++ b/tests/components/home-discount-popup.test.tsx
@@ -124,4 +124,55 @@ describe("HomeDiscountPopup", () => {
 
     expect(screen.queryByText(baseConfig.title)).not.toBeInTheDocument();
   });
+
+  it("shows a changed campaign fingerprint even when the previous campaign is in cooldown", () => {
+    const oldStorageKey =
+      "osoria.homeDiscountPopup.store-123.previous-fingerprint";
+    localStorage.setItem(
+      oldStorageKey,
+      JSON.stringify({ dismissedAt: "2026-04-23T11:59:00.000Z" }),
+    );
+
+    mockUseStore.mockReturnValue({
+      store: {
+        id: "store-123",
+        store_name: "Osoria",
+        homeDiscountPopup: {
+          ...baseConfig,
+          title: "Nueva campaña",
+          fingerprint: "new-fingerprint",
+        },
+      },
+    });
+
+    render(<HomeDiscountPopup />);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("Nueva campaña")).toBeInTheDocument();
+  });
+
+  it("does not render active popup data when its CTA is invalid", () => {
+    mockUseStore.mockReturnValue({
+      store: {
+        id: "store-123",
+        store_name: "Osoria",
+        homeDiscountPopup: {
+          ...baseConfig,
+          ctaMode: "redirect",
+          ctaUrl: null,
+        },
+      },
+    });
+
+    render(<HomeDiscountPopup />);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText(baseConfig.title)).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/home-discount-popup.test.tsx
+++ b/tests/components/home-discount-popup.test.tsx
@@ -46,11 +46,36 @@ const baseConfig: PublicHomeDiscountPopupConfig = {
   fingerprint: "fingerprint-abc",
 };
 
+function createMemoryStorage(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => {
+      entries.clear();
+    },
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      entries.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      entries.set(key, value);
+    },
+  };
+}
+
 describe("HomeDiscountPopup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-23T12:00:00.000Z"));
-    localStorage.clear();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
+    window.localStorage.clear();
     mockUseStore.mockReturnValue({
       store: {
         id: "store-123",
@@ -69,7 +94,9 @@ describe("HomeDiscountPopup", () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     vi.useRealTimers();
   });
 
@@ -128,7 +155,7 @@ describe("HomeDiscountPopup", () => {
   it("shows a changed campaign fingerprint even when the previous campaign is in cooldown", () => {
     const oldStorageKey =
       "osoria.homeDiscountPopup.store-123.previous-fingerprint";
-    localStorage.setItem(
+    window.localStorage.setItem(
       oldStorageKey,
       JSON.stringify({ dismissedAt: "2026-04-23T11:59:00.000Z" }),
     );

--- a/tests/lib/home-discount-popup.test.ts
+++ b/tests/lib/home-discount-popup.test.ts
@@ -419,6 +419,34 @@ describe("validateHomeDiscountPopupAdminStatus", () => {
     );
   });
 
+  it.each(["foo", "javascript:alert(1)"])(
+    "does not mark redirect campaigns publishable when the CTA URL is %s",
+    (ctaUrl) => {
+      const status = validateHomeDiscountPopupAdminStatus(
+        {
+          ...normalizeHomeDiscountPopupConfig({
+            active: true,
+            title: "Promo home",
+            text: "Texto",
+            ctaText: "Ir ahora",
+            ctaMode: "redirect",
+            ctaUrl: "https://example.com/promo",
+          }),
+          ctaUrl,
+        },
+        new Date("2026-05-08T10:00:00.000Z"),
+      );
+
+      expect(status.publishable).toBe(false);
+      expect(status.issues).toEqual([
+        expect.objectContaining({
+          code: "missing_redirect_url",
+          action: expect.stringContaining("URL"),
+        }),
+      ]);
+    },
+  );
+
   it("marks a complete active coupon campaign as publishable", () => {
     expect(
       validateHomeDiscountPopupAdminStatus(

--- a/tests/lib/home-discount-popup.test.ts
+++ b/tests/lib/home-discount-popup.test.ts
@@ -12,6 +12,7 @@ import {
   parseDateTimeLocalValue,
   projectPublicHomeDiscountPopupConfig,
   toDateTimeLocalValue,
+  validateHomeDiscountPopupAdminStatus,
 } from "@/lib/home-discount-popup";
 import {
   HOME_DISCOUNT_POPUP_UPLOAD_BUCKET,
@@ -130,6 +131,40 @@ describe("isHomeDiscountPopupEligible", () => {
     });
     expect(wrongRoute).toMatchObject({ eligible: false, reason: "route" });
     expect(expired).toMatchObject({ eligible: false, reason: "schedule" });
+  });
+
+  it("blocks inactive, invalid CTA, and future campaign schedules with actionable reasons", () => {
+    const storageKey = getHomeDiscountPopupStorageKey("store-123", "campaign");
+
+    expect(
+      isHomeDiscountPopupEligible({
+        config: { ...config, active: false },
+        pathname: "/",
+        now: new Date("2026-04-23T12:00:00.000Z"),
+        storageKey,
+        storageSnapshot: {},
+      }),
+    ).toEqual({ eligible: false, reason: "inactive" });
+
+    expect(
+      isHomeDiscountPopupEligible({
+        config: { ...config, ctaMode: "redirect", ctaUrl: null },
+        pathname: "/",
+        now: new Date("2026-04-23T12:00:00.000Z"),
+        storageKey,
+        storageSnapshot: {},
+      }),
+    ).toEqual({ eligible: false, reason: "invalid_cta" });
+
+    expect(
+      isHomeDiscountPopupEligible({
+        config: { ...config, startsAt: "2026-04-24T10:00:00.000Z" },
+        pathname: "/",
+        now: new Date("2026-04-23T12:00:00.000Z"),
+        storageKey,
+        storageSnapshot: {},
+      }),
+    ).toEqual({ eligible: false, reason: "schedule" });
   });
 });
 
@@ -350,5 +385,55 @@ describe("getHomeDiscountPopupStorageKey", () => {
     expect(getHomeDiscountPopupStorageKey("store-123", "fingerprint-abc")).toBe(
       "osoria.homeDiscountPopup.store-123.fingerprint-abc",
     );
+  });
+});
+
+describe("validateHomeDiscountPopupAdminStatus", () => {
+  it("returns actionable admin issues when an active popup cannot publish", () => {
+    const status = validateHomeDiscountPopupAdminStatus(
+      normalizeHomeDiscountPopupConfig({
+        active: true,
+        title: "Promo home",
+        text: "Texto",
+        ctaText: "Ir ahora",
+        ctaMode: "redirect",
+        ctaUrl: "",
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-09T10:00:00.000Z",
+      }),
+      new Date("2026-05-08T10:00:00.000Z"),
+    );
+
+    expect(status.publishable).toBe(false);
+    expect(status.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing_redirect_url",
+          action: expect.stringContaining("URL"),
+        }),
+        expect.objectContaining({
+          code: "invalid_date_range",
+          action: expect.stringContaining("fechas"),
+        }),
+      ]),
+    );
+  });
+
+  it("marks a complete active coupon campaign as publishable", () => {
+    expect(
+      validateHomeDiscountPopupAdminStatus(
+        normalizeHomeDiscountPopupConfig({
+          active: true,
+          title: "Promo home",
+          text: "Texto",
+          ctaText: "Copiar cupon",
+          coupon: "HOME10",
+          ctaMode: "copy_coupon",
+          startsAt: "2026-05-01T10:00:00.000Z",
+          endsAt: "2026-05-20T10:00:00.000Z",
+        }),
+        new Date("2026-05-08T10:00:00.000Z"),
+      ),
+    ).toEqual({ publishable: true, issues: [] });
   });
 });

--- a/tests/security/home-discount-popup-admin-page.test.ts
+++ b/tests/security/home-discount-popup-admin-page.test.ts
@@ -265,6 +265,31 @@ describe("home discount popup admin page", () => {
     expect(mockToastSuccess).toHaveBeenCalledWith("Popup promocional guardado");
   });
 
+  it("shows an actionable admin alert when the active popup config cannot publish", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        config: {
+          active: true,
+          title: "Promo home",
+          text: "Texto",
+          ctaText: "Ir ahora",
+          ctaMode: "redirect",
+          ctaUrl: "",
+        },
+      }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(createElement(HomeDiscountPopupConfigPage));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "La promo activa no se publicará",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Agrega una URL HTTPS");
+  });
+
   it("opens a local preview with unsaved content and the staged image without uploading", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
Closes #40

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds admin publishability validation for active home discount popups and an actionable warning when configuration cannot publish.
- Verifies public popup rules for active display, invalid CTA suppression, route/date/cooldown gating, and new-campaign fingerprint behavior.
- Keeps existing config persistence and public projection paths unchanged where tests confirm they already satisfy the issue scope.

## Changes
| File | Change |
|------|--------|
| `lib/home-discount-popup.ts` | Adds typed `validateHomeDiscountPopupAdminStatus` helper with actionable issue codes/messages. |
| `app/admin/home-discount-popup/page.tsx` | Shows `role="alert"` for active but unpublishable popup configs. |
| `tests/lib/home-discount-popup.test.ts` | Adds inactive, invalid CTA, date, and admin validation coverage. |
| `tests/components/home-discount-popup.test.tsx` | Adds cooldown/fingerprint and invalid CTA render coverage. |
| `tests/security/home-discount-popup-admin-page.test.ts` | Adds admin actionable-alert coverage. |

## Supabase / migrations
- No Supabase schema migration required.
- No storage changes required; existing `marketing-assets` path remains unchanged.
- No RLS changes required.
- Popup config remains in `ecommerce.store_integrations.metadata.homeDiscountPopup`.

## Test Plan
- [x] Focused tests: `node scripts/run-vitest.mjs tests/lib/home-discount-popup.test.ts tests/components/home-discount-popup.test.tsx tests/security/home-discount-popup-config-route.test.ts tests/security/home-discount-popup-admin-page.test.ts` (26/26)
- [x] Related regression: same focused tests + `tests/security/store-contract.test.ts` (29/29)
- [x] Changed-file ESLint: `npx eslint app/admin/home-discount-popup/page.tsx lib/home-discount-popup.ts tests/components/home-discount-popup.test.tsx tests/lib/home-discount-popup.test.ts tests/security/home-discount-popup-admin-page.test.ts --max-warnings=0`
- [x] Typecheck fallback: `npx tsc --noEmit -p tsconfig.quality.json`
- [x] Whitespace: `git diff --check`
- [ ] Manual QA before merge: browser flow below

## Notes / warnings
- `corepack pnpm typecheck` could not run in this worktree because local `tsc` was missing; equivalent `npx tsc --noEmit -p tsconfig.quality.json` passed.
- Coverage report is unavailable because `@vitest/coverage-v8` is not installed.
- Component tests emit pre-existing React `act(...)` timer warnings, but assertions pass.

## Manual QA checklist before merge
1. Configure an active valid popup in `/admin/home-discount-popup` with CTA and current dates.
2. Open `/` as a fresh visitor and confirm popup appears after configured delay.
3. Close popup, reload within `frequencyHours`, and confirm cooldown prevents repeat.
4. Change the popup configuration, reload as same visitor, and confirm new fingerprint allows the updated campaign.
5. Set active redirect CTA without URL and confirm admin shows an actionable alert.
6. Check mobile viewport for popup placement.

## SDD / verification
- Apply artifact: `sdd/issue-40-home-popup-rules-visibility/apply-progress` (Engram observation 1477)
- Verify artifact: `sdd/issue-40-home-popup-rules-visibility/verify-report` (Engram observation 1481)
- Final SDD verdict: PASS WITH WARNINGS

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Ran relevant checks on modified files
- [x] Docs/issue notes include migration and manual QA details
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
