### PR TITLE
fix(auth): el callback acepta los enlaces token_hash que manda el hook

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,118 +1,173 @@
 "use client"
 
-import { useEffect, Suspense } from "react"
+import { Suspense, useEffect, useRef, useState } from "react"
+import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
+import { XCircle } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card"
+import { FORCE_PASSWORD_CHANGE_PATH, getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
+import { claimEmailLink, readEmailLink, type EmailLinkRejection } from "@/lib/auth/claim-email-link"
 import { finalizeCustomerSignup } from "@/lib/auth/finalize-signup-action"
 import { getSupabaseBrowserClient } from "@/lib/supabase/client"
 import { currentUserMustChangePassword, isCurrentUserAdminOrUnverified } from "@/lib/supabase/permissions-api"
-import { FORCE_PASSWORD_CHANGE_PATH, getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
+
+type CallbackPhase = { step: "verifying" } | { step: "rejected"; reason: EmailLinkRejection }
 
 function AuthCallbackContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const [phase, setPhase] = useState<CallbackPhase>({ step: "verifying" })
+  // El link se gasta al canjearlo: un segundo intento (el doble montaje de
+  // StrictMode en desarrollo) convertiría un link válido en rechazado.
+  const claimStarted = useRef(false)
 
   useEffect(() => {
-    const handleAuthCallback = async () => {
-      const supabase = getSupabaseBrowserClient()
-      if (!supabase) {
-        console.error("[Auth] Supabase no configurado")
-        router.push("/?error=auth_callback_failed")
+    if (claimStarted.current) return
+    claimStarted.current = true
+
+    const pushPostAuthDestination = async () => {
+      // Un dueño con clave temporal (D21) va a cambiarla antes que a cualquier
+      // destino; el guard de servidor de /admin es la red de seguridad si este
+      // adelanto de UX no concluye.
+      if (await currentUserMustChangePassword()) {
+        router.push(FORCE_PASSWORD_CHANGE_PATH)
         return
       }
 
-      try {
-        // Obtener el código de confirmación de la URL
-        const code = searchParams.get('code')
-        const error = searchParams.get('error')
-        const errorDescription = searchParams.get('error_description')
-
-        if (error) {
-          console.error("[Auth] Error en callback:", error, errorDescription)
-          router.push("/?error=auth_callback_failed")
-          return
-        }
-
-        const returnPath = getAuthReturnPath(searchParams)
-
-        const pushPostAuthDestination = async () => {
-          // Un dueño con clave temporal (D21) va a cambiarla antes que a cualquier
-          // destino; el guard de servidor de /admin es la red de seguridad si este
-          // adelanto de UX no concluye.
-          if (await currentUserMustChangePassword()) {
-            router.push(FORCE_PASSWORD_CHANGE_PATH)
-            return
-          }
-
-          router.push(resolvePostAuthDestination({
-            returnPath,
-            canAccessAdmin: await isCurrentUserAdminOrUnverified(),
-          }))
-        }
-
-        if (code) {
-          // Intercambiar el código por una sesión
-          const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
-          
-          if (exchangeError) {
-            console.error("[Auth] Error al intercambiar código:", exchangeError)
-            router.push("/?error=auth_callback_failed")
-            return
-          }
-
-          if (data.session) {
-            // D23: finaliza el perfil del cliente de forma idempotente contra
-            // la tienda que quedó ligada al intent server-side (nunca contra
-            // este host) -- un no-op seguro si `intent` falta (una sesión
-            // existente que solo pasó por aquí, no un signup fresco).
-            //
-            // El resultado se descarta a propósito: la sesión ya quedó
-            // establecida, así que no hay nada que este usuario pueda
-            // corregir si falla (un intent ya consumido o expirado, un
-            // permiso de base de datos). finalizeCustomerSignup ya deja un
-            // log estructurado del lado del servidor ante cualquier fallo
-            // (D36) -- interrumpir aquí el login que sí funcionó no ayuda a
-            // nadie, y quien puede actuar sobre el log es el operador, no
-            // este cliente.
-            await finalizeCustomerSignup(searchParams.get("intent"))
-
-            // Sesión creada (p. ej. tras confirmar correo), redirigir a página de éxito
-            // salvo que exista un destino admin seguro permitido para el usuario.
-            await pushPostAuthDestination()
-            return
-          }
-        }
-
-        // Si no hay código, verificar si ya hay una sesión activa
-        const { data: { session }, error: sessionError } = await supabase.auth.getSession()
-        
-        if (sessionError) {
-          console.error("[Auth] Error al obtener sesión:", sessionError)
-          router.push("/?error=auth_callback_failed")
-          return
-        }
-
-        if (session) {
-          // Ya hay sesión (p. ej. llegó sin code), redirigir a éxito o inicio
-          // salvo que exista un destino admin seguro permitido para el usuario.
-          await pushPostAuthDestination()
-        } else {
-          // No hay sesión, redirigir al login
-          router.push("/?error=no_session")
-        }
-      } catch (error) {
-        console.error("[Auth] Error inesperado en callback:", error)
-        router.push("/?error=auth_callback_failed")
-      }
+      router.push(
+        resolvePostAuthDestination({
+          returnPath: getAuthReturnPath(searchParams),
+          canAccessAdmin: await isCurrentUserAdminOrUnverified(),
+        }),
+      )
     }
 
-    handleAuthCallback()
+    const resolveExistingSession = async (): Promise<EmailLinkRejection | null> => {
+      const supabase = getSupabaseBrowserClient()
+      if (!supabase) {
+        return { cause: "verificationUnavailable" }
+      }
+
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession()
+      if (error) {
+        return { cause: "verificationUnavailable" }
+      }
+      if (!session) {
+        return { cause: "noTokenInLink" }
+      }
+
+      // Ya hay sesión (p. ej. llegó sin link que canjear): redirigir a éxito o
+      // inicio salvo que exista un destino admin seguro permitido.
+      await pushPostAuthDestination()
+      return null
+    }
+
+    const resolveCallback = async (): Promise<EmailLinkRejection | null> => {
+      const gotrueError = readGotrueError(searchParams)
+      if (gotrueError) {
+        return gotrueError
+      }
+
+      const link = readEmailLink({
+        tokenHash: searchParams.get("token_hash"),
+        linkType: searchParams.get("type"),
+        code: searchParams.get("code"),
+      })
+
+      if (link.kind === "absent") {
+        return resolveExistingSession()
+      }
+
+      const claim = await claimEmailLink(link)
+      if (claim.outcome === "rejected") {
+        return claim.reason
+      }
+
+      // D23: finaliza el perfil del cliente de forma idempotente contra la
+      // tienda que quedó ligada al intent server-side (nunca contra este
+      // host) -- un no-op seguro si `intent` falta. El resultado se descarta
+      // a propósito: la sesión ya quedó establecida, así que no hay nada que
+      // este usuario pueda corregir si falla (un intent ya consumido o
+      // expirado, un permiso de base de datos). finalizeCustomerSignup ya
+      // deja un log estructurado del lado del servidor ante cualquier fallo
+      // (D36) -- interrumpir aquí el login que sí funcionó no ayuda a nadie.
+      await finalizeCustomerSignup(searchParams.get("intent"))
+      await pushPostAuthDestination()
+      return null
+    }
+
+    resolveCallback()
+      .catch((error) => {
+        console.error("[Auth] Error inesperado en callback:", error)
+        return { cause: "verificationUnavailable" as const }
+      })
+      .then((rejection) => {
+        if (rejection) {
+          setPhase({ step: "rejected", reason: rejection })
+        }
+      })
   }, [router, searchParams])
+
+  if (phase.step === "rejected") {
+    return <LinkRejectedScreen reason={phase.reason} />
+  }
 
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <p style={{ color: "var(--foreground)" }}>Procesando autenticación...</p>
       </div>
+    </div>
+  )
+}
+
+// GoTrue puede rechazar el link antes de que esta página tenga token_hash o
+// code que canjear (p. ej. la plantilla hospedada de un ?code ya vencido):
+// mismo tratamiento visible que un canje rechazado, nunca un redirect
+// silencioso.
+function readGotrueError(searchParams: Pick<URLSearchParams, "get">): EmailLinkRejection | null {
+  const error = searchParams.get("error")
+  if (!error) {
+    return null
+  }
+
+  return { cause: "refusedByAuth", detail: searchParams.get("error_description") ?? error }
+}
+
+function LinkRejectedScreen({ reason }: { reason: EmailLinkRejection }) {
+  const explanation = {
+    noTokenInLink: "Este enlace no trae los datos de confirmación. Vuelve a registrarte para recibir uno nuevo.",
+    verificationUnavailable: "No pudimos verificar el enlace en este momento. Vuelve a intentarlo en un minuto.",
+    refusedByAuth: "Este enlace de confirmación ya se usó o expiró. Vuelve a registrarte para recibir uno nuevo.",
+  }[reason.cause]
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+            <XCircle className="h-8 w-8 text-destructive" />
+          </div>
+          <h1 className="text-2xl font-semibold leading-none tracking-tight">Enlace no válido</h1>
+          <CardDescription>{explanation}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {reason.cause === "refusedByAuth" && (
+            <Alert variant="destructive">
+              <AlertDescription>{reason.detail}</AlertDescription>
+            </Alert>
+          )}
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/auth/login">Volver a iniciar sesión</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   )
 }
@@ -130,4 +185,3 @@ export default function AuthCallback() {
     </Suspense>
   )
 }
-

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -20,8 +20,8 @@ import {
   type PasswordFieldErrors,
 } from "@/lib/account/password-rule"
 import { getAuthReturnPath, resolvePostAuthDestination } from "@/lib/auth-return-intent"
+import { claimEmailLink, readEmailLink, type EmailLinkRejection } from "@/lib/auth/claim-email-link"
 import { updatePassword } from "@/lib/supabase/auth-api"
-import { getSupabaseBrowserClient } from "@/lib/supabase/client"
 import { isCurrentUserAdminOrUnverified } from "@/lib/supabase/permissions-api"
 
 export default function ResetPasswordPage() {
@@ -34,7 +34,7 @@ export default function ResetPasswordPage() {
 
 type RecoveryPhase =
   | { step: "verifying" }
-  | { step: "linkRejected"; reason: LinkRejection }
+  | { step: "linkRejected"; reason: EmailLinkRejection }
   | { step: "newPassword"; exit: RecoveryExit }
   | { step: "updated"; exit: RecoveryExit }
 
@@ -53,7 +53,12 @@ function ResetPasswordFlow() {
     if (claimStarted.current) return
     claimStarted.current = true
 
-    claimRecoverySession(readRecoveryLink({ tokenHash, linkType, code })).then(async (claim) => {
+    // El tipo se exige y se restringe a "recovery": esta pantalla solo completa
+    // una recuperación, y un token de alta o de cambio de correo no tiene nada
+    // que hacer aquí (a diferencia de app/auth/callback, que acepta cualquiera).
+    const link = readEmailLink({ tokenHash, linkType, code, acceptType: (type) => type === "recovery" })
+
+    claimEmailLink(link).then(async (claim) => {
       if (claim.outcome === "rejected") {
         setPhase({ step: "linkRejected", reason: claim.reason })
         return
@@ -107,70 +112,6 @@ async function resolveRecoveryExit(returnPath: string | null): Promise<RecoveryE
   }
 }
 
-type RecoveryLink =
-  | { kind: "tokenHash"; tokenHash: string }
-  | { kind: "code"; code: string }
-  | { kind: "absent" }
-
-// Un correo de recuperación puede llegar de dos formas y ninguna es el hash
-// implícito heredado (#access_token), que este proyecto ya no puede emitir:
-// `token_hash` es la preferida (D7) porque verifyOtp no depende del navegador
-// que pidió el link, y `?code` es lo que la plantilla de Supabase sigue enviando
-// hasta que el operador la cambie en el panel.
-function readRecoveryLink({
-  tokenHash,
-  linkType,
-  code,
-}: {
-  tokenHash: string | null
-  linkType: string | null
-  code: string | null
-}): RecoveryLink {
-  // El tipo se exige: esta pantalla solo completa una recuperación, y un token
-  // de alta o de cambio de correo no tiene nada que hacer aquí.
-  if (tokenHash && linkType === "recovery") {
-    return { kind: "tokenHash", tokenHash }
-  }
-  if (code) {
-    return { kind: "code", code }
-  }
-  return { kind: "absent" }
-}
-
-type LinkRejection =
-  | { cause: "noTokenInLink" }
-  | { cause: "verificationUnavailable" }
-  | { cause: "refusedByAuth"; detail: string }
-
-type RecoveryClaim = { outcome: "claimed" } | { outcome: "rejected"; reason: LinkRejection }
-
-async function claimRecoverySession(link: RecoveryLink): Promise<RecoveryClaim> {
-  if (link.kind === "absent") {
-    return { outcome: "rejected", reason: { cause: "noTokenInLink" } }
-  }
-
-  const supabase = getSupabaseBrowserClient()
-  if (!supabase) {
-    return { outcome: "rejected", reason: { cause: "verificationUnavailable" } }
-  }
-
-  try {
-    const { error } =
-      link.kind === "tokenHash"
-        ? await supabase.auth.verifyOtp({ token_hash: link.tokenHash, type: "recovery" })
-        : await supabase.auth.exchangeCodeForSession(link.code)
-
-    if (error) {
-      return { outcome: "rejected", reason: { cause: "refusedByAuth", detail: error.message } }
-    }
-
-    return { outcome: "claimed" }
-  } catch (error) {
-    console.error("[ResetPassword] Error al canjear el link de recuperación:", error)
-    return { outcome: "rejected", reason: { cause: "verificationUnavailable" } }
-  }
-}
-
 function VerifyingLinkScreen() {
   const { t } = useLanguage()
 
@@ -189,7 +130,7 @@ function VerifyingLinkScreen() {
   )
 }
 
-function LinkRejectedScreen({ reason }: { reason: LinkRejection }) {
+function LinkRejectedScreen({ reason }: { reason: EmailLinkRejection }) {
   const { t } = useLanguage()
   const router = useRouter()
   const [recoveryOpen, setRecoveryOpen] = useState(false)

--- a/lib/auth/claim-email-link.ts
+++ b/lib/auth/claim-email-link.ts
@@ -1,0 +1,71 @@
+import type { EmailOtpType } from "@supabase/supabase-js"
+
+import { getSupabaseBrowserClient } from "@/lib/supabase/client"
+
+// Every Auth catalog link this app now emits (lib/email/auth-hook.ts's
+// buildActionPath) carries `token_hash`+`type` -- device-independent,
+// verified with verifyOtp, and preferred (originally bug-reset-password-pkce-
+// vs-hash's decision, D7) over `?code`, which stays readable only for
+// GoTrue's hosted templates and any link already sent before the Send Email
+// Hook took over. app/auth/reset-password and app/auth/callback both read a
+// link, decide its shape, and claim it the same way; they differ only in
+// which `type` they accept and what they do after a successful claim, so
+// that part stays with each page.
+export type EmailLink =
+  | { kind: "tokenHash"; tokenHash: string; type: string }
+  | { kind: "code"; code: string }
+  | { kind: "absent" }
+
+export function readEmailLink({
+  tokenHash,
+  linkType,
+  code,
+  acceptType,
+}: {
+  tokenHash: string | null
+  linkType: string | null
+  code: string | null
+  acceptType?: (type: string) => boolean
+}): EmailLink {
+  if (tokenHash && linkType && (!acceptType || acceptType(linkType))) {
+    return { kind: "tokenHash", tokenHash, type: linkType }
+  }
+  if (code) {
+    return { kind: "code", code }
+  }
+  return { kind: "absent" }
+}
+
+export type EmailLinkRejection =
+  | { cause: "noTokenInLink" }
+  | { cause: "verificationUnavailable" }
+  | { cause: "refusedByAuth"; detail: string }
+
+export type EmailLinkClaim = { outcome: "claimed" } | { outcome: "rejected"; reason: EmailLinkRejection }
+
+export async function claimEmailLink(link: EmailLink): Promise<EmailLinkClaim> {
+  if (link.kind === "absent") {
+    return { outcome: "rejected", reason: { cause: "noTokenInLink" } }
+  }
+
+  const supabase = getSupabaseBrowserClient()
+  if (!supabase) {
+    return { outcome: "rejected", reason: { cause: "verificationUnavailable" } }
+  }
+
+  try {
+    const { error } =
+      link.kind === "tokenHash"
+        ? await supabase.auth.verifyOtp({ token_hash: link.tokenHash, type: link.type as EmailOtpType })
+        : await supabase.auth.exchangeCodeForSession(link.code)
+
+    if (error) {
+      return { outcome: "rejected", reason: { cause: "refusedByAuth", detail: error.message } }
+    }
+
+    return { outcome: "claimed" }
+  } catch (error) {
+    console.error("[Auth] Error al canjear el link:", error)
+    return { outcome: "rejected", reason: { cause: "verificationUnavailable" } }
+  }
+}

--- a/tests/auth/auth-callback-redirect.test.tsx
+++ b/tests/auth/auth-callback-redirect.test.tsx
@@ -1,9 +1,10 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const routerPush = vi.hoisted(() => vi.fn());
 const searchParamsGet = vi.hoisted(() => vi.fn());
 const exchangeCodeForSession = vi.hoisted(() => vi.fn());
+const verifyOtp = vi.hoisted(() => vi.fn());
 const getSession = vi.hoisted(() => vi.fn());
 const isCurrentUserAdminOrUnverified = vi.hoisted(() => vi.fn());
 const currentUserMustChangePassword = vi.hoisted(() => vi.fn());
@@ -18,6 +19,7 @@ vi.mock("@/lib/supabase/client", () => ({
   getSupabaseBrowserClient: () => ({
     auth: {
       exchangeCodeForSession,
+      verifyOtp,
       getSession,
     },
   }),
@@ -51,6 +53,7 @@ describe("auth callback safe return destinations", () => {
       return values[key] ?? null;
     });
     exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
+    verifyOtp.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
     getSession.mockResolvedValue({ data: { session: null }, error: null });
     finalizeCustomerSignup.mockResolvedValue({ ok: true });
     isCurrentUserAdminOrUnverified.mockResolvedValue(true);
@@ -162,7 +165,11 @@ describe("auth callback safe return destinations", () => {
     expect(routerPush).not.toHaveBeenCalledWith("/admin/orders");
   });
 
-  it("preserves the callback error branch", async () => {
+  // Antes de este fix, un error que GoTrue devolvía en la propia redirección
+  // (p. ej. un ?code ya vencido de la plantilla hospedada) se perdía en un
+  // redirect silencioso indistinguible de un login exitoso -- justo lo que
+  // hizo tan confuso diagnosticar el defecto en producción.
+  it("shows a visible rejection instead of a silent redirect when GoTrue reports an error", async () => {
     searchParamsGet.mockImplementation((key: string) => {
       const values: Record<string, string | null> = {
         code: null,
@@ -176,13 +183,13 @@ describe("auth callback safe return destinations", () => {
 
     render(<AuthCallback />);
 
-    await waitFor(() => {
-      expect(routerPush).toHaveBeenCalledWith("/?error=auth_callback_failed");
-    });
+    expect(await screen.findByRole("heading", { name: "Enlace no válido" })).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Denied");
     expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(routerPush).not.toHaveBeenCalled();
   });
 
-  it("preserves the no-session branch when there is no code and no active session", async () => {
+  it("shows a visible rejection instead of a silent redirect when there is no link and no active session", async () => {
     searchParamsGet.mockImplementation((key: string) => {
       const values: Record<string, string | null> = {
         code: null,
@@ -197,9 +204,8 @@ describe("auth callback safe return destinations", () => {
 
     render(<AuthCallback />);
 
-    await waitFor(() => {
-      expect(routerPush).toHaveBeenCalledWith("/?error=no_session");
-    });
+    expect(await screen.findByRole("heading", { name: "Enlace no válido" })).toBeInTheDocument();
+    expect(routerPush).not.toHaveBeenCalled();
   });
 
   it("uses a safe admin next destination for an existing admin session", async () => {
@@ -222,8 +228,8 @@ describe("auth callback safe return destinations", () => {
     });
   });
 
-  // D23: la finalización solo se intenta tras un exchangeCodeForSession
-  // FRESCO -- nunca en la rama "ya había sesión" (no hay confirmación que
+  // D23: la finalización solo se intenta tras un canje de link FRESCO (code o
+  // token_hash) -- nunca en la rama "ya había sesión" (no hay confirmación que
   // atar a un intent ahí), y siempre con lo que traiga `intent` en la URL.
   it("finalizes the customer profile with the intent token after a fresh code exchange", async () => {
     searchParamsGet.mockImplementation((key: string) => {
@@ -264,5 +270,89 @@ describe("auth callback safe return destinations", () => {
       expect(routerPush).toHaveBeenCalled();
     });
     expect(finalizeCustomerSignup).not.toHaveBeenCalled();
+  });
+});
+
+// Regresión del defecto en producción: el Send Email Hook (D15) ahora emite
+// `token_hash`+`type` en vez del `?code` de la plantilla hospedada de
+// Supabase, y esta página no lo leía -- un signup confirmado quedaba con
+// `email_confirmed_at` nulo y sin perfil, indistinguible en pantalla de un
+// login exitoso.
+describe("auth callback token_hash link", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        token_hash: "hash-del-correo",
+        type: "signup",
+        code: null,
+        error: null,
+        error_description: null,
+        next: null,
+        redirect: null,
+        intent: "raw-intent-token",
+      };
+      return values[key] ?? null;
+    });
+    verifyOtp.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
+    exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: "token" } }, error: null });
+    getSession.mockResolvedValue({ data: { session: null }, error: null });
+    finalizeCustomerSignup.mockResolvedValue({ ok: true });
+    isCurrentUserAdminOrUnverified.mockResolvedValue(true);
+    currentUserMustChangePassword.mockResolvedValue(false);
+  });
+
+  it("verifies the OTP, finalizes the profile, and lands the user confirmed", async () => {
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(verifyOtp).toHaveBeenCalledWith({ token_hash: "hash-del-correo", type: "signup" });
+    });
+    await waitFor(() => {
+      expect(finalizeCustomerSignup).toHaveBeenCalledWith("raw-intent-token");
+    });
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/auth/cuenta-confirmada");
+    });
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  // D7: token_hash es preferido porque verifyOtp no depende del navegador que
+  // pidió el link -- ambos pueden llegar juntos mientras conviven los links
+  // viejos con la plantilla hospedada.
+  it("prefers token_hash over code when both are present", async () => {
+    searchParamsGet.mockImplementation((key: string) => {
+      const values: Record<string, string | null> = {
+        token_hash: "hash-del-correo",
+        type: "signup",
+        code: "codigo-pkce",
+        error: null,
+        error_description: null,
+        next: null,
+        redirect: null,
+      };
+      return values[key] ?? null;
+    });
+
+    render(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(verifyOtp).toHaveBeenCalledWith({ token_hash: "hash-del-correo", type: "signup" });
+    });
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("shows a visible message instead of a silent redirect when the link is expired or already used", async () => {
+    verifyOtp.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: "Email link is invalid or has expired" },
+    });
+
+    render(<AuthCallback />);
+
+    expect(await screen.findByRole("heading", { name: "Enlace no válido" })).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Email link is invalid or has expired");
+    expect(finalizeCustomerSignup).not.toHaveBeenCalled();
+    expect(routerPush).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Arreglo urgente: confirmar el correo de registro no hacía nada en producción.**

Encontrado haciendo clic en un enlace real, después de fusionar. El enlace aterrizaba en la tienda, la cuenta seguía sin confirmar, y la persona no podía iniciar sesión porque Supabase la rechaza por correo sin confirmar. Verificado en base de datos: `email_confirmed_at` nulo, la intención de auth sin consumir y sin vencer, y ninguna fila de perfil.

## La causa

`app/auth/callback/page.tsx` solo leía `?code=`, el intercambio del flujo PKCE.

Mientras los correos los mandaban las plantillas alojadas de Supabase eso bastaba: para un cliente PKCE emiten ese formato. Al pasar los correos por el Send Email Hook, GoTrue empezó a construir el enlace con `token_hash` y `type`, y la página los ignoraba en silencio — caía a la rama de «ya hay sesión» sin sesión ninguna y redirigía con un parámetro de error que nadie lee.

El enlace real que lo destapó:

```
https://default.osoria.help/auth/callback?intent=…&token_hash=pkce_026c047a…&type=signup
```

Es la misma clase que el fallo ya registrado de recuperación de contraseña (`bug-reset-password-pkce-vs-hash`), que se arregló en `/auth/reset-password` y nunca se llevó al callback porque hasta ahora no le hacía falta.

## El arreglo

El callback acepta las dos formas, prefiriendo `token_hash` como ya hacía recuperación, y pasa **el tipo que venga en el enlace** en vez de fijarlo — el hook emite `signup` hoy y otros tipos del catálogo después. `?code=` sigue funcionando, así que ningún enlace en vuelo se rompe.

La lógica de leer y reclamar un enlace de correo queda en `lib/auth/claim-email-link.ts`, que usan las dos páginas; se eliminó la copia local de recuperación. La finalización idempotente del perfil contra la intención acuñada por el servidor corre en **las dos** ramas, así que la atribución de tienda no se salta por el camino nuevo.

Y un enlace vencido o ya usado **deja de redirigir en silencio**: ahora se ve en pantalla. Esa mudez es lo que hizo tan confuso diagnosticarlo, porque un enlace roto era indistinguible de uno que funcionó. La copia sigue siendo genérica, sin revelar si la dirección existe.

## Las otras tres pantallas de aterrizaje

Revisadas, ninguna tiene el hueco: `/auth/reset-password` ya aceptaba las dos formas y ahora comparte el módulo, sin cambio de comportamiento y con sus pruebas intactas; `/auth/accept-invite` fija `verifyOtp({type:"invite"})`, que coincide con el tipo literal que GoTrue emite para invitaciones y nunca tuvo una era de `?code`; `/auth/accept-membership` usa nuestro propio token y no llama a `supabase.auth` en absoluto.

## Verificación

`lint:full`, `typecheck:full`, `test:full` (288 archivos / 2396 pruebas) y `build`, todos en verde sin avisos. El detector de diseño, limpio.

La prueba de regresión se comprobó **roja contra el código actual** en un árbol de trabajo aparte: cinco casos fallan sin el arreglo, incluidos la preferencia de `token_hash` sobre `code` y el enlace vencido mostrando mensaje en vez de redirigir.

## Por qué se nos escapó

La prueba en vivo que hice tras desplegar fue una **recuperación de contraseña**, cuya página de aterrizaje ya estaba arreglada. Nunca hice clic en un enlace de confirmación de registro. Y las pruebas automáticas simulan el callback en vez de ejercitar el enlace real, así que la diferencia de formato no aparecía por ningún lado.
