### PR TITLE
feat(chatbot): add verified commerce context

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -13,6 +13,7 @@ import {
   type ChatbotPersistenceClient,
   type ChatbotStoreLookup,
 } from "@/lib/supabase/chatbot-api"
+import { getAssistantCommerceContext, isCommerceContextQuestion } from "@/lib/chatbot/commerce-context"
 import { ECOMMERCE_SCHEMA, ECOMMERCE_TABLES } from "@/lib/supabase/contract"
 import { buildProductsContextFromList } from "@/lib/products/chat-product-context"
 
@@ -354,14 +355,19 @@ export async function POST(request: NextRequest) {
         ))
       : null
 
-    const isProductQuestion = lastUserMessage ? isProductRelatedQuestion(lastUserMessage) : false
+    const isProductQuestion = lastUserMessage ? isCommerceContextQuestion(lastUserMessage) || isProductRelatedQuestion(lastUserMessage) : false
     let productsContext = ""
-    if (lastUserMessage) {
-      productsContext = await searchRelevantProducts(lastUserMessage, storeUuid)
+    if (lastUserMessage && productSupabase) {
+      productsContext = await getAssistantCommerceContext({
+        supabase: productSupabase,
+        storeUuid,
+        userMessage: lastUserMessage,
+      })
+      if (!productsContext) productsContext = await searchRelevantProducts(lastUserMessage, storeUuid)
       if (!productsContext) productsContext = await getStoreProductsContext(storeUuid)
     }
 
-    // Combinar la guía de la tienda con el catálogo real cuando exista. La guía nunca reemplaza datos reales.
+    // Combinar la guía de la tienda con el catálogo/comercio real cuando exista. La guía nunca reemplaza datos reales.
     let systemPrompt = buildChatbotSystemPrompt({
       config,
       productsContext,

--- a/components/chatbot/chatbot.tsx
+++ b/components/chatbot/chatbot.tsx
@@ -174,9 +174,12 @@ export function Chatbot({ isOpen, onClose }: ChatbotProps) {
         // La API falló: no mostrar respuestas genéricas que parezcan válidas
         const fallback = findAnswer(currentInput)
         const isSimpleGreeting = /^(hola|hi|hey|buenas|gracias|adios|chao)$/i.test(currentInput.trim())
+        const wantsPromotion = /descuento|descuentos|oferta|ofertas|promo|promoción|promocion|promociones|cupón|cupon|cupones|combo|combos/i.test(currentInput)
         const wantsStoreOrCatalog = /catalogo|catálogo|productos|tienda|qué tienen|que tienen|cuéntame|hablame|información|informacion/i.test(currentInput)
         if (isSimpleGreeting) {
           botResponseText = fallback
+        } else if (wantsPromotion) {
+          botResponseText = "No puedo confirmar promociones, descuentos, cupones o combos en este momento porque el asistente no pudo consultar datos reales. Revisa la tienda o intenta de nuevo en unos segundos."
         } else if (wantsStoreOrCatalog) {
           botResponseText = "No pude conectar con el asistente en este momento. Comprueba tu conexión e inténtalo de nuevo. Si estás en un despliegue (Vercel), verifica que las variables SUPABASE_SERVICE_ROLE_KEY y DEEPSEEK_API_KEY estén configuradas."
         } else {
@@ -194,7 +197,12 @@ export function Chatbot({ isOpen, onClose }: ChatbotProps) {
       setMessages((prev) => [...prev, botResponse])
     } catch {
       const isSimpleGreeting = /^(hola|hi|hey|buenas|gracias|adios|chao)$/i.test(currentInput.trim())
-      const text = isSimpleGreeting ? findAnswer(currentInput) : "El asistente no pudo responder. Inténtalo de nuevo."
+      const wantsPromotion = /descuento|descuentos|oferta|ofertas|promo|promoción|promocion|promociones|cupón|cupon|cupones|combo|combos/i.test(currentInput)
+      const text = isSimpleGreeting
+        ? findAnswer(currentInput)
+        : wantsPromotion
+          ? "No puedo confirmar promociones, descuentos, cupones o combos en este momento porque el asistente no pudo consultar datos reales. Revisa la tienda o intenta de nuevo en unos segundos."
+          : "El asistente no pudo responder. Inténtalo de nuevo."
       const botResponse: Message = {
         id: (Date.now() + 1).toString(),
         text,

--- a/docs/supabase/current-schema.md
+++ b/docs/supabase/current-schema.md
@@ -181,3 +181,9 @@ Este lane implementa un **contrato runtime app-side** para tolerar payloads lega
   - La mutación real se ejecuta server-side con `SUPABASE_SERVICE_ROLE_KEY` sobre `ecommerce.component_styles`.
 - Objetivo: reparar el `42501 permission denied for table component_styles` sin ampliar grants ni ejecutar SQL en vivo.
 - Alcance: este cambio no toca `public.*`, no cambia RLS/policies y no altera la ruta legacy de lectura.
+
+## Assistant commerce context runtime note (issue #43)
+
+- The storefront assistant commerce-context work is runtime-only.
+- It reads existing ecommerce products, combos, inventory fields, and `store_integrations.metadata.homeDiscountPopup` data.
+- No Supabase migration, policy change, table change, seed, or backfill is required for this issue.

--- a/lib/chatbot/commerce-context.ts
+++ b/lib/chatbot/commerce-context.ts
@@ -1,0 +1,176 @@
+import {
+  isHomeDiscountPopupWithinSchedule,
+  projectPublicHomeDiscountPopupConfig,
+  type PublicHomeDiscountPopupConfig,
+} from "@/lib/home-discount-popup"
+import { listCombos } from "@/lib/supabase/combos-api"
+import { ECOMMERCE_TABLES } from "@/lib/supabase/contract"
+
+export type AssistantCommerceProduct = {
+  id: string
+  item_name: string | null
+  item_description?: string | null
+  base_price: number | string | null
+  compare_at_price?: number | string | null
+  currency_code?: string | null
+  item_slug?: string | null
+  is_active?: boolean | null
+  is_available_for_sale?: boolean | null
+  track_inventory?: boolean | null
+  inventory_quantity?: number | string | null
+  metadata?: unknown
+}
+
+export type AssistantCommerceCombo = {
+  id: string
+  name: string
+  slug?: string | null
+  description?: string | null
+  isActive?: boolean
+  pricing: { finalUnitPrice: number; componentSubtotal: number; currencyCode: string }
+  availability: { isAvailable: boolean }
+}
+
+type BuildInput = {
+  products: AssistantCommerceProduct[]
+  combos: AssistantCommerceCombo[]
+  popup: PublicHomeDiscountPopupConfig | null
+  now: Date
+}
+
+const KEYWORDS = [
+  "producto", "productos", "catálogo", "catalogo", "precio", "precios", "comprar", "compra",
+  "descuento", "descuentos", "promo", "promoción", "promocion", "promociones", "oferta", "ofertas",
+  "cupón", "cupon", "cupones", "combo", "combos", "qué tienen", "que tienen", "qué venden", "que venden",
+]
+
+const numberOrNull = (value: unknown) => {
+  const numeric = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}
+const currency = (value?: string | null) => value?.trim() || "COP"
+const compact = (value: string, max = 180) => value.length > max ? `${value.slice(0, max).trim()}...` : value
+
+function isSaleable(product: AssistantCommerceProduct) {
+  return product.is_active !== false && product.is_available_for_sale !== false
+}
+
+function productAvailability(product: AssistantCommerceProduct) {
+  if (!isSaleable(product)) return "no disponible"
+  if (product.track_inventory !== true) return "disponible"
+  const quantity = numberOrNull(product.inventory_quantity) ?? 0
+  return quantity > 0 ? `disponible (${quantity} en inventario)` : "no disponible"
+}
+
+function productCta(product: AssistantCommerceProduct) {
+  if (productAvailability(product) === "no disponible") return null
+  return `/products/${product.item_slug?.trim() || product.id}`
+}
+
+function aiDetails(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return ""
+  const details = (metadata as Record<string, unknown>).ai_details
+  return typeof details === "string" ? details.trim() : ""
+}
+
+function productLine(product: AssistantCommerceProduct) {
+  const current = numberOrNull(product.base_price)
+  if (current === null) return null
+  const previous = numberOrNull(product.compare_at_price)
+  const lines = [
+    `- ${product.item_name?.trim() || "Producto sin nombre"}`,
+    `  Precio actual: ${current} ${currency(product.currency_code)}`,
+  ]
+  if (previous !== null && previous > current) lines.push(`  Precio anterior: ${previous} ${currency(product.currency_code)}`)
+  lines.push(`  Disponibilidad: ${productAvailability(product)}`)
+  const cta = productCta(product)
+  if (cta) lines.push(`  CTA: ${cta}`)
+  if (product.item_description?.trim()) lines.push(`  Descripción: ${compact(product.item_description.trim())}`)
+  const details = aiDetails(product.metadata)
+  if (details) lines.push(`  Detalles: ${compact(details)}`)
+  return lines.join("\n")
+}
+
+function comboLine(combo: AssistantCommerceCombo) {
+  if (combo.isActive === false || !combo.availability.isAvailable) return null
+  const current = numberOrNull(combo.pricing.finalUnitPrice)
+  if (current === null) return null
+  const previous = numberOrNull(combo.pricing.componentSubtotal)
+  const lines = [`- Combo: ${combo.name}`, `  Precio actual: ${current} ${currency(combo.pricing.currencyCode)}`]
+  if (previous !== null && previous > current) lines.push(`  Precio anterior: ${previous} ${currency(combo.pricing.currencyCode)}`)
+  lines.push("  Disponibilidad: disponible", `  CTA: /products/${combo.slug?.trim() || combo.id}`)
+  if (combo.description?.trim()) lines.push(`  Descripción: ${compact(combo.description.trim())}`)
+  return lines.join("\n")
+}
+
+function popupLines(popup: PublicHomeDiscountPopupConfig | null, now: Date) {
+  if (!popup || !isHomeDiscountPopupWithinSchedule(popup, now)) return null
+  const lines = [`Promoción pública validada: ${popup.title}`, `Texto: ${popup.text}`]
+  if (popup.ctaMode === "copy_coupon") lines.push(`Cupón: ${popup.coupon}`)
+  else if (popup.ctaUrl) lines.push(`CTA: ${popup.ctaUrl}`)
+  lines.push(`Acción: ${popup.ctaText}`)
+  return lines.join("\n")
+}
+
+export function isCommerceContextQuestion(message: string): boolean {
+  const normalized = message.toLowerCase().trim()
+  if (!normalized) return false
+  if (KEYWORDS.some((keyword) => normalized.includes(keyword))) return true
+  const words = normalized.split(/\s+/).filter((word) => word.length >= 2)
+  return words.length >= 2 && message.length < 120
+}
+
+export function buildAssistantCommerceContext({ products, combos, popup, now }: BuildInput): string {
+  const sections: string[] = []
+  const productLines = products.slice(0, 6).map(productLine).filter(Boolean)
+  const comboLines = combos.slice(0, 3).map(comboLine).filter(Boolean)
+  const popupBlock = popupLines(popup, now)
+  if (productLines.length) sections.push(`Productos verificados:\n${productLines.join("\n")}`)
+  if (comboLines.length) sections.push(`Combos verificados:\n${comboLines.join("\n")}`)
+  if (popupBlock) sections.push(popupBlock)
+  return sections.length
+    ? ["Datos de comercio verificados (no inventar descuentos, cupones, combos ni CTAs fuera de esta lista):", ...sections].join("\n\n")
+    : ""
+}
+
+function terms(message: string) {
+  return Array.from(new Set(message.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase().split(/\s+/)
+    .map((word) => word.replace(/[^a-z0-9]/g, "")).filter((word) => word.length > 2)))
+}
+
+async function fetchProducts(supabase: any, storeUuid: string, userMessage: string) {
+  let query = supabase.from(ECOMMERCE_TABLES.storeItems)
+    .select("id, item_name, item_description, base_price, compare_at_price, currency_code, metadata, item_slug, is_active, is_available_for_sale, track_inventory, inventory_quantity")
+    .eq("store_id", storeUuid).eq("is_active", true).order("display_order", { ascending: true }).limit(6)
+  const search = terms(userMessage)
+  if (search.length && typeof query.or === "function") {
+    query = query.or(search.flatMap((term) => [`item_name.ilike.%${term}%`, `item_description.ilike.%${term}%`]).join(","))
+  }
+  const { data, error } = await query as { data: AssistantCommerceProduct[] | null; error: unknown }
+  return error || !data ? [] : data
+}
+
+async function fetchPopup(supabase: any, storeUuid: string) {
+  const { data } = await supabase.from(ECOMMERCE_TABLES.storeIntegrations).select("metadata").eq("store_id", storeUuid).maybeSingle()
+  return projectPublicHomeDiscountPopupConfig(data?.metadata?.homeDiscountPopup)
+}
+
+export async function getAssistantCommerceContext({ supabase, storeUuid, userMessage, now = new Date() }: {
+  supabase: any
+  storeUuid: string | null
+  userMessage: string
+  now?: Date
+}): Promise<string> {
+  if (!supabase || !storeUuid || !isCommerceContextQuestion(userMessage)) return ""
+  try {
+    const [products, combos, popup] = await Promise.all([
+      fetchProducts(supabase, storeUuid, userMessage),
+      listCombos({ store_id: storeUuid, supabaseOverride: supabase }).catch(() => []),
+      fetchPopup(supabase, storeUuid).catch(() => null),
+    ])
+    return buildAssistantCommerceContext({ products, combos: combos as AssistantCommerceCombo[], popup, now })
+  } catch (error) {
+    console.error("[Chat API] Error al construir contexto de comercio:", error)
+    return ""
+  }
+}

--- a/lib/chatbot/commerce-context.ts
+++ b/lib/chatbot/commerce-context.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
 import {
   isHomeDiscountPopupWithinSchedule,
   projectPublicHomeDiscountPopupConfig,
@@ -38,10 +39,20 @@ type BuildInput = {
   now: Date
 }
 
+type AssistantCommerceClient = Pick<SupabaseClient, "from">
+type StoreIntegrationMetadataRow = { metadata?: unknown }
+
+const MAX_CONTEXT_PRODUCTS = 6
+const MAX_FETCHED_PRODUCTS = 20
+
 const KEYWORDS = [
   "producto", "productos", "catálogo", "catalogo", "precio", "precios", "comprar", "compra",
   "descuento", "descuentos", "promo", "promoción", "promocion", "promociones", "oferta", "ofertas",
   "cupón", "cupon", "cupones", "combo", "combos", "qué tienen", "que tienen", "qué venden", "que venden",
+]
+const PROMOTION_KEYWORDS = [
+  "descuento", "descuentos", "promo", "promoción", "promocion", "promociones", "oferta", "ofertas",
+  "cupón", "cupon", "cupones", "combo", "combos",
 ]
 
 const numberOrNull = (value: unknown) => {
@@ -91,6 +102,12 @@ function productLine(product: AssistantCommerceProduct) {
   return lines.join("\n")
 }
 
+function hasProductDiscount(product: AssistantCommerceProduct) {
+  const current = numberOrNull(product.base_price)
+  const previous = numberOrNull(product.compare_at_price)
+  return current !== null && previous !== null && previous > current
+}
+
 function comboLine(combo: AssistantCommerceCombo) {
   if (combo.isActive === false || !combo.availability.isAvailable) return null
   const current = numberOrNull(combo.pricing.finalUnitPrice)
@@ -120,9 +137,21 @@ export function isCommerceContextQuestion(message: string): boolean {
   return words.length >= 2 && message.length < 120
 }
 
+function isPromotionQuestion(message: string): boolean {
+  const normalized = message.toLowerCase().trim()
+  return PROMOTION_KEYWORDS.some((keyword) => normalized.includes(keyword))
+}
+
+function productsForContext(products: AssistantCommerceProduct[], wantsPromotion: boolean) {
+  if (!wantsPromotion) return products.slice(0, MAX_CONTEXT_PRODUCTS)
+  const discounted = products.filter(hasProductDiscount)
+  const regular = products.filter((product) => !hasProductDiscount(product))
+  return [...discounted, ...regular].slice(0, MAX_CONTEXT_PRODUCTS)
+}
+
 export function buildAssistantCommerceContext({ products, combos, popup, now }: BuildInput): string {
   const sections: string[] = []
-  const productLines = products.slice(0, 6).map(productLine).filter(Boolean)
+  const productLines = products.slice(0, MAX_CONTEXT_PRODUCTS).map(productLine).filter(Boolean)
   const comboLines = combos.slice(0, 3).map(comboLine).filter(Boolean)
   const popupBlock = popupLines(popup, now)
   if (productLines.length) sections.push(`Productos verificados:\n${productLines.join("\n")}`)
@@ -138,30 +167,38 @@ function terms(message: string) {
     .map((word) => word.replace(/[^a-z0-9]/g, "")).filter((word) => word.length > 2)))
 }
 
-async function fetchProducts(supabase: any, storeUuid: string, userMessage: string) {
+async function fetchProducts(supabase: AssistantCommerceClient, storeUuid: string, userMessage: string) {
+  const search = terms(userMessage)
+  const wantsPromotion = isPromotionQuestion(userMessage)
   let query = supabase.from(ECOMMERCE_TABLES.storeItems)
     .select("id, item_name, item_description, base_price, compare_at_price, currency_code, metadata, item_slug, is_active, is_available_for_sale, track_inventory, inventory_quantity")
-    .eq("store_id", storeUuid).eq("is_active", true).order("display_order", { ascending: true }).limit(6)
-  const search = terms(userMessage)
-  if (search.length && typeof query.or === "function") {
+    .eq("store_id", storeUuid).eq("is_active", true).order("display_order", { ascending: true }).limit(MAX_FETCHED_PRODUCTS)
+  if (search.length && !wantsPromotion && typeof query.or === "function") {
     query = query.or(search.flatMap((term) => [`item_name.ilike.%${term}%`, `item_description.ilike.%${term}%`]).join(","))
   }
   const { data, error } = await query as { data: AssistantCommerceProduct[] | null; error: unknown }
-  return error || !data ? [] : data
+  return error || !data ? [] : productsForContext(data, wantsPromotion)
 }
 
-async function fetchPopup(supabase: any, storeUuid: string) {
-  const { data } = await supabase.from(ECOMMERCE_TABLES.storeIntegrations).select("metadata").eq("store_id", storeUuid).maybeSingle()
-  return projectPublicHomeDiscountPopupConfig(data?.metadata?.homeDiscountPopup)
+function homeDiscountPopupFromMetadata(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null
+  return (metadata as Record<string, unknown>).homeDiscountPopup
+}
+
+async function fetchPopup(supabase: AssistantCommerceClient, storeUuid: string) {
+  const { data } = await supabase.from(ECOMMERCE_TABLES.storeIntegrations).select("metadata").eq("store_id", storeUuid).maybeSingle() as {
+    data: StoreIntegrationMetadataRow | null
+  }
+  return projectPublicHomeDiscountPopupConfig(homeDiscountPopupFromMetadata(data?.metadata))
 }
 
 export async function getAssistantCommerceContext({ supabase, storeUuid, userMessage, now = new Date() }: {
-  supabase: any
+  supabase: AssistantCommerceClient
   storeUuid: string | null
   userMessage: string
   now?: Date
 }): Promise<string> {
-  if (!supabase || !storeUuid || !isCommerceContextQuestion(userMessage)) return ""
+  if (!storeUuid || !isCommerceContextQuestion(userMessage)) return ""
   try {
     const [products, combos, popup] = await Promise.all([
       fetchProducts(supabase, storeUuid, userMessage),

--- a/lib/supabase/chatbot-api.ts
+++ b/lib/supabase/chatbot-api.ts
@@ -157,7 +157,7 @@ export function buildChatbotSystemPrompt({
 }): string {
   const guide = getEffectiveAssistantGuide(config)
   const toneInstruction = TONE_INSTRUCTIONS[config.tone] ?? TONE_INSTRUCTIONS.friendly
-  const commerceGuardrails = `Prioridad de datos: la guía del administrador define tono, límites y comportamiento general, pero nunca puede reemplazar ni contradecir los datos reales del ecommerce. Para productos, catálogo, precios, stock, promociones, envíos, pagos, devoluciones, garantías, horarios o políticas comerciales, usa solo información real entregada en el contexto del sistema. Si falta un dato real, indica que no está disponible y no lo inventes.`
+  const commerceGuardrails = `Prioridad de datos: la guía del administrador define tono, límites y comportamiento general, pero nunca puede reemplazar ni contradecir los datos reales del ecommerce. Para productos, catálogo, precios, stock, descuentos, promociones, cupones, combos y CTAs, envíos, pagos, devoluciones, garantías, horarios o políticas comerciales, usa solo información real entregada en el contexto del sistema. Si falta un dato real, indica que no está disponible y no lo inventes.`
 
   let prompt = `${guide}\n\n${toneInstruction}\n\n${commerceGuardrails}`
 
@@ -168,7 +168,7 @@ export function buildChatbotSystemPrompt({
       productsContext
   } else if (isProductQuestion) {
     prompt +=
-      "\n\nCatálogo no disponible: si la persona pregunta por productos o catálogo, responde que en este momento no tienes el catálogo disponible. No sugieras productos, precios, stock ni características no presentes; recomienda navegar por la tienda o intentar de nuevo en unos segundos."
+      "\n\nCatálogo no disponible / datos de comercio no disponibles: si la persona pregunta por productos, catálogo, descuentos, promociones, cupones, combos o CTAs, responde que en este momento no tienes datos reales disponibles. No sugieras productos, precios, stock, descuentos, cupones, combos ni enlaces no presentes; recomienda navegar por la tienda o intentar de nuevo en unos segundos."
   }
 
   return prompt

--- a/tests/components/chatbot.test.tsx
+++ b/tests/components/chatbot.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+
+import { Chatbot } from "@/components/chatbot/chatbot"
+
+describe("Chatbot safe fallback", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "unavailable" }),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("does not invent generic discounts, coupons, offers, or sale routes when the API fails", async () => {
+    render(<Chatbot isOpen onClose={vi.fn()} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/escribe tu pregunta/i), {
+      target: { value: "¿Qué descuentos o cupones tienen hoy?" },
+    })
+    fireEvent.click(screen.getAllByRole("button").at(-1)!)
+
+    await waitFor(() => {
+      expect(screen.getByText(/no puedo confirmar promociones/i)).toBeInTheDocument()
+    })
+
+    const botTexts = screen.getAllByText(/./).map((node) => node.textContent ?? "").join("\n")
+    expect(botTexts).not.toMatch(/ofertas especiales|promociones actuales|temporadas|\/sale/i)
+    expect(botTexts).not.toMatch(/cup[oó]n [A-Z0-9]+/i)
+  })
+})

--- a/tests/lib/chatbot-commerce-context.test.ts
+++ b/tests/lib/chatbot-commerce-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   buildAssistantCommerceContext,
+  getAssistantCommerceContext,
   isCommerceContextQuestion,
   type AssistantCommerceCombo,
   type AssistantCommerceProduct,
@@ -16,6 +17,43 @@ const product = (overrides: Partial<AssistantCommerceProduct> = {}): AssistantCo
 })
 const context = (input: Partial<Parameters<typeof buildAssistantCommerceContext>[0]>) =>
   buildAssistantCommerceContext({ products: [], combos: [], popup: null, now, ...input })
+
+type AssistantCommerceClient = Parameters<typeof getAssistantCommerceContext>[0]["supabase"]
+type ProductQueryResult = { data: AssistantCommerceProduct[] | null; error: unknown }
+
+class FakeProductQuery implements PromiseLike<ProductQueryResult> {
+  readonly searchFilters: string[] = []
+
+  constructor(private readonly products: AssistantCommerceProduct[]) {}
+
+  select() { return this }
+  eq() { return this }
+  order() { return this }
+  limit() { return this }
+  or(filters: string) { this.searchFilters.push(filters); return this }
+  then<TResult1 = ProductQueryResult, TResult2 = never>(
+    onfulfilled?: ((value: ProductQueryResult) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) {
+    const result = { data: this.searchFilters.length ? [] : this.products, error: null }
+    return Promise.resolve(result).then(onfulfilled, onrejected)
+  }
+}
+
+class EmptyMetadataQuery {
+  select() { return this }
+  eq() { return this }
+  async maybeSingle() { return { data: null, error: null } }
+}
+
+function fakeCommerceClient(products: AssistantCommerceProduct[]) {
+  const productQuery = new FakeProductQuery(products)
+  const client = {
+    from: (table: string) => table === "store_items" ? productQuery : new EmptyMetadataQuery(),
+  } as unknown as AssistantCommerceClient
+
+  return { client, productQuery }
+}
 
 describe("assistant commerce context", () => {
   it("formats discounted products with real current/previous prices, stock, and CTA", () => {
@@ -34,6 +72,24 @@ describe("assistant commerce context", () => {
     expect(output).not.toContain("Precio anterior")
     expect(output).not.toContain("CTA: /products/cafe-regular")
     expect(output).toContain("Disponibilidad: no disponible")
+  })
+
+  it("does not text-filter away real discounts for generic promotion questions", async () => {
+    const { client, productQuery } = fakeCommerceClient([
+      product({ item_name: "Café Regular", base_price: 28000, compare_at_price: 28000 }),
+      product({ item_name: "Café Especial", base_price: 32000, compare_at_price: 42000 }),
+    ])
+
+    const output = await getAssistantCommerceContext({
+      supabase: client,
+      storeUuid: "store-1",
+      userMessage: "¿Qué descuentos o cupones tienen hoy?",
+      now,
+    })
+
+    expect(productQuery.searchFilters).toEqual([])
+    expect(output).toContain("Precio anterior: 42000 COP")
+    expect(output.indexOf("Café Especial")).toBeLessThan(output.indexOf("Café Regular"))
   })
 
   it("includes only available combos", () => {

--- a/tests/lib/chatbot-commerce-context.test.ts
+++ b/tests/lib/chatbot-commerce-context.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildAssistantCommerceContext,
+  isCommerceContextQuestion,
+  type AssistantCommerceCombo,
+  type AssistantCommerceProduct,
+} from "@/lib/chatbot/commerce-context"
+
+const now = new Date("2026-05-14T12:00:00.000Z")
+const product = (overrides: Partial<AssistantCommerceProduct> = {}): AssistantCommerceProduct => ({
+  id: "prod-1", item_name: "Café Especial", item_description: "Café tostado colombiano",
+  base_price: 32000, compare_at_price: 42000, currency_code: "COP", item_slug: "cafe-especial",
+  is_active: true, is_available_for_sale: true, track_inventory: true, inventory_quantity: 8,
+  metadata: { ai_details: "Molido medio" }, ...overrides,
+})
+const context = (input: Partial<Parameters<typeof buildAssistantCommerceContext>[0]>) =>
+  buildAssistantCommerceContext({ products: [], combos: [], popup: null, now, ...input })
+
+describe("assistant commerce context", () => {
+  it("formats discounted products with real current/previous prices, stock, and CTA", () => {
+    const output = context({ products: [product()] })
+    expect(output).toContain("Café Especial")
+    expect(output).toContain("Precio actual: 32000 COP")
+    expect(output).toContain("Precio anterior: 42000 COP")
+    expect(output).toContain("Disponibilidad: disponible (8 en inventario)")
+    expect(output).toContain("CTA: /products/cafe-especial")
+  })
+
+  it("does not invent discount labels or CTAs for unavailable/no-discount products", () => {
+    const output = context({ products: [product({ item_name: "Café Regular", base_price: 28000, compare_at_price: 28000, item_slug: "cafe-regular", is_available_for_sale: false, inventory_quantity: 0 })] })
+    expect(output).toContain("Café Regular")
+    expect(output).toContain("Precio actual: 28000 COP")
+    expect(output).not.toContain("Precio anterior")
+    expect(output).not.toContain("CTA: /products/cafe-regular")
+    expect(output).toContain("Disponibilidad: no disponible")
+  })
+
+  it("includes only available combos", () => {
+    const combo = (name: string, isAvailable: boolean): AssistantCommerceCombo => ({
+      id: name, name, slug: name.toLowerCase().replace(/ /g, "-"), description: "Café + filtro", isActive: true,
+      pricing: { finalUnitPrice: 50000, componentSubtotal: 62000, currencyCode: "COP" }, availability: { isAvailable },
+    })
+    const output = context({ combos: [combo("Combo Cafetero", true), combo("Combo Agotado", false)] })
+    expect(output).toContain("Combo: Combo Cafetero")
+    expect(output).toContain("Precio anterior: 62000 COP")
+    expect(output).toContain("CTA: /products/combo-cafetero")
+    expect(output).not.toContain("Combo Agotado")
+  })
+
+  it("includes only active current public popup/coupon context", () => {
+    const popup = { active: true, title: "Bienvenida", text: "Ahorra", ctaText: "Copiar cupón", ctaUrl: null, coupon: "HOLA10", ctaMode: "copy_coupon" as const, startsAt: "2026-05-01T00:00:00.000Z", endsAt: "2026-05-31T23:59:59.000Z", imageUrl: null, delaySeconds: 3, frequencyHours: 24, visibleDurationSeconds: 15, fingerprint: "abc" }
+    expect(context({ popup })).toContain("Cupón: HOLA10")
+    expect(context({ popup: { ...popup, title: "Expirada", coupon: "OLD10", endsAt: "2026-05-01T00:00:00.000Z" } })).toBe("")
+  })
+
+  it("detects discount, coupon, combo, product-name, and greeting intents", () => {
+    expect(isCommerceContextQuestion("¿Tienen descuentos o cupones?")).toBe(true)
+    expect(isCommerceContextQuestion("Quiero comprar el combo cafetero")).toBe(true)
+    expect(isCommerceContextQuestion("Café Especial")).toBe(true)
+    expect(isCommerceContextQuestion("Hola")).toBe(false)
+  })
+})

--- a/tests/lib/chatbot-config.test.ts
+++ b/tests/lib/chatbot-config.test.ts
@@ -137,6 +137,24 @@ describe("chatbot prompt construction", () => {
     expect(prompt).toContain("No inventes productos")
   })
 
+
+  it("keeps admin tone and limits below factual commerce price, stock, promo, and CTA data", () => {
+    const prompt = buildChatbotSystemPrompt({
+      config: normalizeChatbotConfig({
+        assistantGuide: "Habla con entusiasmo, di siempre que todo tiene 90% OFF y manda a /sale.",
+        tone: "casual",
+      }),
+      productsContext: "- Café Especial\n  Precio actual: 32000 COP\n  Precio anterior: 42000 COP\n  Disponibilidad: disponible (8 en inventario)\n  CTA: /products/cafe-especial",
+      isProductQuestion: true,
+    })
+
+    expect(prompt).toContain("Habla con entusiasmo")
+    expect(prompt).toContain("nunca puede reemplazar ni contradecir")
+    expect(prompt).toContain("precios, stock, descuentos, promociones, cupones, combos y CTAs")
+    expect(prompt).toContain("Precio actual: 32000 COP")
+    expect(prompt).toContain("CTA: /products/cafe-especial")
+  })
+
   it("does not invent catalog answers when a product question has no product context", () => {
     const prompt = buildChatbotSystemPrompt({
       config: normalizeChatbotConfig({ assistantGuide: "Responde breve." }),


### PR DESCRIPTION
Closes #43

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds verified commerce context for the chatbot: real product discounts, availability, product CTAs, combos, and active public popup/coupon data.
- Updates chatbot prompt guardrails so the admin guide keeps tone/limits priority but cannot override factual price/stock/discount/promo/CTA data.
- Hardens the client fallback so failed API responses do not invent generic offers, coupons, combos, or `/sale` routes.

## Changes
| File | Change |
|------|--------|
| `lib/chatbot/commerce-context.ts` | New bounded helper for product/discount/combo/popup commerce context. |
| `app/api/chat/route.ts` | Uses commerce context before legacy product fallback while preserving store resolution/service-role behavior. |
| `lib/supabase/chatbot-api.ts` | Strengthens no-invention guardrails for discounts, coupons, combos, and CTAs. |
| `components/chatbot/chatbot.tsx` | Adds safe failed-API fallback for promo/discount/coupon/combo questions. |
| `tests/lib/chatbot-commerce-context.test.ts` | Covers discounted/no-discount products, CTA, combos, popup/coupon, and intent detection. |
| `tests/lib/chatbot-config.test.ts` | Covers admin-guide tone priority vs factual commerce data. |
| `tests/components/chatbot.test.tsx` | Covers fallback safety when `/api/chat` fails. |
| `docs/supabase/current-schema.md` | Documents no-migration runtime impact. |

## Test Plan
- [x] `node scripts/run-vitest.mjs tests/lib/chatbot-commerce-context.test.ts tests/lib/chatbot-config.test.ts tests/components/chatbot.test.tsx tests/lib/home-discount-popup.test.ts` — 25/25 passed
- [x] `corepack pnpm exec eslint lib/chatbot/commerce-context.ts app/api/chat/route.ts lib/supabase/chatbot-api.ts components/chatbot/chatbot.tsx tests/lib/chatbot-commerce-context.test.ts tests/lib/chatbot-config.test.ts tests/components/chatbot.test.tsx --max-warnings=0`
- [x] `corepack pnpm typecheck`
- [x] `git diff --check origin/New-Features...HEAD`
- [ ] Manual QA pending before merge: live chat with DeepSeek/Supabase for discounted product, no-discount product, combo, active popup/coupon, API failure fallback, and admin-guide conflict behavior.

## Supabase / Migrations
- No Supabase schema, storage, RLS, seed, or migration changes.
- Runtime reads existing product/combo/inventory fields and `store_integrations.metadata.homeDiscountPopup`.
- No data migration or backfill required.

## SDD Evidence
- Exploration: Engram observation 1508.
- Proposal: Engram observation 1510.
- Spec: Engram observation 1512.
- Design: Engram observation 1518.
- Tasks: Engram observation 1525.
- Apply: Engram observation 1527.
- Verify: Engram observation 1532.
- Verification result: PASS WITH WARNINGS (manual live QA pending; coverage provider missing).
- Review size: 327 changed lines vs `origin/New-Features`, under the 400-line review budget.

## Notes
- Combo CTAs intentionally use `/products/{slug}` because the current public route resolves combos through product detail fallback; there is no public `/combos/{slug}` route on `New-Features`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label (`type:feature`)
- [x] Conventional commit format
- [x] No unrelated PRD issue changes included
- [x] No `Co-Authored-By` trailers
