### PR TITLE
feat(products): clarify pricing visibility

### DIFF
--- a/app/admin/products/[id]/edit/page.tsx
+++ b/app/admin/products/[id]/edit/page.tsx
@@ -27,6 +27,7 @@ import { updateItem, getCategories, getItemById } from "@/lib/supabase/products-
 import type { ItemCategory } from "@/lib/types/products"
 import { MultiImageUpload } from "@/components/admin/multi-image-upload"
 import { toast } from "sonner"
+import { getAdminCompareAtPriceNotice, getValidCompareAtPrice } from "@/lib/shopify/utils"
 
 export default function EditProductPage() {
   const { isAdmin, loading } = useAdminPermissions()
@@ -158,6 +159,8 @@ export default function EditProductPage() {
     }
   }, [isAdmin, productId, router])
 
+  const compareAtPriceNotice = getAdminCompareAtPriceNotice(formData.base_price, formData.compare_at_price)
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     
@@ -167,8 +170,12 @@ export default function EditProductPage() {
     }
 
     if (!formData.base_price || parseFloat(formData.base_price) <= 0) {
-      toast.error("El precio base debe ser mayor a 0")
+      toast.error("El precio de venta actual debe ser mayor a 0")
       return
+    }
+
+    if (compareAtPriceNotice) {
+      toast.warning(compareAtPriceNotice)
     }
 
     // Validar imágenes: máximo 3
@@ -205,7 +212,7 @@ export default function EditProductPage() {
           item_description: formData.item_description.trim() || undefined,
           category_id: formData.category_id || undefined,
           base_price: parseFloat(formData.base_price),
-          compare_at_price: formData.compare_at_price ? parseFloat(formData.compare_at_price) : undefined,
+          compare_at_price: getValidCompareAtPrice(formData.base_price, formData.compare_at_price),
           currency_code: formData.currency_code,
           is_active: formData.is_active,
           is_featured: formData.is_featured,
@@ -427,7 +434,7 @@ export default function EditProductPage() {
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-3 gap-4">
                     <div className="space-y-2">
-                      <Label htmlFor="base_price">Precio Base *</Label>
+                      <Label htmlFor="base_price">Precio de venta actual *</Label>
                       <Input
                         id="base_price"
                         type="number"
@@ -435,13 +442,16 @@ export default function EditProductPage() {
                         min="0"
                         value={formData.base_price}
                         onChange={(e) => setFormData({ ...formData, base_price: e.target.value })}
-                        placeholder="0.00"
+                        placeholder="Ej: 72000"
                         required
                       />
+                      <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+                        Este es el precio que pagará el cliente. Se muestra como precio actual en tienda, cards y detalle.
+                      </p>
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="compare_at_price">Precio Comparación</Label>
+                      <Label htmlFor="compare_at_price">Precio anterior / precio de comparación</Label>
                       <Input
                         id="compare_at_price"
                         type="number"
@@ -449,8 +459,17 @@ export default function EditProductPage() {
                         min="0"
                         value={formData.compare_at_price}
                         onChange={(e) => setFormData({ ...formData, compare_at_price: e.target.value })}
-                        placeholder="0.00"
+                        placeholder="Ej: 90000"
+                        aria-describedby={compareAtPriceNotice ? "compare-at-price-warning" : undefined}
                       />
+                      <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+                        Opcional: úsalo solo cuando sea mayor al precio actual; se verá tachado como referencia.
+                      </p>
+                      {compareAtPriceNotice ? (
+                        <p id="compare-at-price-warning" role="alert" className="text-xs font-medium text-amber-600">
+                          {compareAtPriceNotice}
+                        </p>
+                      ) : null}
                     </div>
 
                     <div className="space-y-2">

--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -27,6 +27,7 @@ import { createItem, getCategories } from "@/lib/supabase/products-api"
 import type { ItemCategory } from "@/lib/types/products"
 import { MultiImageUpload } from "@/components/admin/multi-image-upload"
 import { toast } from "sonner"
+import { getAdminCompareAtPriceNotice, getValidCompareAtPrice } from "@/lib/shopify/utils"
 
 export default function CreateProductPage() {
   const { isAdmin, loading } = useAdminPermissions()
@@ -86,6 +87,8 @@ export default function CreateProductPage() {
     }
   }, [isAdmin])
 
+  const compareAtPriceNotice = getAdminCompareAtPriceNotice(formData.base_price, formData.compare_at_price)
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     
@@ -95,8 +98,12 @@ export default function CreateProductPage() {
     }
 
     if (!formData.base_price || parseFloat(formData.base_price) <= 0) {
-      toast.error("El precio base debe ser mayor a 0")
+      toast.error("El precio de venta actual debe ser mayor a 0")
       return
+    }
+
+    if (compareAtPriceNotice) {
+      toast.warning(compareAtPriceNotice)
     }
 
     // Validar cantidad de stock
@@ -132,7 +139,7 @@ export default function CreateProductPage() {
           item_description: formData.item_description.trim() || undefined,
           category_id: formData.category_id || undefined,
           base_price: parseFloat(formData.base_price),
-          compare_at_price: formData.compare_at_price ? parseFloat(formData.compare_at_price) : undefined,
+          compare_at_price: getValidCompareAtPrice(formData.base_price, formData.compare_at_price),
           currency_code: formData.currency_code,
           is_active: formData.is_active,
           is_featured: formData.is_featured,
@@ -354,7 +361,7 @@ export default function CreateProductPage() {
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-3 gap-4">
                     <div className="space-y-2">
-                      <Label htmlFor="base_price">Precio Base *</Label>
+                      <Label htmlFor="base_price">Precio de venta actual *</Label>
                       <Input
                         id="base_price"
                         type="number"
@@ -362,13 +369,16 @@ export default function CreateProductPage() {
                         min="0"
                         value={formData.base_price}
                         onChange={(e) => setFormData({ ...formData, base_price: e.target.value })}
-                        placeholder="0.00"
+                        placeholder="Ej: 72000"
                         required
                       />
+                      <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+                        Este es el precio que pagará el cliente. Se muestra como precio actual en tienda, cards y detalle.
+                      </p>
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="compare_at_price">Precio Comparación</Label>
+                      <Label htmlFor="compare_at_price">Precio anterior / precio de comparación</Label>
                       <Input
                         id="compare_at_price"
                         type="number"
@@ -376,8 +386,17 @@ export default function CreateProductPage() {
                         min="0"
                         value={formData.compare_at_price}
                         onChange={(e) => setFormData({ ...formData, compare_at_price: e.target.value })}
-                        placeholder="0.00"
+                        placeholder="Ej: 90000"
+                        aria-describedby={compareAtPriceNotice ? "compare-at-price-warning" : undefined}
                       />
+                      <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+                        Opcional: úsalo solo cuando sea mayor al precio actual; se verá tachado como referencia.
+                      </p>
+                      {compareAtPriceNotice ? (
+                        <p id="compare-at-price-warning" role="alert" className="text-xs font-medium text-amber-600">
+                          {compareAtPriceNotice}
+                        </p>
+                      ) : null}
                     </div>
 
                     <div className="space-y-2">

--- a/app/shop/components/product-card/index.tsx
+++ b/app/shop/components/product-card/index.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import Link from 'next/link';
 import { Product } from '@/lib/shopify/types';
 import { AddToCart, AddToCartButton } from '@/components/cart/add-to-cart';
-import { formatPrice } from '@/lib/shopify/utils';
+import { resolveProductPricing } from '@/lib/shopify/utils';
 import { VariantSelector } from '../variant-selector';
 import { ProductImage } from './product-image';
 import { Button } from '@/components/ui/button';
@@ -14,10 +14,7 @@ export const ProductCard = ({ product }: { product: Product }) => {
   const hasNoOptions = product.options.length === 0;
   const hasOneOptionWithOneValue = product.options.length === 1 && product.options[0].values.length === 1;
   const justHasColorOption = product.options.length === 1 && product.options[0].name.toLowerCase() === 'color';
-  const formattedPrice = formatPrice(
-    product.priceRange.minVariantPrice.amount,
-    product.priceRange.minVariantPrice.currencyCode,
-  );
+  const pricing = resolveProductPricing(product.priceRange.minVariantPrice, product.compareAtPrice);
   const isCombo = product.productKind === 'combo';
 
   const renderInCardAddToCart = hasNoOptions || hasOneOptionWithOneValue || justHasColorOption;
@@ -36,7 +33,7 @@ export const ProductCard = ({ product }: { product: Product }) => {
       <Link
         href={`/products/${product.handle}`}
         className="block size-full focus-visible:outline-none"
-        aria-label={`View details for ${product.title}, price ${formattedPrice}`}
+        aria-label={`View details for ${product.title}, price ${pricing.formattedCurrentPrice}`}
         prefetch
       >
         <Suspense fallback={null}>
@@ -49,12 +46,13 @@ export const ProductCard = ({ product }: { product: Product }) => {
         <div className="flex gap-6 justify-between items-baseline px-3 py-1 w-full font-semibold transition-all duration-300 translate-y-0 max-md:hidden group-hover:opacity-0 group-focus-visible:opacity-0 group-hover:-translate-y-full group-focus-visible:-translate-y-full">
           <p className="text-sm uppercase 2xl:text-base text-balance">{product.title}</p>
           <div className="flex gap-2 items-center text-sm uppercase 2xl:text-base">
-            {formatPrice(product.priceRange.minVariantPrice.amount, product.priceRange.minVariantPrice.currencyCode)}
-            {product.compareAtPrice && (
+            {pricing.formattedCurrentPrice}
+            {pricing.formattedCompareAtPrice && (
               <span className="line-through opacity-30">
-                {formatPrice(product.compareAtPrice.amount, product.compareAtPrice.currencyCode)}
+                {pricing.formattedCompareAtPrice}
               </span>
             )}
+            {pricing.savingsLabel && <span className="sr-only">{pricing.savingsLabel}</span>}
           </div>
         </div>
 
@@ -65,12 +63,13 @@ export const ProductCard = ({ product }: { product: Product }) => {
               <Badge variant="outline" className="w-fit">Combo</Badge>
             )}
             <div className="flex gap-2 items-center place-self-end text-lg font-semibold">
-              {formatPrice(product.priceRange.minVariantPrice.amount, product.priceRange.minVariantPrice.currencyCode)}
-              {product.compareAtPrice && (
+              {pricing.formattedCurrentPrice}
+              {pricing.formattedCompareAtPrice && (
                 <span className="text-base line-through opacity-30">
-                  {formatPrice(product.compareAtPrice.amount, product.compareAtPrice.currencyCode)}
+                  {pricing.formattedCompareAtPrice}
                 </span>
               )}
+              {pricing.savingsLabel && <span className="sr-only">{pricing.savingsLabel}</span>}
             </div>
             {showVariantSelector ? (
               <Suspense fallback={null}>

--- a/components/products/featured-product-label.tsx
+++ b/components/products/featured-product-label.tsx
@@ -4,6 +4,7 @@ import { Product } from '@/lib/shopify/types';
 import { AddToCart, AddToCartButton } from '../cart/add-to-cart';
 import { Suspense } from 'react';
 import Link from 'next/link';
+import { resolveProductPricing } from '@/lib/shopify/utils';
 
 export function FeaturedProductLabel({
   product,
@@ -14,6 +15,8 @@ export function FeaturedProductLabel({
   principal?: boolean;
   className?: string;
 }) {
+  const pricing = resolveProductPricing(product.priceRange.minVariantPrice, product.compareAtPrice);
+
   if (principal) {
     return (
       <div
@@ -35,10 +38,11 @@ export function FeaturedProductLabel({
           <p className="text-sm font-medium line-clamp-3">{product.description}</p>
         </div>
         <div className="flex col-span-1 gap-3 items-center text-2xl font-semibold md:self-end">
-          ${Number(product.priceRange.minVariantPrice.amount)}
-          {product.compareAtPrice && (
-            <span className="line-through opacity-30">${Number(product.compareAtPrice.amount)}</span>
+          {pricing.formattedCurrentPrice}
+          {pricing.formattedCompareAtPrice && (
+            <span className="line-through opacity-30">{pricing.formattedCompareAtPrice}</span>
           )}
+          {pricing.savingsLabel && <span className="text-sm font-medium opacity-70">{pricing.savingsLabel}</span>}
         </div>
         <Suspense
           fallback={<AddToCartButton className="flex gap-20 justify-between pr-2" size="lg" product={product} />}
@@ -59,10 +63,11 @@ export function FeaturedProductLabel({
           {product.title}
         </Link>
         <div className="flex gap-2 items-center text-base font-semibold">
-          ${Number(product.priceRange.minVariantPrice.amount)}
-          {product.compareAtPrice && (
-            <span className="text-sm line-through opacity-30">${Number(product.compareAtPrice.amount)}</span>
+          {pricing.formattedCurrentPrice}
+          {pricing.formattedCompareAtPrice && (
+            <span className="text-sm line-through opacity-30">{pricing.formattedCompareAtPrice}</span>
           )}
+          {pricing.savingsLabel && <span className="sr-only">{pricing.savingsLabel}</span>}
         </div>
       </div>
       <Suspense fallback={<AddToCartButton product={product} iconOnly variant="default" size="icon-lg" />}>

--- a/components/sections/products-grid-wrapper.tsx
+++ b/components/sections/products-grid-wrapper.tsx
@@ -1,9 +1,10 @@
 import { ProductsGrid } from "./products-grid"
 import { getItems } from "@/lib/supabase/products-api"
+import { resolveProductPricing } from "@/lib/shopify/utils"
 
 export async function ProductsGridWrapper() {
   // Obtener productos de la base de datos
-  let products: Array<{ id: string; name: string; category: string; price: string; image: string; slug: string }> = []
+  let products: Array<{ id: string; name: string; category: string; price: string; compareAtPrice?: string; savingsLabel?: string; image: string; slug: string }> = []
   
   try {
     const result = await getItems({
@@ -14,29 +15,26 @@ export async function ProductsGridWrapper() {
       order_direction: 'asc',
     })
     
-    products = result.items.map(item => ({
-      id: item.id,
-      name: item.item_name,
-      category: item.category?.category_name || "Sin categoría",
-      price: formatPrice(item.base_price, item.currency_code),
-      image: item.primary_image_url || "/placeholder.svg",
-      slug: item.item_slug || item.id,
-    }))
+    products = result.items.map(item => {
+      const pricing = resolveProductPricing(
+        { amount: String(item.base_price), currencyCode: item.currency_code },
+        item.compare_at_price ? { amount: String(item.compare_at_price), currencyCode: item.currency_code } : undefined,
+      )
+
+      return {
+        id: item.id,
+        name: item.item_name,
+        category: item.category?.category_name || "Sin categoría",
+        price: pricing.formattedCurrentPrice,
+        compareAtPrice: pricing.formattedCompareAtPrice,
+        savingsLabel: pricing.savingsLabel,
+        image: item.primary_image_url || "/placeholder.svg",
+        slug: item.item_slug || item.id,
+      }
+    })
   } catch (error) {
     console.error('Error fetching products:', error)
   }
 
   return <ProductsGrid initialProducts={products} />
 }
-
-// Helper para formatear precio
-function formatPrice(price: number | string, currencyCode: string = "COP"): string {
-  const numPrice = typeof price === 'string' ? parseFloat(price) : price
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(numPrice)
-}
-

--- a/components/sections/products-grid.tsx
+++ b/components/sections/products-grid.tsx
@@ -60,6 +60,8 @@ interface ProductsGridProps {
     name: string
     category: string
     price: string
+    compareAtPrice?: string
+    savingsLabel?: string
     image: string
     slug?: string
   }>
@@ -177,9 +179,21 @@ export function ProductsGrid({ initialProducts }: ProductsGridProps = {}) {
                     {product.name}
                   </h3>
                   <p className="text-xs sm:text-sm md:text-[13.9775px] font-inter font-normal mb-2" style={{ color: "var(--muted-foreground)" }}>{product.category}</p>
-                  <p className="text-base sm:text-lg md:text-[20.5864px] font-inter font-normal" style={{ color: "var(--card-foreground)" }}>
-                    {product.price}
-                  </p>
+                  <div className="space-y-1">
+                    <p className="text-base sm:text-lg md:text-[20.5864px] font-inter font-normal" style={{ color: "var(--card-foreground)" }}>
+                      {product.price}
+                    </p>
+                    {product.compareAtPrice ? (
+                      <p className="text-xs sm:text-sm line-through" style={{ color: "var(--muted-foreground)" }}>
+                        {product.compareAtPrice}
+                      </p>
+                    ) : null}
+                    {product.savingsLabel ? (
+                      <p className="text-xs sm:text-sm font-medium" style={{ color: "var(--primary)" }}>
+                        {product.savingsLabel}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
 
                 <div 

--- a/lib/shopify/utils.ts
+++ b/lib/shopify/utils.ts
@@ -1,14 +1,90 @@
 import { thumbHashToDataURL } from 'thumbhash';
-import { ProductCollectionSortKey, ProductSortKey } from './types';
+import { Money, ProductCollectionSortKey, ProductSortKey } from './types';
+
+const COP_LOCALE = 'es-CO';
+
+function toNumber(value: number | string | undefined | null): number | null {
+  if (value === undefined || value === null || value === '') return null;
+
+  const parsed = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 // Format price utility
-export const formatPrice = (price: string, currencyCode: string): string => {
-  return new Intl.NumberFormat(undefined, {
+export const formatPrice = (price: number | string, currencyCode: string = 'COP'): string => {
+  const parsedPrice = toNumber(price) ?? 0;
+
+  return new Intl.NumberFormat(COP_LOCALE, {
     style: 'currency',
     currency: currencyCode,
     currencyDisplay: 'narrowSymbol',
-  }).format(parseFloat(price));
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(parsedPrice);
 };
+
+export interface ProductPricingVisibility {
+  currentPrice: Money;
+  compareAtPrice?: Money;
+  hasDiscount: boolean;
+  savingsAmount?: number;
+  discountPercent?: number;
+  formattedCurrentPrice: string;
+  formattedCompareAtPrice?: string;
+  formattedSavings?: string;
+  savingsLabel?: string;
+}
+
+export function resolveProductPricing(currentPrice: Money, compareAtPrice?: Money): ProductPricingVisibility {
+  const currentAmount = toNumber(currentPrice.amount) ?? 0;
+  const compareAmount = toNumber(compareAtPrice?.amount);
+  const hasDiscount = compareAmount !== null && compareAmount > currentAmount;
+  const savingsAmount = hasDiscount ? compareAmount - currentAmount : undefined;
+  const discountPercent = hasDiscount && compareAmount > 0
+    ? Math.round(((compareAmount - currentAmount) / compareAmount) * 100)
+    : undefined;
+  const formattedSavings = savingsAmount !== undefined
+    ? formatPrice(savingsAmount, currentPrice.currencyCode)
+    : undefined;
+
+  return {
+    currentPrice,
+    compareAtPrice: hasDiscount ? compareAtPrice : undefined,
+    hasDiscount,
+    savingsAmount,
+    discountPercent,
+    formattedCurrentPrice: formatPrice(currentAmount, currentPrice.currencyCode),
+    formattedCompareAtPrice: hasDiscount && compareAtPrice
+      ? formatPrice(compareAmount, compareAtPrice.currencyCode)
+      : undefined,
+    formattedSavings,
+    savingsLabel: formattedSavings && discountPercent !== undefined
+      ? `Ahorra ${formattedSavings} (${discountPercent}%)`
+      : undefined,
+  };
+}
+
+export const INVALID_COMPARE_AT_PRICE_NOTICE =
+  'El precio anterior debe ser mayor al precio de venta actual para mostrar descuento. Se guardará sin precio tachado.';
+
+export function getAdminCompareAtPriceNotice(basePrice: number | string, compareAtPrice?: number | string): string | null {
+  const baseAmount = toNumber(basePrice);
+  const compareAmount = toNumber(compareAtPrice);
+
+  if (baseAmount === null || compareAmount === null) return null;
+
+  return compareAmount <= baseAmount ? INVALID_COMPARE_AT_PRICE_NOTICE : null;
+}
+
+export function getValidCompareAtPrice(basePrice: number | string, compareAtPrice?: number | string): number | undefined {
+  const baseAmount = toNumber(basePrice);
+  const compareAmount = toNumber(compareAtPrice);
+
+  if (baseAmount === null || compareAmount === null || compareAmount <= baseAmount) return undefined;
+
+  return compareAmount;
+}
+
 
 // Helper for returning the expected error state to actions instead of throwing.
 export const handleFormActionError = (error: unknown, defaultMessage: string) => {

--- a/tests/components/shop-product-card.test.tsx
+++ b/tests/components/shop-product-card.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react';
+/* eslint-disable @next/next/no-img-element -- Test mock for next/image renders a plain img to keep component assertions focused. */
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ProductCard } from '@/app/shop/components/product-card';
+import { LatestProductCard } from '@/components/products/latest-product-card';
+import { ProductsGrid } from '@/components/sections/products-grid';
 import type { Product } from '@/lib/shopify/types';
 
 vi.mock('next/link', () => ({
@@ -9,6 +12,10 @@ vi.mock('next/link', () => ({
       {children}
     </a>
   ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => <img src={src} alt={alt} {...props} />,
 }));
 
 vi.mock('@/components/cart/add-to-cart', () => ({
@@ -28,30 +35,66 @@ vi.mock('@/components/wishlist/wishlist-button', () => ({
   WishlistButton: () => <button type="button" aria-label="Agregar a favoritos" />,
 }));
 
-const comboProduct: Product = {
+vi.mock('@/contexts/styles-context', () => ({
+  useComponentStyle: () => ({ styles: { title: 'Productos populares' } }),
+}));
+
+vi.mock('@/contexts/admin-context', () => ({
+  useAdmin: () => ({ componentEdits: new Map() }),
+}));
+
+vi.mock('@/contexts/store-context', () => ({
+  useStore: () => ({ store: { subdomain: 'default' } }),
+}));
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'product-1',
+    title: 'Café Especial',
+    handle: 'cafe-especial',
+    productKind: 'product',
+    description: 'Café premium',
+    descriptionHtml: '<p>Café premium</p>',
+    featuredImage: {
+      url: '/coffee.jpg',
+      altText: 'Café Especial',
+      height: 600,
+      width: 600,
+    },
+    currencyCode: 'COP',
+    priceRange: {
+      minVariantPrice: { amount: '72000', currencyCode: 'COP' },
+      maxVariantPrice: { amount: '72000', currencyCode: 'COP' },
+    },
+    seo: {
+      title: 'Café Especial',
+      description: 'Café premium',
+    },
+    options: [],
+    tags: [],
+    variants: [
+      {
+        id: 'variant-1',
+        title: 'Default',
+        availableForSale: true,
+        price: { amount: '72000', currencyCode: 'COP' },
+        selectedOptions: [],
+      },
+    ],
+    images: [],
+    availableForSale: true,
+    ...overrides,
+  };
+}
+
+const comboProduct = makeProduct({
   id: 'combo-1',
   title: 'Combo Café',
   handle: 'combo-cafe',
   productKind: 'combo',
   description: 'Café + mug',
   descriptionHtml: '<p>Café + mug</p>',
-  featuredImage: {
-    url: '/combo.jpg',
-    altText: 'Combo Café',
-    height: 600,
-    width: 600,
-  },
-  currencyCode: 'COP',
-  priceRange: {
-    minVariantPrice: { amount: '72000', currencyCode: 'COP' },
-    maxVariantPrice: { amount: '72000', currencyCode: 'COP' },
-  },
   compareAtPrice: { amount: '80000', currencyCode: 'COP' },
-  seo: {
-    title: 'Combo Café',
-    description: 'Café + mug',
-  },
-  options: [],
   tags: ['combo'],
   variants: [
     {
@@ -62,9 +105,7 @@ const comboProduct: Product = {
       selectedOptions: [],
     },
   ],
-  images: [],
-  availableForSale: true,
-};
+});
 
 describe('shop ProductCard combo behavior', () => {
   it('keeps a visible combo detail link while preserving card add-to-cart parity', () => {
@@ -74,5 +115,68 @@ describe('shop ProductCard combo behavior', () => {
     expect(detailLink).toHaveAttribute('href', '/products/combo-cafe');
     expect(screen.getByRole('button', { name: /agregar al carrito/i })).toBeInTheDocument();
     expect(screen.queryByTestId('variant-selector')).not.toBeInTheDocument();
+  });
+});
+
+describe('shop product card pricing visibility', () => {
+  it('shows the same current and comparison COP prices on product cards and latest cards', () => {
+    const saleProduct = makeProduct({ compareAtPrice: { amount: '90000', currencyCode: 'COP' } });
+
+    render(
+      <>
+        <ProductCard product={saleProduct} />
+        <LatestProductCard product={saleProduct} />
+      </>,
+    );
+
+    expect(screen.getAllByText(/\$\s72\.000/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/\$\s90\.000/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/Ahorra \$\s18\.000 \(20%\)/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not render stale comparison or savings copy when comparison is invalid', () => {
+    render(<ProductCard product={makeProduct({ compareAtPrice: { amount: '72000', currencyCode: 'COP' } })} />);
+
+    expect(screen.getAllByText(/\$\s72\.000/).length).toBeGreaterThan(0);
+    expect(screen.queryByText('Ahorra $ 0 (0%)')).not.toBeInTheDocument();
+    expect(screen.queryByText('$ 70.000')).not.toBeInTheDocument();
+  });
+
+  it('renders catalog/home grid prices with the same current and comparison values', () => {
+    render(
+      <ProductsGrid
+        initialProducts={[
+          {
+            id: 'product-1',
+            name: 'Café Especial',
+            category: 'Café',
+            price: '$ 72.000',
+            compareAtPrice: '$ 90.000',
+            savingsLabel: 'Ahorra $ 18.000 (20%)',
+            image: '/coffee.jpg',
+            slug: 'cafe-especial',
+          },
+          {
+            id: 'product-2',
+            name: 'Café Regular',
+            category: 'Café',
+            price: '$ 72.000',
+            compareAtPrice: undefined,
+            savingsLabel: undefined,
+            image: '/coffee-regular.jpg',
+            slug: 'cafe-regular',
+          },
+        ]}
+      />,
+    );
+
+    const saleCard = screen.getByRole('link', { name: /café especial/i });
+    expect(within(saleCard).getByText(/\$\s72\.000/)).toBeInTheDocument();
+    expect(within(saleCard).getByText(/\$\s90\.000/)).toBeInTheDocument();
+    expect(within(saleCard).getByText(/Ahorra \$\s18\.000 \(20%\)/)).toBeInTheDocument();
+
+    const regularCard = screen.getByRole('link', { name: /café regular/i });
+    expect(within(regularCard).getByText(/\$\s72\.000/)).toBeInTheDocument();
+    expect(within(regularCard).queryByText(/\$\s90\.000/)).not.toBeInTheDocument();
   });
 });

--- a/tests/products/admin-product-pricing-page.test.tsx
+++ b/tests/products/admin-product-pricing-page.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CreateProductPage from '@/app/admin/products/create/page';
+
+const mockUseAdminPermissions = vi.fn();
+const mockPush = vi.fn();
+const mockCreateItem = vi.fn();
+const mockGetCategories = vi.fn();
+const mockToastWarning = vi.fn();
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock('@/contexts/admin-permissions-context', () => ({
+  useAdminPermissions: () => mockUseAdminPermissions(),
+}));
+
+vi.mock('@/lib/supabase/products-api', () => ({
+  createItem: (...args: unknown[]) => mockCreateItem(...args),
+  getCategories: (...args: unknown[]) => mockGetCategories(...args),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) =>
+    createElement('a', { href }, children),
+}));
+
+vi.mock('lucide-react', () => {
+  const Icon = () => createElement('span');
+  return {
+    ArrowLeft: Icon,
+    Loader2: Icon,
+    Save: Icon,
+    ShieldAlert: Icon,
+  };
+});
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => createElement('div', {}, children),
+  SelectContent: ({ children }: { children: ReactNode }) => createElement('div', {}, children),
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) =>
+    createElement('div', { 'data-value': value }, children),
+  SelectTrigger: ({ children }: { children: ReactNode }) =>
+    createElement('button', { type: 'button' }, children),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => createElement('span', {}, placeholder),
+}));
+
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: ({ id, checked, onCheckedChange }: { id: string; checked: boolean; onCheckedChange: (value: boolean) => void }) =>
+    createElement('input', {
+      id,
+      type: 'checkbox',
+      checked,
+      onChange: (event: Event) => onCheckedChange((event.target as HTMLInputElement).checked),
+    }),
+}));
+
+vi.mock('@/components/admin/multi-image-upload', () => ({
+  MultiImageUpload: () => createElement('div', { 'data-testid': 'mock-image-upload' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    warning: (...args: unknown[]) => mockToastWarning(...args),
+  },
+}));
+
+function setupAdminCreatePage() {
+  mockUseAdminPermissions.mockReturnValue({ isAdmin: true, loading: false });
+  mockGetCategories.mockResolvedValue([]);
+  mockCreateItem.mockResolvedValue({
+    success: true,
+    item: { id: 'item-1', item_name: 'Café Especial' },
+  });
+}
+
+describe('admin product pricing page clarity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupAdminCreatePage();
+  });
+
+  it('renders commercial price labels and guidance for current and comparison prices', async () => {
+    render(<CreateProductPage />);
+
+    expect(screen.getByLabelText(/precio de venta actual/i)).toBeInTheDocument();
+    expect(screen.getByText(/precio que pagará el cliente/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/precio anterior \/ precio de comparación/i)).toBeInTheDocument();
+    expect(screen.getByText(/se verá tachado como referencia/i)).toBeInTheDocument();
+    await waitFor(() => expect(mockGetCategories).toHaveBeenCalledWith(true));
+  });
+
+  it('warns and omits compare_at_price when comparison is not greater than current price', async () => {
+    render(<CreateProductPage />);
+
+    fireEvent.change(screen.getByLabelText(/nombre del producto/i), {
+      target: { value: 'Café Especial' },
+    });
+    fireEvent.change(screen.getByLabelText(/precio de venta actual/i), {
+      target: { value: '72000' },
+    });
+    fireEvent.change(screen.getByLabelText(/precio anterior \/ precio de comparación/i), {
+      target: { value: '70000' },
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'El precio anterior debe ser mayor al precio de venta actual',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /crear producto/i }));
+
+    await waitFor(() => expect(mockCreateItem).toHaveBeenCalledTimes(1));
+    expect(mockToastWarning).toHaveBeenCalledWith(
+      'El precio anterior debe ser mayor al precio de venta actual para mostrar descuento. Se guardará sin precio tachado.',
+    );
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base_price: 72000,
+        compare_at_price: undefined,
+      }),
+      [],
+    );
+  });
+});

--- a/tests/products/product-pricing-visibility.test.tsx
+++ b/tests/products/product-pricing-visibility.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { adaptSupabaseProduct } from '@/lib/products/adapter';
+import { getAdminCompareAtPriceNotice, resolveProductPricing } from '@/lib/shopify/utils';
+
+const baseItem = {
+  id: 'item-1',
+  item_name: 'Café Especial',
+  item_slug: 'cafe-especial',
+  item_description: 'Café premium',
+  item_description_html: '<p>Café premium</p>',
+  item_kind: 'product',
+  combo: null,
+  category: { id: 'cat-1', category_name: 'Café', category_description: null, updated_at: '2026-05-14' },
+  category_id: 'cat-1',
+  base_price: 72000,
+  currency_code: 'COP',
+  compare_at_price: null,
+  primary_image_url: '/coffee.jpg',
+  primary_image_alt: 'Café Especial',
+  images: [],
+  options: [],
+  variants: [],
+  tags: [],
+  seo_title: null,
+  seo_description: null,
+  is_available_for_sale: true,
+  is_active: true,
+  metadata: {},
+} as any;
+
+describe('product pricing visibility projection', () => {
+  it('keeps a valid comparison price and exposes uniform COP labels and savings', () => {
+    const product = adaptSupabaseProduct({ ...baseItem, compare_at_price: 90000 });
+    const pricing = resolveProductPricing(product.priceRange.minVariantPrice, product.compareAtPrice);
+
+    expect(product.compareAtPrice).toEqual({ amount: '90000', currencyCode: 'COP' });
+    expect(pricing).toMatchObject({
+      hasDiscount: true,
+      formattedCurrentPrice: '$ 72.000',
+      formattedCompareAtPrice: '$ 90.000',
+      formattedSavings: '$ 18.000',
+      discountPercent: 20,
+    });
+  });
+
+  it('does not expose a false discount when comparison is missing or not greater than current price', () => {
+    const noDiscount = adaptSupabaseProduct({ ...baseItem, compare_at_price: null });
+    const invalidDiscount = adaptSupabaseProduct({ ...baseItem, compare_at_price: 72000 });
+
+    expect(resolveProductPricing(noDiscount.priceRange.minVariantPrice, noDiscount.compareAtPrice)).toMatchObject({
+      hasDiscount: false,
+      formattedCurrentPrice: '$ 72.000',
+      formattedCompareAtPrice: undefined,
+    });
+    expect(resolveProductPricing(invalidDiscount.priceRange.minVariantPrice, invalidDiscount.compareAtPrice)).toMatchObject({
+      hasDiscount: false,
+      formattedCurrentPrice: '$ 72.000',
+      formattedCompareAtPrice: undefined,
+    });
+    expect(invalidDiscount.compareAtPrice).toBeUndefined();
+  });
+
+  it('returns the admin warning copy for invalid comparison prices', () => {
+    expect(getAdminCompareAtPriceNotice('72000', '70000')).toBe(
+      'El precio anterior debe ser mayor al precio de venta actual para mostrar descuento. Se guardará sin precio tachado.',
+    );
+    expect(getAdminCompareAtPriceNotice('72000', '90000')).toBeNull();
+    expect(getAdminCompareAtPriceNotice('72000', '')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #41

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Renames and explains admin product pricing fields as **Precio de venta actual** and **Precio anterior / precio de comparación**.
- Centralizes COP price projection for cards/latest cards/home grids so current price, comparison price, and savings labels stay consistent.
- Prevents false discounts when `compare_at_price <= base_price` by warning admin and omitting invalid comparison values from save payloads.

## Changes
| File | Change |
|------|--------|
| `lib/shopify/utils.ts` | Adds uniform COP formatter, pricing projection, admin warning copy, and valid comparison sanitizer. |
| `app/admin/products/create/page.tsx` | Adds commercial labels/helper copy, inline alert, warning toast, and sanitized comparison save. |
| `app/admin/products/[id]/edit/page.tsx` | Mirrors create-page pricing clarity and invalid comparison handling. |
| `app/shop/components/product-card/index.tsx` | Uses shared pricing projection for current/comparison/savings. |
| `components/products/featured-product-label.tsx` | Uses shared pricing projection for latest/featured labels. |
| `components/sections/products-grid.tsx` | Renders shared current/comparison/savings labels in grids. |
| `components/sections/products-grid-wrapper.tsx` | Passes projected pricing into grid cards. |
| `tests/products/product-pricing-visibility.test.tsx` | Covers valid discount, no discount, invalid comparison, COP formatting. |
| `tests/products/admin-product-pricing-page.test.tsx` | Covers admin labels, invalid alert, warning toast, and sanitized save payload. |
| `tests/components/shop-product-card.test.tsx` | Covers card/latest/grid pricing consistency. |

## Supabase / migrations
- No Supabase schema migration required.
- No storage changes required.
- No RLS changes required.
- Existing `base_price`, `compare_at_price`, and `currency_code` fields are reused.

## Review size note
This PR is a documented single-PR size exception: review payload exceeds 400 lines due Strict TDD test coverage, and the project direction is **1 PR per issue**.

## Test Plan
- [x] Focused tests: `node scripts/run-vitest.mjs tests/products/product-pricing-visibility.test.tsx tests/products/admin-product-pricing-page.test.tsx tests/components/shop-product-card.test.tsx` (3 files / 9 tests)
- [x] Changed-file ESLint: `corepack pnpm exec eslint app/admin/products/create/page.tsx app/admin/products/[id]/edit/page.tsx app/shop/components/product-card/index.tsx components/products/latest-product-card.tsx components/products/featured-product-label.tsx components/sections/products-grid.tsx components/sections/products-grid-wrapper.tsx lib/products/adapter.ts lib/shopify/utils.ts tests/products/product-pricing-visibility.test.tsx tests/products/admin-product-pricing-page.test.tsx tests/components/shop-product-card.test.tsx --max-warnings=0`
- [x] Typecheck: `corepack pnpm typecheck`
- [x] Whitespace: `git diff --check`
- [x] Full suite: `corepack pnpm test` (41 files / 241 tests)
- [ ] Manual QA before merge: browser flow below

## Manual QA checklist before merge
1. Open `/admin/products/create` and confirm pricing labels/helper text are clear.
2. Enter current price 72,000 and comparison 70,000; confirm inline warning appears and saving omits false comparison.
3. Enter current price 72,000 and comparison 90,000; confirm no warning.
4. Check product cards/latest cards/home/catalog grids show current price, struck comparison, and savings label consistently for valid discounts.
5. Confirm products without valid comparison show only current price.
6. Check responsive spacing for savings label on mobile/card layouts.

## SDD / verification
- Apply artifact: `sdd/issue-41-admin-price-clarity-card-visibility/apply-progress` (Engram observation 1487)
- Verify artifact: `sdd/issue-41-admin-price-clarity-card-visibility/verify-report` (Engram observation 1491)
- Final SDD verdict: PASS WITH WARNINGS

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:feature`
- [x] Ran relevant checks on modified files
- [x] Docs/issue notes include migration and manual QA details
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
