### PR TITLE
fix(qa): cierra el lote de hallazgos del QA sobre la tienda demo

### DIFF
--- a/app/(platform)/admin/stores/components/enter-store-button.tsx
+++ b/app/(platform)/admin/stores/components/enter-store-button.tsx
@@ -1,21 +1,22 @@
 "use client"
 
 import { useTransition } from "react"
-import { useRouter } from "next/navigation"
 import { LogIn, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { setActiveStore } from "@/app/admin/actions/active-store"
+import { toStoreHost } from "@/lib/utils/store-host"
 
 export function EnterStoreButton({
   storeId,
   storeName,
+  subdomain,
 }: {
   storeId: string
   storeName: string
+  subdomain: string
 }) {
-  const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
   function handleEnter() {
@@ -26,7 +27,9 @@ export function EnterStoreButton({
         return
       }
 
-      router.push("/admin")
+      window.location.assign(
+        `${window.location.protocol}//${toStoreHost(subdomain, window.location.host)}/admin`,
+      )
     })
   }
 

--- a/app/(platform)/admin/stores/components/tenants-table.tsx
+++ b/app/(platform)/admin/stores/components/tenants-table.tsx
@@ -100,7 +100,11 @@ function buildColumns(managedStoreIds: string[]): Column<TenantRow>[] {
             isPublic={tenant.is_public}
           />
           {managedStoreIds.includes(tenant.id) ? (
-            <EnterStoreButton storeId={tenant.id} storeName={tenant.store_name} />
+            <EnterStoreButton
+              storeId={tenant.id}
+              storeName={tenant.store_name}
+              subdomain={tenant.subdomain}
+            />
           ) : (
             <SupportAccessButton storeId={tenant.id} storeName={tenant.store_name} />
           )}

--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -38,7 +38,7 @@ export default async function AdminOrderDetailPage({ params }: OrderDetailPagePr
   }
 
   const { id } = await params;
-  const order = await getOrderById(id, authorization.storeId);
+  const order = await getOrderById(id, authorization.storeId, authorization.supabase);
   if (!order) {
     notFound();
   }

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -22,7 +22,7 @@ export default async function AdminOrdersPage({ searchParams }: OrdersPageProps)
   const page = parsePositiveInt(pageParam, 1);
   const pageSize = parsePositiveInt(pageSizeParam, DEFAULT_PAGE_SIZE);
 
-  const list = await loadOrders(authorization.storeId, page, pageSize);
+  const list = await loadOrders(authorization.supabase, authorization.storeId, page, pageSize);
 
   return (
     <AdminPageContainer>
@@ -47,18 +47,22 @@ type OrdersList =
   | { state: "error"; total: number };
 
 async function loadOrders(
+  supabase: any,
   storeId: string,
   page: number,
   pageSize: number,
 ): Promise<OrdersList> {
   try {
-    const { orders, total } = await getOrders({
-      storeId,
-      limit: pageSize,
-      offset: (page - 1) * pageSize,
-      order_by: "created_at",
-      order_direction: "desc",
-    });
+    const { orders, total } = await getOrders(
+      {
+        storeId,
+        limit: pageSize,
+        offset: (page - 1) * pageSize,
+        order_by: "created_at",
+        order_direction: "desc",
+      },
+      supabase,
+    );
 
     if (orders.length === 0) {
       return { state: "empty", total };

--- a/app/admin/products/components/products-table.tsx
+++ b/app/admin/products/components/products-table.tsx
@@ -92,27 +92,35 @@ const columns: Column<StoreItemWithDetails>[] = [
   {
     key: "stock",
     header: "Stock",
-    cell: (product) => (
-      <div>
-        <div className="font-medium">{product.inventory_quantity}</div>
-        {product.track_inventory &&
-          product.inventory_quantity <= product.low_stock_threshold && (
+    cell: (product) =>
+      product.track_inventory ? (
+        <div>
+          <div className="font-medium">{product.inventory_quantity}</div>
+          {product.inventory_quantity <= product.low_stock_threshold && (
             <Badge variant="destructive" className="mt-1 text-xs">
               Stock bajo
             </Badge>
           )}
-      </div>
-    ),
+        </div>
+      ) : (
+        <Badge variant="outline" className="w-fit text-xs font-normal">
+          Sin seguimiento
+        </Badge>
+      ),
   },
   {
     key: "status",
     header: "Estado",
-    cell: (product) =>
-      product.is_featured ? (
-        <Badge variant="outline" className="w-fit">
-          Destacado
-        </Badge>
-      ) : null,
+    cell: (product) => (
+      <div className="flex flex-wrap items-center gap-1.5">
+        {!product.is_active && <Badge variant="secondary">Inactivo</Badge>}
+        {product.is_featured && (
+          <Badge variant="outline" className="w-fit">
+            Destacado
+          </Badge>
+        )}
+      </div>
+    ),
   },
   {
     key: "actions",

--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -20,7 +20,7 @@ export default async function CreateProductPage() {
   return (
     <AdminPageContainer maxWidth="4xl">
       <AdminPageHeader
-        title="Crear Nuevo Producto"
+        title="Nuevo Producto"
         subtitle="Completa el formulario para agregar un nuevo producto al catálogo"
       />
       <CreateProductForm categories={categories} />

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -81,7 +81,7 @@ async function loadProducts(
       {
         store_id: storeId,
         item_kind: "products",
-        is_active: true,
+        is_active: null,
         limit: pageSize,
         offset: (page - 1) * pageSize,
         order_by: "created_at",

--- a/app/admin/settings/shipping/actions.ts
+++ b/app/admin/settings/shipping/actions.ts
@@ -9,7 +9,7 @@ import {
   unmatchedDestinationActionFormSchema,
 } from "@/lib/shipping/schemas"
 import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
-import { listDepartments, listMunicipalitiesByDepartment, type Department, type Municipality } from "@/lib/shipping/locations-api"
+import { listMunicipalitiesByDepartment, type Municipality } from "@/lib/shipping/locations-api"
 import { saveShippingMode, saveUnmatchedDestinationAction } from "@/lib/supabase/shipping-settings-api"
 import { deleteShippingZone, saveShippingZone } from "@/lib/supabase/shipping-zones-api"
 
@@ -137,16 +137,6 @@ export async function deleteShippingZoneAction(zoneId: string): Promise<AdminAct
 
   revalidatePath(SHIPPING_SETTINGS_PATH)
   return { success: true }
-}
-
-// D28's chained picker (department, then municipio filtered to it), reused
-// here for the zone destination picker -- both server actions require the
-// same active-store admin grant every other picker action in this console
-// does (app/admin/actions/catalog-pickers.ts), even though co_locations is
-// public data, so the zones screen has a single authority path throughout.
-export async function listShippingDepartmentsAction(): Promise<Department[]> {
-  const { supabase } = await requireActiveStoreGrant()
-  return listDepartments(supabase)
 }
 
 export async function listShippingMunicipalitiesAction(departmentCode: string): Promise<Municipality[]> {

--- a/app/admin/settings/shipping/actions.ts
+++ b/app/admin/settings/shipping/actions.ts
@@ -16,7 +16,6 @@ import { deleteShippingZone, saveShippingZone } from "@/lib/supabase/shipping-zo
 const SHIPPING_SETTINGS_PATH = "/admin/settings/shipping"
 const SETTINGS_PATH = "/admin/settings"
 const INVALID_INPUT = "Los datos no son válidos. Revisa el formulario e intenta de nuevo."
-const MUNICIPALITY_SEARCH_LIMIT = 50
 
 // D13/D27: storeId always comes from the active-store gate, never from the
 // client -- the same authority shape every other settings action in this
@@ -144,6 +143,8 @@ export async function listShippingMunicipalitiesAction(departmentCode: string): 
   const { supabase } = await requireActiveStoreGrant()
   return listMunicipalitiesByDepartment(departmentCode, supabase)
 }
+
+const MUNICIPALITY_SEARCH_LIMIT = 50
 
 export async function searchShippingMunicipalitiesAction(query: string): Promise<Municipality[]> {
   const { supabase } = await requireActiveStoreGrant()

--- a/app/admin/settings/shipping/actions.ts
+++ b/app/admin/settings/shipping/actions.ts
@@ -9,13 +9,14 @@ import {
   unmatchedDestinationActionFormSchema,
 } from "@/lib/shipping/schemas"
 import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
-import { listMunicipalitiesByDepartment, type Municipality } from "@/lib/shipping/locations-api"
+import { listMunicipalitiesByDepartment, searchMunicipalities, type Municipality } from "@/lib/shipping/locations-api"
 import { saveShippingMode, saveUnmatchedDestinationAction } from "@/lib/supabase/shipping-settings-api"
 import { deleteShippingZone, saveShippingZone } from "@/lib/supabase/shipping-zones-api"
 
 const SHIPPING_SETTINGS_PATH = "/admin/settings/shipping"
 const SETTINGS_PATH = "/admin/settings"
 const INVALID_INPUT = "Los datos no son válidos. Revisa el formulario e intenta de nuevo."
+const MUNICIPALITY_SEARCH_LIMIT = 50
 
 // D13/D27: storeId always comes from the active-store gate, never from the
 // client -- the same authority shape every other settings action in this
@@ -142,6 +143,11 @@ export async function deleteShippingZoneAction(zoneId: string): Promise<AdminAct
 export async function listShippingMunicipalitiesAction(departmentCode: string): Promise<Municipality[]> {
   const { supabase } = await requireActiveStoreGrant()
   return listMunicipalitiesByDepartment(departmentCode, supabase)
+}
+
+export async function searchShippingMunicipalitiesAction(query: string): Promise<Municipality[]> {
+  const { supabase } = await requireActiveStoreGrant()
+  return searchMunicipalities(query, MUNICIPALITY_SEARCH_LIMIT, supabase)
 }
 
 async function requireActiveStoreGrant() {

--- a/app/admin/settings/shipping/components/zone-editor.tsx
+++ b/app/admin/settings/shipping/components/zone-editor.tsx
@@ -1,90 +1,36 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useState } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useFieldArray, useForm, type Control, type FieldPath } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { Check, ChevronsUpDown, Loader2, Pencil, Plus, Save, X } from "lucide-react"
+import { Pencil, Plus, X } from "lucide-react"
 import { toast } from "sonner"
 
 import { ConfirmActionButton } from "@/components/admin/confirm-action-button"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { FieldError } from "@/components/ui/field-error"
-import { FormField } from "@/components/ui/form-field"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { translations } from "@/lib/i18n/translations"
-import type { Department, Municipality } from "@/lib/shipping/locations-api"
 import {
   UNMATCHED_DESTINATION_ACTIONS,
   destinationKey,
-  findShippingLadderGaps,
   shippingRateBasisLabelKey,
-  shippingRateLadderSchema,
-  shippingZoneFormSchema,
-  toRateLadderPayload,
-  type ShippingRateLadder,
   type UnmatchedDestinationAction,
-  type ZoneEditorFormValues,
 } from "@/lib/shipping/schemas"
-import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
-import {
-  deleteShippingZoneAction,
-  listShippingDepartmentsAction,
-  listShippingMunicipalitiesAction,
-  saveShippingZoneAction,
-  updateUnmatchedDestinationActionAction,
-} from "../actions"
-import { EMPTY_RANGE_ROW, RateLadderField } from "./rate-ladder-field"
+import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import { deleteShippingZoneAction, updateUnmatchedDestinationActionAction } from "../actions"
 
 const copy = translations.es.shipping.zones
 
-// Replaces a plain `string | "new" | null` state: "new" used to be absorbed
-// by `string`, so nothing enforced the distinction and every read site had
-// to re-derive it by hand (was editingZoneId "new", null, or a real id?).
-// A discriminated union makes each of the dialog's three states -- closed,
-// creating, editing a specific zone -- its own checked shape instead.
-type ZoneEditorState = { mode: "closed" } | { mode: "creating" } | { mode: "editing"; zoneId: string }
-
 export function ShippingZonesSection({
   zones,
-  missingWeightProducts,
   unmatchedDestinationAction,
 }: {
   zones: ShippingZoneRecord[]
-  missingWeightProducts: MissingWeightProduct[]
   unmatchedDestinationAction: UnmatchedDestinationAction
 }) {
-  const [editorState, setEditorState] = useState<ZoneEditorState>({ mode: "closed" })
-  const [departments, setDepartments] = useState<Department[]>([])
-
-  useEffect(() => {
-    listShippingDepartmentsAction()
-      .then(setDepartments)
-      .catch((error) => console.error("[Shipping Zones] Error al cargar departamentos:", error))
-  }, [])
-
-  const editingZoneId = editorState.mode === "editing" ? editorState.zoneId : null
-  // Looked up only to PRE-FILL the form -- a stale `zones` list (refreshed
-  // elsewhere while the dialog stayed open) can legitimately miss it, but
-  // that must never flip the save into a create: editingZoneId above, not
-  // this lookup, is what ZoneForm uses to decide create-vs-edit.
-  const editingZone = editingZoneId ? zones.find((zone) => zone.id === editingZoneId) ?? null : null
-
   return (
     <div className="space-y-6">
       <UnmatchedDestinationCard defaultValue={unmatchedDestinationAction} />
@@ -95,51 +41,25 @@ export function ShippingZonesSection({
             <CardTitle className="text-base">{copy.sectionTitle}</CardTitle>
             <CardDescription>{copy.sectionDescription}</CardDescription>
           </div>
-          <Button type="button" size="sm" className="shrink-0 gap-1.5" onClick={() => setEditorState({ mode: "creating" })}>
-            <Plus className="h-4 w-4" /> {copy.addButton}
+          <Button size="sm" className="shrink-0 gap-1.5" asChild>
+            <Link href="/admin/settings/shipping/zones/new">
+              <Plus className="h-4 w-4" /> {copy.addButton}
+            </Link>
           </Button>
         </CardHeader>
         <CardContent>
           {zones.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">{copy.emptyDescription}</p>
           ) : (
-            <ZonesTable zones={zones} onEdit={(zoneId) => setEditorState({ mode: "editing", zoneId })} />
+            <ZonesTable zones={zones} />
           )}
         </CardContent>
       </Card>
-
-      <Dialog
-        open={editorState.mode !== "closed"}
-        onOpenChange={(open) => !open && setEditorState({ mode: "closed" })}
-      >
-        <DialogContent className="editor-chrome max-h-[85vh] max-w-2xl overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{editorState.mode === "creating" ? copy.createTitle : copy.editTitle}</DialogTitle>
-            <DialogDescription>{copy.sectionDescription}</DialogDescription>
-          </DialogHeader>
-          {editorState.mode !== "closed" ? (
-            <ZoneForm
-              key={editingZoneId ?? "new"}
-              zoneId={editingZoneId}
-              zone={editingZone}
-              departments={departments}
-              missingWeightProducts={missingWeightProducts}
-              onClose={() => setEditorState({ mode: "closed" })}
-            />
-          ) : null}
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }
 
-function ZonesTable({
-  zones,
-  onEdit,
-}: {
-  zones: ShippingZoneRecord[]
-  onEdit: (zoneId: string) => void
-}) {
+function ZonesTable({ zones }: { zones: ShippingZoneRecord[] }) {
   return (
     <Table>
       <TableHeader>
@@ -170,8 +90,10 @@ function ZonesTable({
             </TableCell>
             <TableCell className="text-right">
               <div className="flex items-center justify-end gap-1">
-                <Button variant="outline" size="sm" onClick={() => onEdit(zone.id)} className="gap-1.5">
-                  <Pencil className="h-3.5 w-3.5" /> {copy.editTitle}
+                <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                  <Link href={`/admin/settings/shipping/zones/${zone.id}/edit`}>
+                    <Pencil className="h-3.5 w-3.5" /> {copy.editTitle}
+                  </Link>
                 </Button>
                 <DeleteZoneButton zoneId={zone.id} zoneName={zone.name} />
               </div>
@@ -239,306 +161,5 @@ function UnmatchedDestinationCard({ defaultValue }: { defaultValue: UnmatchedDes
         </Select>
       </CardContent>
     </Card>
-  )
-}
-
-function toRateLadderFormValues(ladder: ShippingRateLadder): ZoneEditorFormValues["rateLadder"] {
-  if (ladder.basis === "flat") {
-    return { basis: "flat", amount: ladder.amount, ranges: [EMPTY_RANGE_ROW] }
-  }
-  return { basis: ladder.basis, amount: "0", ranges: ladder.ranges }
-}
-
-function toDefaultValues(zone: ShippingZoneRecord | null): ZoneEditorFormValues {
-  if (!zone) {
-    return {
-      name: "",
-      destinations: [],
-      rateLadder: { basis: "flat", amount: "0", ranges: [EMPTY_RANGE_ROW] },
-    }
-  }
-
-  return {
-    name: zone.name,
-    destinations: zone.destinations.map((destination) => ({
-      departmentCode: destination.departmentCode,
-      municipalityCode: destination.municipalityCode,
-    })),
-    rateLadder: toRateLadderFormValues(zone.rateLadder),
-  }
-}
-
-function nameHintKey(kind: "department" | "municipality", code: string): string {
-  return `${kind}:${code}`
-}
-
-function buildNameHints(zone: ShippingZoneRecord | null): Map<string, string> {
-  const hints = new Map<string, string>()
-  for (const destination of zone?.destinations ?? []) {
-    hints.set(nameHintKey("department", destination.departmentCode), destination.departmentName)
-    if (destination.municipalityCode && destination.municipalityName) {
-      hints.set(nameHintKey("municipality", destination.municipalityCode), destination.municipalityName)
-    }
-  }
-  return hints
-}
-
-function ZoneForm({
-  zoneId,
-  zone,
-  departments,
-  missingWeightProducts,
-  onClose,
-}: {
-  // Decides create-vs-edit on submit -- sourced from editorState, never
-  // re-derived from `zone` (see the editingZoneId comment above the caller).
-  zoneId: string | null
-  zone: ShippingZoneRecord | null
-  departments: Department[]
-  missingWeightProducts: MissingWeightProduct[]
-  onClose: () => void
-}) {
-  const router = useRouter()
-  const nameHints = useMemo(() => buildNameHints(zone), [zone])
-
-  const {
-    control,
-    register,
-    handleSubmit,
-    setError,
-    formState: { errors, isSubmitting },
-  } = useForm<ZoneEditorFormValues>({
-    resolver: zodResolver(shippingZoneFormSchema),
-    defaultValues: toDefaultValues(zone),
-  })
-
-  // Takes handleSubmit's own validated payload instead of re-reading the
-  // form with getValues(): one reading of the form, not two that can quietly
-  // differ (the resolver trims `name`; a second, untrimmed read would have
-  // undone that).
-  async function onSubmit(values: ZoneEditorFormValues) {
-    const ladderPayload = toRateLadderPayload(values.rateLadder)
-    const parsedLadder = shippingRateLadderSchema.safeParse(ladderPayload)
-    if (!parsedLadder.success) {
-      // looseRateLadderFieldSchema (the resolver's own schema) never fails on
-      // the ladder, so this is the only place a broken row/amount is ever
-      // caught -- surfaced on the exact field RateLadderField renders
-      // (rate-ladder-field.tsx's Controllers read fieldState off this SAME
-      // control), the same "inline error, no toast" treatment name/destinations
-      // already get from the resolver above.
-      for (const issue of parsedLadder.error.issues) {
-        setError(`rateLadder.${issue.path.join(".")}` as FieldPath<ZoneEditorFormValues>, {
-          type: "manual",
-          message: issue.message,
-        })
-      }
-      return
-    }
-
-    const gapIssues = findShippingLadderGaps(parsedLadder.data)
-    if (gapIssues.length > 0) {
-      // D6 is a cross-row invariant, not one field's fault -- one toast per
-      // issue (same "several problems, several toasts" shape processOrder
-      // already uses in app/checkout/page.tsx for stock errors) so fixing the
-      // first one doesn't just uncover a second the owner was never shown.
-      gapIssues.forEach((issue) => toast.error(issue.message))
-      return
-    }
-
-    const result = await saveShippingZoneAction(
-      { name: values.name, destinations: values.destinations, rateLadder: parsedLadder.data },
-      zoneId ?? undefined,
-    )
-
-    if (!result.success) {
-      toast.error(result.error || copy.saveErrorToast)
-      return
-    }
-
-    toast.success(copy.savedToast)
-    router.refresh()
-    onClose()
-  }
-
-  return (
-    <form onSubmit={(event) => void handleSubmit(onSubmit)(event)} className="space-y-4">
-      <FormField id="zone-name" label={copy.nameLabel} error={errors.name?.message}>
-        {(field) => <Input {...field} placeholder={copy.namePlaceholder} {...register("name")} />}
-      </FormField>
-
-      <DestinationsField control={control} departments={departments} nameHints={nameHints} />
-      <FieldError message={errors.destinations?.message} />
-
-      <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
-
-      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-        <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
-          {copy.cancelButton}
-        </Button>
-        <Button type="submit" disabled={isSubmitting} className="gap-2">
-          {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-          {isSubmitting ? copy.saving : copy.saveButton}
-        </Button>
-      </div>
-    </form>
-  )
-}
-
-function DestinationsField({
-  control,
-  departments,
-  nameHints,
-}: {
-  control: Control<ZoneEditorFormValues>
-  departments: Department[]
-  nameHints: Map<string, string>
-}) {
-  const { fields, append, remove } = useFieldArray({ control, name: "destinations" })
-  const [names, setNames] = useState(nameHints)
-  const [selectedDepartment, setSelectedDepartment] = useState("")
-  const [municipalities, setMunicipalities] = useState<Municipality[]>([])
-  const [loadingMunicipalities, setLoadingMunicipalities] = useState(false)
-  const [municipalityPickerOpen, setMunicipalityPickerOpen] = useState(false)
-
-  // Fetches, not a state mirror: the effect's only job is asking the server
-  // for the chosen department's municipios, so it stays an effect. Every
-  // setState the effect body itself would need synchronously (clearing the
-  // previous department's stale list, flagging the fetch as loading) instead
-  // happens in the SELECT handler below that causes it -- only the async
-  // .then/.finally callbacks reporting the fetch's own outcome set state
-  // from here, the "derive it from the event that caused it" shape React's
-  // own effect guidance asks for.
-  useEffect(() => {
-    if (!selectedDepartment) return
-
-    let active = true
-    listShippingMunicipalitiesAction(selectedDepartment)
-      .then((result) => {
-        if (active) setMunicipalities(result)
-      })
-      .catch((error) => console.error("[Shipping Zones] Error al cargar municipios:", error))
-      .finally(() => {
-        if (active) setLoadingMunicipalities(false)
-      })
-
-    return () => {
-      active = false
-    }
-  }, [selectedDepartment])
-
-  function selectDepartment(departmentCode: string) {
-    setSelectedDepartment(departmentCode)
-    setMunicipalities([])
-    setLoadingMunicipalities(true)
-  }
-
-  // departmentName falls back to the `departments` prop directly instead of
-  // seeding it into `names` on every prop change: `names` only needs to hold
-  // hints the prop can't supply (a destination's name once picked, or an
-  // already-saved zone's own destinations).
-  function departmentName(departmentCode: string): string {
-    return (
-      names.get(nameHintKey("department", departmentCode)) ??
-      departments.find((department) => department.code === departmentCode)?.name ??
-      departmentCode
-    )
-  }
-
-  const existingKeys = new Set(fields.map(destinationKey))
-
-  function addWholeDepartment() {
-    if (!selectedDepartment || existingKeys.has(destinationKey({ departmentCode: selectedDepartment, municipalityCode: null }))) return
-    append({ departmentCode: selectedDepartment, municipalityCode: null })
-  }
-
-  function addMunicipality(municipality: Municipality) {
-    if (existingKeys.has(destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }))) return
-
-    setNames((current) => {
-      const next = new Map(current)
-      next.set(nameHintKey("department", municipality.departmentCode), municipality.departmentName)
-      next.set(nameHintKey("municipality", municipality.code), municipality.name)
-      return next
-    })
-    append({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code })
-    setMunicipalityPickerOpen(false)
-  }
-
-  return (
-    <div className="space-y-3">
-      <Label>{copy.destinationsLabel}</Label>
-
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <Select value={selectedDepartment} onValueChange={selectDepartment}>
-          <SelectTrigger className="w-full sm:w-64">
-            <SelectValue placeholder={copy.departmentPlaceholder} />
-          </SelectTrigger>
-          <SelectContent className="editor-chrome">
-            {departments.map((department) => (
-              <SelectItem key={department.code} value={department.code}>
-                {department.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button type="button" variant="outline" size="sm" disabled={!selectedDepartment} onClick={addWholeDepartment}>
-          {copy.addWholeDepartmentButton}
-        </Button>
-      </div>
-
-      {selectedDepartment ? (
-        <Popover open={municipalityPickerOpen} onOpenChange={setMunicipalityPickerOpen}>
-          <PopoverTrigger asChild>
-            <Button type="button" variant="outline" size="sm" className="w-full justify-between sm:w-72">
-              {copy.addMunicipalityButton}
-              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="editor-chrome w-72 p-0">
-            <Command>
-              <CommandInput placeholder={copy.municipalitySearchPlaceholder} />
-              <CommandList>
-                <CommandEmpty>{loadingMunicipalities ? copy.loadingMunicipalities : copy.noMunicipalitiesFound}</CommandEmpty>
-                <CommandGroup>
-                  {municipalities.map((municipality) => {
-                    const alreadyAdded = existingKeys.has(
-                      destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }),
-                    )
-                    return (
-                      <CommandItem
-                        key={municipality.id}
-                        value={municipality.name}
-                        disabled={alreadyAdded}
-                        onSelect={() => addMunicipality(municipality)}
-                      >
-                        <Check className={alreadyAdded ? "mr-2 h-4 w-4 opacity-100" : "mr-2 h-4 w-4 opacity-0"} />
-                        {municipality.name}
-                      </CommandItem>
-                    )
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      ) : null}
-
-      <div className="flex flex-wrap gap-2">
-        {fields.map((field, index) => {
-          const label = field.municipalityCode
-            ? names.get(nameHintKey("municipality", field.municipalityCode)) ?? field.municipalityCode
-            : `${copy.wholeDepartmentPrefix} ${departmentName(field.departmentCode)}`
-
-          return (
-            <Badge key={field.id} variant="secondary" className="gap-1.5 normal-case">
-              {label}
-              <button type="button" onClick={() => remove(index)} aria-label={copy.removeDestinationLabel}>
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          )
-        })}
-      </div>
-    </div>
   )
 }

--- a/app/admin/settings/shipping/components/zone-editor.tsx
+++ b/app/admin/settings/shipping/components/zone-editor.tsx
@@ -3,10 +3,11 @@
 import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { Pencil, Plus, X } from "lucide-react"
+import { Info, Pencil, Plus, X } from "lucide-react"
 import { toast } from "sonner"
 
 import { ConfirmActionButton } from "@/components/admin/confirm-action-button"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -17,20 +18,29 @@ import {
   UNMATCHED_DESTINATION_ACTIONS,
   destinationKey,
   shippingRateBasisLabelKey,
+  type ShippingMode,
   type UnmatchedDestinationAction,
 } from "@/lib/shipping/schemas"
-import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import type { ShippingZoneDestinationView, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
 import { deleteShippingZoneAction, updateUnmatchedDestinationActionAction } from "../actions"
 
 const copy = translations.es.shipping.zones
 
+const VISIBLE_DESTINATION_BADGES = 3
+
 export function ShippingZonesSection({
+  mode,
   zones,
   unmatchedDestinationAction,
 }: {
+  mode: ShippingMode
   zones: ShippingZoneRecord[]
   unmatchedDestinationAction: UnmatchedDestinationAction
 }) {
+  if (mode === "coordinate") {
+    return <CoordinateModeNotice />
+  }
+
   return (
     <div className="space-y-6">
       <UnmatchedDestinationCard defaultValue={unmatchedDestinationAction} />
@@ -49,13 +59,33 @@ export function ShippingZonesSection({
         </CardHeader>
         <CardContent>
           {zones.length === 0 ? (
-            <p className="py-8 text-center text-sm text-muted-foreground">{copy.emptyDescription}</p>
+            <div className="flex flex-col items-center gap-1 py-8 text-center">
+              <p className="font-medium">{copy.emptyTitle}</p>
+              <p className="text-sm text-muted-foreground">{copy.emptyDescription}</p>
+            </div>
           ) : (
             <ZonesTable zones={zones} />
           )}
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+function CoordinateModeNotice() {
+  return (
+    <Alert>
+      <Info aria-hidden />
+      <AlertTitle>{copy.coordinateModeTitle}</AlertTitle>
+      <AlertDescription>
+        <p>
+          {copy.coordinateModeDescription}{" "}
+          <Link href="#shipping-mode" className="font-medium underline underline-offset-4">
+            {copy.coordinateModeCta}
+          </Link>
+        </p>
+      </AlertDescription>
+    </Alert>
   )
 }
 
@@ -75,15 +105,7 @@ function ZonesTable({ zones }: { zones: ShippingZoneRecord[] }) {
           <TableRow key={zone.id}>
             <TableCell className="font-medium">{zone.name}</TableCell>
             <TableCell className="whitespace-normal">
-              <div className="flex flex-wrap gap-1">
-                {zone.destinations.map((destination) => (
-                  <Badge key={destinationKey(destination)} variant="outline">
-                    {destination.municipalityCode
-                      ? destination.municipalityName
-                      : `${copy.wholeDepartmentPrefix} ${destination.departmentName}`}
-                  </Badge>
-                ))}
-              </div>
+              <DestinationBadges destinations={zone.destinations} />
             </TableCell>
             <TableCell>
               <Badge variant="secondary">{copy[shippingRateBasisLabelKey(zone.rateLadder.basis)]}</Badge>
@@ -102,6 +124,26 @@ function ZonesTable({ zones }: { zones: ShippingZoneRecord[] }) {
         ))}
       </TableBody>
     </Table>
+  )
+}
+
+function DestinationBadges({ destinations }: { destinations: ShippingZoneDestinationView[] }) {
+  const visibleDestinations = destinations.slice(0, VISIBLE_DESTINATION_BADGES)
+  const hiddenDestinationsCount = destinations.length - visibleDestinations.length
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {visibleDestinations.map((destination) => (
+        <Badge key={destinationKey(destination)} variant="outline">
+          {destination.municipalityCode
+            ? destination.municipalityName
+            : `${copy.wholeDepartmentPrefix} ${destination.departmentName}`}
+        </Badge>
+      ))}
+      {hiddenDestinationsCount > 0 && (
+        <Badge variant="secondary">{copy.moreDestinationsLabel.replace("{count}", String(hiddenDestinationsCount))}</Badge>
+      )}
+    </div>
   )
 }
 

--- a/app/admin/settings/shipping/components/zone-form.tsx
+++ b/app/admin/settings/shipping/components/zone-form.tsx
@@ -5,12 +5,13 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useFieldArray, useForm, type Control, type FieldPath } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Check, ChevronsUpDown, Loader2, Save, X } from "lucide-react"
+import { Check, ChevronDown, ChevronRight, ChevronsUpDown, Loader2, Save } from "lucide-react"
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Command,
   CommandEmpty,
@@ -24,9 +25,8 @@ import { FormField } from "@/components/ui/form-field"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { translations } from "@/lib/i18n/translations"
-import type { Department, Municipality } from "@/lib/shipping/locations-api"
+import { MUNICIPALITY_SEARCH_MIN_LENGTH, type Department, type Municipality } from "@/lib/shipping/locations-api"
 import {
   destinationKey,
   findShippingLadderGaps,
@@ -36,13 +36,23 @@ import {
   type ShippingRateLadder,
   type ZoneEditorFormValues,
 } from "@/lib/shipping/schemas"
-import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
-import { listShippingMunicipalitiesAction, saveShippingZoneAction } from "../actions"
+import type {
+  ClaimedDestination,
+  MissingWeightProduct,
+  ShippingZoneRecord,
+} from "@/lib/supabase/shipping-zones-api"
+import {
+  listShippingMunicipalitiesAction,
+  saveShippingZoneAction,
+  searchShippingMunicipalitiesAction,
+} from "../actions"
 import { EMPTY_RANGE_ROW, RateLadderField } from "./rate-ladder-field"
 
 const copy = translations.es.shipping.zones
 
 const SHIPPING_ZONES_LIST_PATH = "/admin/settings/shipping"
+
+type DestinationValue = ZoneEditorFormValues["destinations"][number]
 
 function toRateLadderFormValues(ladder: ShippingRateLadder): ZoneEditorFormValues["rateLadder"] {
   if (ladder.basis === "flat") {
@@ -70,34 +80,20 @@ function toDefaultValues(zone: ShippingZoneRecord | null): ZoneEditorFormValues 
   }
 }
 
-function nameHintKey(kind: "department" | "municipality", code: string): string {
-  return `${kind}:${code}`
-}
-
-function buildNameHints(zone: ShippingZoneRecord | null): Map<string, string> {
-  const hints = new Map<string, string>()
-  for (const destination of zone?.destinations ?? []) {
-    hints.set(nameHintKey("department", destination.departmentCode), destination.departmentName)
-    if (destination.municipalityCode && destination.municipalityName) {
-      hints.set(nameHintKey("municipality", destination.municipalityCode), destination.municipalityName)
-    }
-  }
-  return hints
-}
-
 export function ZoneForm({
   zoneId,
   zone,
   departments,
   missingWeightProducts,
+  claimedDestinations = [],
 }: {
   zoneId: string | null
   zone: ShippingZoneRecord | null
   departments: Department[]
   missingWeightProducts: MissingWeightProduct[]
+  claimedDestinations?: ClaimedDestination[]
 }) {
   const router = useRouter()
-  const nameHints = useMemo(() => buildNameHints(zone), [zone])
 
   const {
     control,
@@ -169,7 +165,7 @@ export function ZoneForm({
             {(field) => <Input {...field} placeholder={copy.namePlaceholder} {...register("name")} />}
           </FormField>
 
-          <DestinationsField control={control} departments={departments} nameHints={nameHints} />
+          <DestinationsField control={control} departments={departments} claimedDestinations={claimedDestinations} />
           <FieldError message={errors.destinations?.message} />
 
           <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
@@ -189,35 +185,151 @@ export function ZoneForm({
   )
 }
 
+function withoutDepartment(destinations: DestinationValue[], departmentCode: string): DestinationValue[] {
+  return destinations.filter((destination) => destination.departmentCode !== departmentCode)
+}
+
+function nextDestinationsForWholeDepartment(
+  destinations: DestinationValue[],
+  departmentCode: string,
+  checked: boolean,
+): DestinationValue[] {
+  const rest = withoutDepartment(destinations, departmentCode)
+  return checked ? [...rest, { departmentCode, municipalityCode: null }] : rest
+}
+
+function nextDestinationsForMunicipality(
+  destinations: DestinationValue[],
+  municipality: Municipality,
+  checked: boolean,
+): DestinationValue[] {
+  const key = destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code })
+  const rest = destinations.filter((destination) => destinationKey(destination) !== key)
+  return checked
+    ? [...rest, { departmentCode: municipality.departmentCode, municipalityCode: municipality.code }]
+    : rest
+}
+
+function selectableWholeDepartments(departments: Department[], claimedByKey: Map<string, string>): DestinationValue[] {
+  return departments
+    .filter((department) => !claimedByKey.has(destinationKey({ departmentCode: department.code, municipalityCode: null })))
+    .map((department) => ({ departmentCode: department.code, municipalityCode: null }))
+}
+
+function claimedDestinationsByKey(claimedDestinations: ClaimedDestination[]): Map<string, string> {
+  return new Map(
+    claimedDestinations.map((destination) => [
+      destinationKey({ departmentCode: destination.departmentCode, municipalityCode: destination.municipalityCode }),
+      destination.zoneName,
+    ]),
+  )
+}
+
+const EMPTY_MUNICIPALITY_CODES = new Set<string>()
+
 function DestinationsField({
   control,
   departments,
-  nameHints,
+  claimedDestinations,
 }: {
   control: Control<ZoneEditorFormValues>
   departments: Department[]
-  nameHints: Map<string, string>
+  claimedDestinations: ClaimedDestination[]
 }) {
-  const { fields, append, remove } = useFieldArray({ control, name: "destinations" })
-  const [names, setNames] = useState(nameHints)
-  const [selectedDepartment, setSelectedDepartment] = useState("")
+  const { fields, replace } = useFieldArray({ control, name: "destinations" })
+  const claimedByKey = useMemo(() => claimedDestinationsByKey(claimedDestinations), [claimedDestinations])
+
+  const existingKeys = new Set(fields.map(destinationKey))
+  const wholeDepartmentCodes = new Set(
+    fields.filter((field) => field.municipalityCode === null).map((field) => field.departmentCode),
+  )
+  const municipalityCodesByDepartment = new Map<string, Set<string>>()
+  for (const field of fields) {
+    if (field.municipalityCode === null) continue
+    const codes = municipalityCodesByDepartment.get(field.departmentCode) ?? new Set<string>()
+    codes.add(field.municipalityCode)
+    municipalityCodesByDepartment.set(field.departmentCode, codes)
+  }
+
+  function toggleDepartmentWhole(departmentCode: string, checked: boolean) {
+    replace(nextDestinationsForWholeDepartment(fields, departmentCode, checked))
+  }
+
+  function toggleMunicipality(municipality: Municipality, checked: boolean) {
+    replace(nextDestinationsForMunicipality(fields, municipality, checked))
+  }
+
+  return (
+    <div className="space-y-3">
+      <Label>{copy.destinationsLabel}</Label>
+
+      <MunicipalitySearchField
+        wholeDepartmentCodes={wholeDepartmentCodes}
+        existingKeys={existingKeys}
+        claimedByKey={claimedByKey}
+        onSelect={(municipality) => toggleMunicipality(municipality, true)}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => replace(selectableWholeDepartments(departments, claimedByKey))}
+          >
+            {copy.selectAllDepartmentsButton}
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => replace([])}>
+            {copy.clearDestinationsButton}
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {fields.length} {copy.selectedDestinationsCountLabel}
+        </p>
+      </div>
+
+      <div className="max-h-96 divide-y overflow-y-auto rounded-md border">
+        {departments.map((department) => (
+          <DepartmentRow
+            key={department.code}
+            department={department}
+            claimedByKey={claimedByKey}
+            wholeSelected={wholeDepartmentCodes.has(department.code)}
+            selectedMunicipalityCodes={municipalityCodesByDepartment.get(department.code) ?? EMPTY_MUNICIPALITY_CODES}
+            onToggleWhole={(checked) => toggleDepartmentWhole(department.code, checked)}
+            onToggleMunicipality={toggleMunicipality}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DepartmentRow({
+  department,
+  claimedByKey,
+  wholeSelected,
+  selectedMunicipalityCodes,
+  onToggleWhole,
+  onToggleMunicipality,
+}: {
+  department: Department
+  claimedByKey: Map<string, string>
+  wholeSelected: boolean
+  selectedMunicipalityCodes: Set<string>
+  onToggleWhole: (checked: boolean) => void
+  onToggleMunicipality: (municipality: Municipality, checked: boolean) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
   const [municipalities, setMunicipalities] = useState<Municipality[]>([])
   const [loadingMunicipalities, setLoadingMunicipalities] = useState(false)
-  const [municipalityPickerOpen, setMunicipalityPickerOpen] = useState(false)
 
-  // Fetches, not a state mirror: the effect's only job is asking the server
-  // for the chosen department's municipios, so it stays an effect. Every
-  // setState the effect body itself would need synchronously (clearing the
-  // previous department's stale list, flagging the fetch as loading) instead
-  // happens in the SELECT handler below that causes it -- only the async
-  // .then/.finally callbacks reporting the fetch's own outcome set state
-  // from here, the "derive it from the event that caused it" shape React's
-  // own effect guidance asks for.
   useEffect(() => {
-    if (!selectedDepartment) return
+    if (!expanded) return
 
     let active = true
-    listShippingMunicipalitiesAction(selectedDepartment)
+    listShippingMunicipalitiesAction(department.code)
       .then((result) => {
         if (active) setMunicipalities(result)
       })
@@ -229,121 +341,216 @@ function DestinationsField({
     return () => {
       active = false
     }
-  }, [selectedDepartment])
+  }, [expanded, department.code])
 
-  function selectDepartment(departmentCode: string) {
-    setSelectedDepartment(departmentCode)
-    setMunicipalities([])
-    setLoadingMunicipalities(true)
+  function toggleExpanded() {
+    if (!expanded) setLoadingMunicipalities(true)
+    setExpanded((current) => !current)
   }
 
-  // departmentName falls back to the `departments` prop directly instead of
-  // seeding it into `names` on every prop change: `names` only needs to hold
-  // hints the prop can't supply (a destination's name once picked, or an
-  // already-saved zone's own destinations).
-  function departmentName(departmentCode: string): string {
-    return (
-      names.get(nameHintKey("department", departmentCode)) ??
-      departments.find((department) => department.code === departmentCode)?.name ??
-      departmentCode
-    )
-  }
-
-  const existingKeys = new Set(fields.map(destinationKey))
-
-  function addWholeDepartment() {
-    if (!selectedDepartment || existingKeys.has(destinationKey({ departmentCode: selectedDepartment, municipalityCode: null }))) return
-    append({ departmentCode: selectedDepartment, municipalityCode: null })
-  }
-
-  function addMunicipality(municipality: Municipality) {
-    if (existingKeys.has(destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }))) return
-
-    setNames((current) => {
-      const next = new Map(current)
-      next.set(nameHintKey("department", municipality.departmentCode), municipality.departmentName)
-      next.set(nameHintKey("municipality", municipality.code), municipality.name)
-      return next
-    })
-    append({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code })
-    setMunicipalityPickerOpen(false)
-  }
+  const claimedWholeBy = claimedByKey.get(destinationKey({ departmentCode: department.code, municipalityCode: null }))
+  const checkboxId = `department-${department.code}`
 
   return (
-    <div className="space-y-3">
-      <Label>{copy.destinationsLabel}</Label>
-
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <Select value={selectedDepartment} onValueChange={selectDepartment}>
-          <SelectTrigger className="w-full sm:w-64">
-            <SelectValue placeholder={copy.departmentPlaceholder} />
-          </SelectTrigger>
-          <SelectContent className="editor-chrome">
-            {departments.map((department) => (
-              <SelectItem key={department.code} value={department.code}>
-                {department.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button type="button" variant="outline" size="sm" disabled={!selectedDepartment} onClick={addWholeDepartment}>
-          {copy.addWholeDepartmentButton}
+    <div className="p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Checkbox
+          id={checkboxId}
+          checked={wholeSelected}
+          disabled={Boolean(claimedWholeBy)}
+          onCheckedChange={(checked) => onToggleWhole(checked === true)}
+        />
+        <Label htmlFor={checkboxId} className="min-w-0 flex-1 cursor-pointer">
+          {department.name}
+        </Label>
+        {claimedWholeBy ? (
+          <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedWholeBy}"`}</Badge>
+        ) : selectedMunicipalityCodes.size > 0 ? (
+          <span className="text-xs text-muted-foreground">
+            {selectedMunicipalityCodes.size} {copy.selectedMunicipalitiesCountLabel}
+          </span>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="gap-1"
+          aria-expanded={expanded}
+          onClick={toggleExpanded}
+        >
+          {expanded ? copy.hideMunicipalitiesButton : copy.showMunicipalitiesButton}
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
         </Button>
       </div>
 
-      {selectedDepartment ? (
-        <Popover open={municipalityPickerOpen} onOpenChange={setMunicipalityPickerOpen}>
-          <PopoverTrigger asChild>
-            <Button type="button" variant="outline" size="sm" className="w-full justify-between sm:w-72">
-              {copy.addMunicipalityButton}
-              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="editor-chrome w-72 p-0">
-            <Command>
-              <CommandInput placeholder={copy.municipalitySearchPlaceholder} />
-              <CommandList>
-                <CommandEmpty>{loadingMunicipalities ? copy.loadingMunicipalities : copy.noMunicipalitiesFound}</CommandEmpty>
+      {expanded ? (
+        <MunicipalityChecklist
+          loading={loadingMunicipalities}
+          municipalities={municipalities}
+          claimedByKey={claimedByKey}
+          wholeSelected={wholeSelected}
+          selectedMunicipalityCodes={selectedMunicipalityCodes}
+          onToggleMunicipality={onToggleMunicipality}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function MunicipalityChecklist({
+  loading,
+  municipalities,
+  claimedByKey,
+  wholeSelected,
+  selectedMunicipalityCodes,
+  onToggleMunicipality,
+}: {
+  loading: boolean
+  municipalities: Municipality[]
+  claimedByKey: Map<string, string>
+  wholeSelected: boolean
+  selectedMunicipalityCodes: Set<string>
+  onToggleMunicipality: (municipality: Municipality, checked: boolean) => void
+}) {
+  if (loading) {
+    return <p className="mt-2 pl-6 text-sm text-muted-foreground">{copy.loadingMunicipalities}</p>
+  }
+
+  if (municipalities.length === 0) {
+    return <p className="mt-2 pl-6 text-sm text-muted-foreground">{copy.noMunicipalitiesFound}</p>
+  }
+
+  return (
+    <div className="mt-2 grid grid-cols-1 gap-1 pl-6 sm:grid-cols-2">
+      {municipalities.map((municipality) => {
+        const claimedBy = claimedByKey.get(
+          destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }),
+        )
+        const checked = wholeSelected || selectedMunicipalityCodes.has(municipality.code)
+        const checkboxId = `municipality-${municipality.code}`
+
+        return (
+          <div key={municipality.id} className="flex items-center gap-2">
+            <Checkbox
+              id={checkboxId}
+              checked={checked}
+              disabled={wholeSelected || Boolean(claimedBy)}
+              onCheckedChange={(value) => onToggleMunicipality(municipality, value === true)}
+            />
+            <Label htmlFor={checkboxId} className="min-w-0 flex-1 cursor-pointer text-sm">
+              {municipality.name}
+            </Label>
+            {claimedBy ? (
+              <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedBy}"`}</Badge>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+const MUNICIPALITY_SEARCH_DEBOUNCE_MS = 300
+
+function MunicipalitySearchField({
+  wholeDepartmentCodes,
+  existingKeys,
+  claimedByKey,
+  onSelect,
+}: {
+  wholeDepartmentCodes: Set<string>
+  existingKeys: Set<string>
+  claimedByKey: Map<string, string>
+  onSelect: (municipality: Municipality) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<Municipality[]>([])
+  const [searching, setSearching] = useState(false)
+
+  const trimmedQuery = query.trim()
+  const queryTooShort = trimmedQuery.length < MUNICIPALITY_SEARCH_MIN_LENGTH
+
+  useEffect(() => {
+    if (queryTooShort) return
+
+    let active = true
+    const timeoutId = setTimeout(() => {
+      searchShippingMunicipalitiesAction(trimmedQuery)
+        .then((municipalities) => {
+          if (active) setResults(municipalities)
+        })
+        .catch((error) => console.error("[Shipping Zones] Error al buscar municipios:", error))
+        .finally(() => {
+          if (active) setSearching(false)
+        })
+    }, MUNICIPALITY_SEARCH_DEBOUNCE_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timeoutId)
+    }
+  }, [trimmedQuery, queryTooShort])
+
+  function handleQueryChange(value: string) {
+    setQuery(value)
+    if (value.trim().length < MUNICIPALITY_SEARCH_MIN_LENGTH) {
+      setResults([])
+      setSearching(false)
+    } else {
+      setSearching(true)
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" role="combobox" aria-expanded={open} className="w-full justify-between font-normal">
+          {copy.municipalitySearchPlaceholder}
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="editor-chrome w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput value={query} onValueChange={handleQueryChange} placeholder={copy.municipalitySearchPlaceholder} />
+          <CommandList>
+            {queryTooShort ? null : (
+              <>
+                <CommandEmpty>{searching ? copy.loadingMunicipalities : copy.noMunicipalitiesFound}</CommandEmpty>
                 <CommandGroup>
-                  {municipalities.map((municipality) => {
-                    const alreadyAdded = existingKeys.has(
-                      destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }),
-                    )
+                  {results.map((municipality) => {
+                    const key = destinationKey({
+                      departmentCode: municipality.departmentCode,
+                      municipalityCode: municipality.code,
+                    })
+                    const claimedBy = claimedByKey.get(key)
+                    const alreadySelected = wholeDepartmentCodes.has(municipality.departmentCode) || existingKeys.has(key)
+
                     return (
                       <CommandItem
                         key={municipality.id}
-                        value={municipality.name}
-                        disabled={alreadyAdded}
-                        onSelect={() => addMunicipality(municipality)}
+                        value={municipality.code}
+                        disabled={alreadySelected || Boolean(claimedBy)}
+                        onSelect={() => {
+                          onSelect(municipality)
+                          setOpen(false)
+                          setQuery("")
+                        }}
                       >
-                        <Check className={alreadyAdded ? "mr-2 h-4 w-4 opacity-100" : "mr-2 h-4 w-4 opacity-0"} />
-                        {municipality.name}
+                        <Check className={alreadySelected ? "h-4 w-4 opacity-100" : "h-4 w-4 opacity-0"} />
+                        <span className="flex-1">{`${municipality.name} (${municipality.departmentName})`}</span>
+                        {claimedBy ? (
+                          <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedBy}"`}</Badge>
+                        ) : null}
                       </CommandItem>
                     )
                   })}
                 </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      ) : null}
-
-      <div className="flex flex-wrap gap-2">
-        {fields.map((field, index) => {
-          const label = field.municipalityCode
-            ? names.get(nameHintKey("municipality", field.municipalityCode)) ?? field.municipalityCode
-            : `${copy.wholeDepartmentPrefix} ${departmentName(field.departmentCode)}`
-
-          return (
-            <Badge key={field.id} variant="secondary" className="gap-1.5 normal-case">
-              {label}
-              <button type="button" onClick={() => remove(index)} aria-label={copy.removeDestinationLabel}>
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          )
-        })}
-      </div>
-    </div>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/app/admin/settings/shipping/components/zone-form.tsx
+++ b/app/admin/settings/shipping/components/zone-form.tsx
@@ -8,6 +8,17 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Check, ChevronDown, ChevronRight, ChevronsUpDown, Loader2, Save } from "lucide-react"
 import { toast } from "sonner"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -51,6 +62,9 @@ import { EMPTY_RANGE_ROW, RateLadderField } from "./rate-ladder-field"
 const copy = translations.es.shipping.zones
 
 const SHIPPING_ZONES_LIST_PATH = "/admin/settings/shipping"
+
+const DESTINATIONS_LABEL_ID = "zone-destinations-label"
+const DESTINATIONS_ERROR_ID = "zone-destinations-error"
 
 type DestinationValue = ZoneEditorFormValues["destinations"][number]
 
@@ -156,7 +170,9 @@ export function ZoneForm({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{copy.formTitle}</CardTitle>
+        <CardTitle asChild className="text-base">
+          <h2>{copy.formTitle}</h2>
+        </CardTitle>
         <CardDescription>{copy.formDescription}</CardDescription>
       </CardHeader>
       <CardContent>
@@ -165,8 +181,12 @@ export function ZoneForm({
             {(field) => <Input {...field} placeholder={copy.namePlaceholder} {...register("name")} />}
           </FormField>
 
-          <DestinationsField control={control} departments={departments} claimedDestinations={claimedDestinations} />
-          <FieldError message={errors.destinations?.message} />
+          <DestinationsField
+            control={control}
+            departments={departments}
+            claimedDestinations={claimedDestinations}
+            errorMessage={errors.destinations?.message}
+          />
 
           <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
 
@@ -225,31 +245,54 @@ function claimedDestinationsByKey(claimedDestinations: ClaimedDestination[]): Ma
   )
 }
 
+function existingDestinationKeys(destinations: DestinationValue[]): Set<string> {
+  return new Set(destinations.map(destinationKey))
+}
+
+function wholeDepartmentCodesOf(destinations: DestinationValue[]): Set<string> {
+  return new Set(
+    destinations.filter((destination) => destination.municipalityCode === null).map((destination) => destination.departmentCode),
+  )
+}
+
+function groupMunicipalityCodesByDepartment(destinations: DestinationValue[]): Map<string, Set<string>> {
+  const codesByDepartment = new Map<string, Set<string>>()
+  for (const destination of destinations) {
+    if (destination.municipalityCode === null) continue
+    const codes = codesByDepartment.get(destination.departmentCode) ?? new Set<string>()
+    codes.add(destination.municipalityCode)
+    codesByDepartment.set(destination.departmentCode, codes)
+  }
+  return codesByDepartment
+}
+
+function ClaimedByBadge({ id, zoneName }: { id?: string; zoneName: string }) {
+  return (
+    <Badge id={id} variant="outline" className="normal-case">
+      {`${copy.claimedByPrefix} "${zoneName}"`}
+    </Badge>
+  )
+}
+
 const EMPTY_MUNICIPALITY_CODES = new Set<string>()
 
 function DestinationsField({
   control,
   departments,
   claimedDestinations,
+  errorMessage,
 }: {
   control: Control<ZoneEditorFormValues>
   departments: Department[]
   claimedDestinations: ClaimedDestination[]
+  errorMessage?: string
 }) {
   const { fields, replace } = useFieldArray({ control, name: "destinations" })
   const claimedByKey = useMemo(() => claimedDestinationsByKey(claimedDestinations), [claimedDestinations])
 
-  const existingKeys = new Set(fields.map(destinationKey))
-  const wholeDepartmentCodes = new Set(
-    fields.filter((field) => field.municipalityCode === null).map((field) => field.departmentCode),
-  )
-  const municipalityCodesByDepartment = new Map<string, Set<string>>()
-  for (const field of fields) {
-    if (field.municipalityCode === null) continue
-    const codes = municipalityCodesByDepartment.get(field.departmentCode) ?? new Set<string>()
-    codes.add(field.municipalityCode)
-    municipalityCodesByDepartment.set(field.departmentCode, codes)
-  }
+  const existingKeys = existingDestinationKeys(fields)
+  const wholeDepartmentCodes = wholeDepartmentCodesOf(fields)
+  const municipalityCodesByDepartment = groupMunicipalityCodesByDepartment(fields)
 
   function toggleDepartmentWhole(departmentCode: string, checked: boolean) {
     replace(nextDestinationsForWholeDepartment(fields, departmentCode, checked))
@@ -259,9 +302,20 @@ function DestinationsField({
     replace(nextDestinationsForMunicipality(fields, municipality, checked))
   }
 
+  function selectAllDepartments() {
+    const nextDestinations = selectableWholeDepartments(departments, claimedByKey)
+    replace(nextDestinations)
+    toast.success(copy.selectedAllDestinationsToast.replace("{count}", String(nextDestinations.length)))
+  }
+
   return (
-    <div className="space-y-3">
-      <Label>{copy.destinationsLabel}</Label>
+    <div
+      role="group"
+      aria-labelledby={DESTINATIONS_LABEL_ID}
+      aria-describedby={errorMessage ? DESTINATIONS_ERROR_ID : undefined}
+      className="space-y-3"
+    >
+      <Label id={DESTINATIONS_LABEL_ID}>{copy.destinationsLabel}</Label>
 
       <MunicipalitySearchField
         wholeDepartmentCodes={wholeDepartmentCodes}
@@ -271,18 +325,11 @@ function DestinationsField({
       />
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => replace(selectableWholeDepartments(departments, claimedByKey))}
-          >
+        <div className="flex gap-3">
+          <Button type="button" variant="outline" size="sm" onClick={selectAllDepartments}>
             {copy.selectAllDepartmentsButton}
           </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => replace([])}>
-            {copy.clearDestinationsButton}
-          </Button>
+          <ClearDestinationsButton count={fields.length} onConfirm={() => replace([])} />
         </div>
         <p className="text-sm text-muted-foreground">
           {fields.length} {copy.selectedDestinationsCountLabel}
@@ -302,7 +349,56 @@ function DestinationsField({
           />
         ))}
       </div>
+
+      <FieldError id={DESTINATIONS_ERROR_ID} message={errorMessage} />
     </div>
+  )
+}
+
+function ClearDestinationsButton({ count, onConfirm }: { count: number; onConfirm: () => void }) {
+  const [open, setOpen] = useState(false)
+
+  function handleConfirm() {
+    onConfirm()
+    setOpen(false)
+    toast.success(copy.clearedDestinationsToast)
+  }
+
+  if (count === 0) {
+    return (
+      <Button type="button" variant="ghost" size="sm" onClick={onConfirm}>
+        {copy.clearDestinationsButton}
+      </Button>
+    )
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="ghost" size="sm">
+          {copy.clearDestinationsButton}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="editor-chrome">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{copy.clearDestinationsConfirmTitle}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {copy.clearDestinationsConfirmDescription.replace("{count}", String(count))}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{copy.cancelButton}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(event) => {
+              event.preventDefault()
+              handleConfirm()
+            }}
+          >
+            {copy.clearDestinationsConfirmButton}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 
@@ -324,6 +420,7 @@ function DepartmentRow({
   const [expanded, setExpanded] = useState(false)
   const [municipalities, setMunicipalities] = useState<Municipality[]>([])
   const [loadingMunicipalities, setLoadingMunicipalities] = useState(false)
+  const [municipalitiesError, setMunicipalitiesError] = useState(false)
 
   useEffect(() => {
     if (!expanded) return
@@ -333,7 +430,10 @@ function DepartmentRow({
       .then((result) => {
         if (active) setMunicipalities(result)
       })
-      .catch((error) => console.error("[Shipping Zones] Error al cargar municipios:", error))
+      .catch((error) => {
+        console.error("[Shipping Zones] Error al cargar municipios:", error)
+        if (active) setMunicipalitiesError(true)
+      })
       .finally(() => {
         if (active) setLoadingMunicipalities(false)
       })
@@ -344,12 +444,16 @@ function DepartmentRow({
   }, [expanded, department.code])
 
   function toggleExpanded() {
-    if (!expanded) setLoadingMunicipalities(true)
+    if (!expanded) {
+      setLoadingMunicipalities(true)
+      setMunicipalitiesError(false)
+    }
     setExpanded((current) => !current)
   }
 
   const claimedWholeBy = claimedByKey.get(destinationKey({ departmentCode: department.code, municipalityCode: null }))
   const checkboxId = `department-${department.code}`
+  const claimedDescriptionId = claimedWholeBy ? `${checkboxId}-claimed` : undefined
 
   return (
     <div className="p-3">
@@ -357,14 +461,22 @@ function DepartmentRow({
         <Checkbox
           id={checkboxId}
           checked={wholeSelected}
-          disabled={Boolean(claimedWholeBy)}
-          onCheckedChange={(checked) => onToggleWhole(checked === true)}
+          aria-disabled={claimedWholeBy ? true : undefined}
+          aria-describedby={claimedDescriptionId}
+          className="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          onCheckedChange={(checked) => {
+            if (claimedWholeBy) return
+            onToggleWhole(checked === true)
+          }}
         />
-        <Label htmlFor={checkboxId} className="min-w-0 flex-1 cursor-pointer">
+        <Label
+          htmlFor={checkboxId}
+          className="min-w-0 flex-1 cursor-pointer max-md:flex max-md:min-h-11 max-md:items-center peer-aria-disabled:cursor-not-allowed peer-aria-disabled:opacity-70"
+        >
           {department.name}
         </Label>
         {claimedWholeBy ? (
-          <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedWholeBy}"`}</Badge>
+          <ClaimedByBadge id={claimedDescriptionId} zoneName={claimedWholeBy} />
         ) : selectedMunicipalityCodes.size > 0 ? (
           <span className="text-xs text-muted-foreground">
             {selectedMunicipalityCodes.size} {copy.selectedMunicipalitiesCountLabel}
@@ -386,6 +498,7 @@ function DepartmentRow({
       {expanded ? (
         <MunicipalityChecklist
           loading={loadingMunicipalities}
+          error={municipalitiesError}
           municipalities={municipalities}
           claimedByKey={claimedByKey}
           wholeSelected={wholeSelected}
@@ -399,6 +512,7 @@ function DepartmentRow({
 
 function MunicipalityChecklist({
   loading,
+  error,
   municipalities,
   claimedByKey,
   wholeSelected,
@@ -406,6 +520,7 @@ function MunicipalityChecklist({
   onToggleMunicipality,
 }: {
   loading: boolean
+  error: boolean
   municipalities: Municipality[]
   claimedByKey: Map<string, string>
   wholeSelected: boolean
@@ -414,6 +529,10 @@ function MunicipalityChecklist({
 }) {
   if (loading) {
     return <p className="mt-2 pl-6 text-sm text-muted-foreground">{copy.loadingMunicipalities}</p>
+  }
+
+  if (error) {
+    return <p className="mt-2 pl-6 text-sm text-destructive">{copy.municipalitiesLoadError}</p>
   }
 
   if (municipalities.length === 0) {
@@ -428,21 +547,29 @@ function MunicipalityChecklist({
         )
         const checked = wholeSelected || selectedMunicipalityCodes.has(municipality.code)
         const checkboxId = `municipality-${municipality.code}`
+        const isLocked = wholeSelected || Boolean(claimedBy)
+        const claimedDescriptionId = claimedBy ? `${checkboxId}-claimed` : undefined
 
         return (
           <div key={municipality.id} className="flex items-center gap-2">
             <Checkbox
               id={checkboxId}
               checked={checked}
-              disabled={wholeSelected || Boolean(claimedBy)}
-              onCheckedChange={(value) => onToggleMunicipality(municipality, value === true)}
+              aria-disabled={isLocked ? true : undefined}
+              aria-describedby={claimedDescriptionId}
+              className="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+              onCheckedChange={(value) => {
+                if (isLocked) return
+                onToggleMunicipality(municipality, value === true)
+              }}
             />
-            <Label htmlFor={checkboxId} className="min-w-0 flex-1 cursor-pointer text-sm">
+            <Label
+              htmlFor={checkboxId}
+              className="min-w-0 flex-1 cursor-pointer text-sm max-md:flex max-md:min-h-11 max-md:items-center peer-aria-disabled:cursor-not-allowed peer-aria-disabled:opacity-70"
+            >
               {municipality.name}
             </Label>
-            {claimedBy ? (
-              <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedBy}"`}</Badge>
-            ) : null}
+            {claimedBy ? <ClaimedByBadge id={claimedDescriptionId} zoneName={claimedBy} /> : null}
           </div>
         )
       })}
@@ -467,6 +594,7 @@ function MunicipalitySearchField({
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<Municipality[]>([])
   const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState(false)
 
   const trimmedQuery = query.trim()
   const queryTooShort = trimmedQuery.length < MUNICIPALITY_SEARCH_MIN_LENGTH
@@ -478,9 +606,16 @@ function MunicipalitySearchField({
     const timeoutId = setTimeout(() => {
       searchShippingMunicipalitiesAction(trimmedQuery)
         .then((municipalities) => {
-          if (active) setResults(municipalities)
+          if (!active) return
+          setResults(municipalities)
+          setSearchError(false)
         })
-        .catch((error) => console.error("[Shipping Zones] Error al buscar municipios:", error))
+        .catch((error) => {
+          console.error("[Shipping Zones] Error al buscar municipios:", error)
+          if (!active) return
+          setResults([])
+          setSearchError(true)
+        })
         .finally(() => {
           if (active) setSearching(false)
         })
@@ -516,7 +651,13 @@ function MunicipalitySearchField({
           <CommandList>
             {queryTooShort ? null : (
               <>
-                <CommandEmpty>{searching ? copy.loadingMunicipalities : copy.noMunicipalitiesFound}</CommandEmpty>
+                <CommandEmpty>
+                  {searching
+                    ? copy.loadingMunicipalities
+                    : searchError
+                      ? copy.municipalitiesLoadError
+                      : copy.noMunicipalitiesFound}
+                </CommandEmpty>
                 <CommandGroup>
                   {results.map((municipality) => {
                     const key = destinationKey({
@@ -525,12 +666,14 @@ function MunicipalitySearchField({
                     })
                     const claimedBy = claimedByKey.get(key)
                     const alreadySelected = wholeDepartmentCodes.has(municipality.departmentCode) || existingKeys.has(key)
+                    const claimedDescriptionId = claimedBy ? `search-${municipality.code}-claimed` : undefined
 
                     return (
                       <CommandItem
                         key={municipality.id}
                         value={municipality.code}
                         disabled={alreadySelected || Boolean(claimedBy)}
+                        aria-describedby={claimedDescriptionId}
                         onSelect={() => {
                           onSelect(municipality)
                           setOpen(false)
@@ -539,9 +682,7 @@ function MunicipalitySearchField({
                       >
                         <Check className={alreadySelected ? "h-4 w-4 opacity-100" : "h-4 w-4 opacity-0"} />
                         <span className="flex-1">{`${municipality.name} (${municipality.departmentName})`}</span>
-                        {claimedBy ? (
-                          <Badge variant="outline" className="normal-case">{`${copy.claimedByPrefix} "${claimedBy}"`}</Badge>
-                        ) : null}
+                        {claimedBy ? <ClaimedByBadge id={claimedDescriptionId} zoneName={claimedBy} /> : null}
                       </CommandItem>
                     )
                   })}

--- a/app/admin/settings/shipping/components/zone-form.tsx
+++ b/app/admin/settings/shipping/components/zone-form.tsx
@@ -1,0 +1,349 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useFieldArray, useForm, type Control, type FieldPath } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Check, ChevronsUpDown, Loader2, Save, X } from "lucide-react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { FieldError } from "@/components/ui/field-error"
+import { FormField } from "@/components/ui/form-field"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { translations } from "@/lib/i18n/translations"
+import type { Department, Municipality } from "@/lib/shipping/locations-api"
+import {
+  destinationKey,
+  findShippingLadderGaps,
+  shippingRateLadderSchema,
+  shippingZoneFormSchema,
+  toRateLadderPayload,
+  type ShippingRateLadder,
+  type ZoneEditorFormValues,
+} from "@/lib/shipping/schemas"
+import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import { listShippingMunicipalitiesAction, saveShippingZoneAction } from "../actions"
+import { EMPTY_RANGE_ROW, RateLadderField } from "./rate-ladder-field"
+
+const copy = translations.es.shipping.zones
+
+const SHIPPING_ZONES_LIST_PATH = "/admin/settings/shipping"
+
+function toRateLadderFormValues(ladder: ShippingRateLadder): ZoneEditorFormValues["rateLadder"] {
+  if (ladder.basis === "flat") {
+    return { basis: "flat", amount: ladder.amount, ranges: [EMPTY_RANGE_ROW] }
+  }
+  return { basis: ladder.basis, amount: "0", ranges: ladder.ranges }
+}
+
+function toDefaultValues(zone: ShippingZoneRecord | null): ZoneEditorFormValues {
+  if (!zone) {
+    return {
+      name: "",
+      destinations: [],
+      rateLadder: { basis: "flat", amount: "0", ranges: [EMPTY_RANGE_ROW] },
+    }
+  }
+
+  return {
+    name: zone.name,
+    destinations: zone.destinations.map((destination) => ({
+      departmentCode: destination.departmentCode,
+      municipalityCode: destination.municipalityCode,
+    })),
+    rateLadder: toRateLadderFormValues(zone.rateLadder),
+  }
+}
+
+function nameHintKey(kind: "department" | "municipality", code: string): string {
+  return `${kind}:${code}`
+}
+
+function buildNameHints(zone: ShippingZoneRecord | null): Map<string, string> {
+  const hints = new Map<string, string>()
+  for (const destination of zone?.destinations ?? []) {
+    hints.set(nameHintKey("department", destination.departmentCode), destination.departmentName)
+    if (destination.municipalityCode && destination.municipalityName) {
+      hints.set(nameHintKey("municipality", destination.municipalityCode), destination.municipalityName)
+    }
+  }
+  return hints
+}
+
+export function ZoneForm({
+  zoneId,
+  zone,
+  departments,
+  missingWeightProducts,
+}: {
+  zoneId: string | null
+  zone: ShippingZoneRecord | null
+  departments: Department[]
+  missingWeightProducts: MissingWeightProduct[]
+}) {
+  const router = useRouter()
+  const nameHints = useMemo(() => buildNameHints(zone), [zone])
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<ZoneEditorFormValues>({
+    resolver: zodResolver(shippingZoneFormSchema),
+    defaultValues: toDefaultValues(zone),
+  })
+
+  // Takes handleSubmit's own validated payload instead of re-reading the
+  // form with getValues(): one reading of the form, not two that can quietly
+  // differ (the resolver trims `name`; a second, untrimmed read would have
+  // undone that).
+  async function onSubmit(values: ZoneEditorFormValues) {
+    const ladderPayload = toRateLadderPayload(values.rateLadder)
+    const parsedLadder = shippingRateLadderSchema.safeParse(ladderPayload)
+    if (!parsedLadder.success) {
+      // looseRateLadderFieldSchema (the resolver's own schema) never fails on
+      // the ladder, so this is the only place a broken row/amount is ever
+      // caught -- surfaced on the exact field RateLadderField renders
+      // (rate-ladder-field.tsx's Controllers read fieldState off this SAME
+      // control), the same "inline error, no toast" treatment name/destinations
+      // already get from the resolver above.
+      for (const issue of parsedLadder.error.issues) {
+        setError(`rateLadder.${issue.path.join(".")}` as FieldPath<ZoneEditorFormValues>, {
+          type: "manual",
+          message: issue.message,
+        })
+      }
+      return
+    }
+
+    const gapIssues = findShippingLadderGaps(parsedLadder.data)
+    if (gapIssues.length > 0) {
+      // D6 is a cross-row invariant, not one field's fault -- one toast per
+      // issue (same "several problems, several toasts" shape processOrder
+      // already uses in app/checkout/page.tsx for stock errors) so fixing the
+      // first one doesn't just uncover a second the owner was never shown.
+      gapIssues.forEach((issue) => toast.error(issue.message))
+      return
+    }
+
+    const result = await saveShippingZoneAction(
+      { name: values.name, destinations: values.destinations, rateLadder: parsedLadder.data },
+      zoneId ?? undefined,
+    )
+
+    if (!result.success) {
+      toast.error(result.error || copy.saveErrorToast)
+      return
+    }
+
+    toast.success(copy.savedToast)
+    router.push(SHIPPING_ZONES_LIST_PATH)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{copy.formTitle}</CardTitle>
+        <CardDescription>{copy.formDescription}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={(event) => void handleSubmit(onSubmit)(event)} className="space-y-4">
+          <FormField id="zone-name" label={copy.nameLabel} error={errors.name?.message}>
+            {(field) => <Input {...field} placeholder={copy.namePlaceholder} {...register("name")} />}
+          </FormField>
+
+          <DestinationsField control={control} departments={departments} nameHints={nameHints} />
+          <FieldError message={errors.destinations?.message} />
+
+          <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" asChild>
+              <Link href={SHIPPING_ZONES_LIST_PATH}>{copy.cancelButton}</Link>
+            </Button>
+            <Button type="submit" disabled={isSubmitting} className="gap-2">
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              {isSubmitting ? copy.saving : copy.saveButton}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DestinationsField({
+  control,
+  departments,
+  nameHints,
+}: {
+  control: Control<ZoneEditorFormValues>
+  departments: Department[]
+  nameHints: Map<string, string>
+}) {
+  const { fields, append, remove } = useFieldArray({ control, name: "destinations" })
+  const [names, setNames] = useState(nameHints)
+  const [selectedDepartment, setSelectedDepartment] = useState("")
+  const [municipalities, setMunicipalities] = useState<Municipality[]>([])
+  const [loadingMunicipalities, setLoadingMunicipalities] = useState(false)
+  const [municipalityPickerOpen, setMunicipalityPickerOpen] = useState(false)
+
+  // Fetches, not a state mirror: the effect's only job is asking the server
+  // for the chosen department's municipios, so it stays an effect. Every
+  // setState the effect body itself would need synchronously (clearing the
+  // previous department's stale list, flagging the fetch as loading) instead
+  // happens in the SELECT handler below that causes it -- only the async
+  // .then/.finally callbacks reporting the fetch's own outcome set state
+  // from here, the "derive it from the event that caused it" shape React's
+  // own effect guidance asks for.
+  useEffect(() => {
+    if (!selectedDepartment) return
+
+    let active = true
+    listShippingMunicipalitiesAction(selectedDepartment)
+      .then((result) => {
+        if (active) setMunicipalities(result)
+      })
+      .catch((error) => console.error("[Shipping Zones] Error al cargar municipios:", error))
+      .finally(() => {
+        if (active) setLoadingMunicipalities(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [selectedDepartment])
+
+  function selectDepartment(departmentCode: string) {
+    setSelectedDepartment(departmentCode)
+    setMunicipalities([])
+    setLoadingMunicipalities(true)
+  }
+
+  // departmentName falls back to the `departments` prop directly instead of
+  // seeding it into `names` on every prop change: `names` only needs to hold
+  // hints the prop can't supply (a destination's name once picked, or an
+  // already-saved zone's own destinations).
+  function departmentName(departmentCode: string): string {
+    return (
+      names.get(nameHintKey("department", departmentCode)) ??
+      departments.find((department) => department.code === departmentCode)?.name ??
+      departmentCode
+    )
+  }
+
+  const existingKeys = new Set(fields.map(destinationKey))
+
+  function addWholeDepartment() {
+    if (!selectedDepartment || existingKeys.has(destinationKey({ departmentCode: selectedDepartment, municipalityCode: null }))) return
+    append({ departmentCode: selectedDepartment, municipalityCode: null })
+  }
+
+  function addMunicipality(municipality: Municipality) {
+    if (existingKeys.has(destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }))) return
+
+    setNames((current) => {
+      const next = new Map(current)
+      next.set(nameHintKey("department", municipality.departmentCode), municipality.departmentName)
+      next.set(nameHintKey("municipality", municipality.code), municipality.name)
+      return next
+    })
+    append({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code })
+    setMunicipalityPickerOpen(false)
+  }
+
+  return (
+    <div className="space-y-3">
+      <Label>{copy.destinationsLabel}</Label>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Select value={selectedDepartment} onValueChange={selectDepartment}>
+          <SelectTrigger className="w-full sm:w-64">
+            <SelectValue placeholder={copy.departmentPlaceholder} />
+          </SelectTrigger>
+          <SelectContent className="editor-chrome">
+            {departments.map((department) => (
+              <SelectItem key={department.code} value={department.code}>
+                {department.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button type="button" variant="outline" size="sm" disabled={!selectedDepartment} onClick={addWholeDepartment}>
+          {copy.addWholeDepartmentButton}
+        </Button>
+      </div>
+
+      {selectedDepartment ? (
+        <Popover open={municipalityPickerOpen} onOpenChange={setMunicipalityPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button type="button" variant="outline" size="sm" className="w-full justify-between sm:w-72">
+              {copy.addMunicipalityButton}
+              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="editor-chrome w-72 p-0">
+            <Command>
+              <CommandInput placeholder={copy.municipalitySearchPlaceholder} />
+              <CommandList>
+                <CommandEmpty>{loadingMunicipalities ? copy.loadingMunicipalities : copy.noMunicipalitiesFound}</CommandEmpty>
+                <CommandGroup>
+                  {municipalities.map((municipality) => {
+                    const alreadyAdded = existingKeys.has(
+                      destinationKey({ departmentCode: municipality.departmentCode, municipalityCode: municipality.code }),
+                    )
+                    return (
+                      <CommandItem
+                        key={municipality.id}
+                        value={municipality.name}
+                        disabled={alreadyAdded}
+                        onSelect={() => addMunicipality(municipality)}
+                      >
+                        <Check className={alreadyAdded ? "mr-2 h-4 w-4 opacity-100" : "mr-2 h-4 w-4 opacity-0"} />
+                        {municipality.name}
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        {fields.map((field, index) => {
+          const label = field.municipalityCode
+            ? names.get(nameHintKey("municipality", field.municipalityCode)) ?? field.municipalityCode
+            : `${copy.wholeDepartmentPrefix} ${departmentName(field.departmentCode)}`
+
+          return (
+            <Badge key={field.id} variant="secondary" className="gap-1.5 normal-case">
+              {label}
+              <button type="button" onClick={() => remove(index)} aria-label={copy.removeDestinationLabel}>
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/settings/shipping/components/zones-section.tsx
+++ b/app/admin/settings/shipping/components/zones-section.tsx
@@ -48,7 +48,9 @@ export function ShippingZonesSection({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between gap-3">
           <div>
-            <CardTitle className="text-base">{copy.sectionTitle}</CardTitle>
+            <CardTitle asChild className="text-base">
+              <h2>{copy.sectionTitle}</h2>
+            </CardTitle>
             <CardDescription>{copy.sectionDescription}</CardDescription>
           </div>
           <Button size="sm" className="shrink-0 gap-1.5" asChild>
@@ -185,7 +187,9 @@ function UnmatchedDestinationCard({ defaultValue }: { defaultValue: UnmatchedDes
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{copy.unmatchedDestinationTitle}</CardTitle>
+        <CardTitle asChild className="text-base">
+          <h2>{copy.unmatchedDestinationTitle}</h2>
+        </CardTitle>
         <CardDescription>{copy.unmatchedDestinationDescription}</CardDescription>
       </CardHeader>
       <CardContent>

--- a/app/admin/settings/shipping/page.tsx
+++ b/app/admin/settings/shipping/page.tsx
@@ -15,7 +15,7 @@ import {
   type ShippingContactPendingReason,
 } from "./components/shipping-contact-pending-notice"
 import { ShippingModeForm } from "./components/shipping-mode-form"
-import { ShippingZonesSection } from "./components/zone-editor"
+import { ShippingZonesSection } from "./components/zones-section"
 
 const copy = translations.es.shipping
 

--- a/app/admin/settings/shipping/page.tsx
+++ b/app/admin/settings/shipping/page.tsx
@@ -8,7 +8,7 @@ import { getStoreIdentityReadiness, type StoreIdentityReadiness } from "@/lib/st
 import { buildWhatsAppLink } from "@/lib/stores/whatsapp-contact"
 import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
 import { loadShippingSettings } from "@/lib/supabase/shipping-settings-api"
-import { findMissingWeightProducts, listShippingZones } from "@/lib/supabase/shipping-zones-api"
+import { listShippingZones } from "@/lib/supabase/shipping-zones-api"
 import { loadStoreIdentity } from "@/lib/supabase/store-identity-api"
 import {
   ShippingContactPendingNotice,
@@ -30,11 +30,10 @@ export default async function ShippingSettingsPage() {
   }
 
   const { supabase, storeId } = authorization
-  const [settings, identity, zones, missingWeightProducts] = await Promise.all([
+  const [settings, identity, zones] = await Promise.all([
     loadShippingSettings(supabase, storeId),
     loadStoreIdentity(supabase, storeId),
     listShippingZones(supabase, storeId),
-    findMissingWeightProducts(supabase, storeId),
   ])
   const readiness = getStoreIdentityReadiness(identity)
   const contactPendingReason = resolveContactPendingReason(settings.mode, readiness, identity.phone)
@@ -44,11 +43,7 @@ export default async function ShippingSettingsPage() {
       <AdminPageHeader title={copy.settingsTitle} subtitle={copy.settingsSubtitle} />
       {contactPendingReason && <ShippingContactPendingNotice reason={contactPendingReason} />}
       <ShippingModeForm defaultValues={{ mode: toSelectableShippingMode(settings.mode) }} />
-      <ShippingZonesSection
-        zones={zones}
-        missingWeightProducts={missingWeightProducts}
-        unmatchedDestinationAction={settings.unmatchedDestinationAction}
-      />
+      <ShippingZonesSection zones={zones} unmatchedDestinationAction={settings.unmatchedDestinationAction} />
     </AdminPageContainer>
   )
 }

--- a/app/admin/settings/shipping/page.tsx
+++ b/app/admin/settings/shipping/page.tsx
@@ -43,7 +43,11 @@ export default async function ShippingSettingsPage() {
       <AdminPageHeader title={copy.settingsTitle} subtitle={copy.settingsSubtitle} />
       {contactPendingReason && <ShippingContactPendingNotice reason={contactPendingReason} />}
       <ShippingModeForm defaultValues={{ mode: toSelectableShippingMode(settings.mode) }} />
-      <ShippingZonesSection zones={zones} unmatchedDestinationAction={settings.unmatchedDestinationAction} />
+      <ShippingZonesSection
+        mode={settings.mode}
+        zones={zones}
+        unmatchedDestinationAction={settings.unmatchedDestinationAction}
+      />
     </AdminPageContainer>
   )
 }

--- a/app/admin/settings/shipping/zones/[zoneId]/edit/page.tsx
+++ b/app/admin/settings/shipping/zones/[zoneId]/edit/page.tsx
@@ -6,6 +6,7 @@ import { translations } from "@/lib/i18n/translations"
 import { listDepartments } from "@/lib/shipping/locations-api"
 import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
 import {
+  findClaimedDestinations,
   findMissingWeightProducts,
   listShippingZones,
   type ShippingZoneRecord,
@@ -26,10 +27,11 @@ export default async function EditShippingZonePage({
   }
 
   const { supabase, storeId } = authorization
-  const [zone, departments, missingWeightProducts] = await Promise.all([
+  const [zone, departments, missingWeightProducts, claimedDestinations] = await Promise.all([
     findStoreZone(zoneId, supabase, storeId),
     listDepartments(supabase),
     findMissingWeightProducts(supabase, storeId),
+    findClaimedDestinations(supabase, storeId, zoneId),
   ])
 
   if (!zone) {
@@ -39,7 +41,13 @@ export default async function EditShippingZonePage({
   return (
     <AdminPageContainer maxWidth="4xl">
       <AdminPageHeader title={copy.editTitle} subtitle={copy.sectionDescription} />
-      <ZoneForm zoneId={zone.id} zone={zone} departments={departments} missingWeightProducts={missingWeightProducts} />
+      <ZoneForm
+        zoneId={zone.id}
+        zone={zone}
+        departments={departments}
+        missingWeightProducts={missingWeightProducts}
+        claimedDestinations={claimedDestinations}
+      />
     </AdminPageContainer>
   )
 }

--- a/app/admin/settings/shipping/zones/[zoneId]/edit/page.tsx
+++ b/app/admin/settings/shipping/zones/[zoneId]/edit/page.tsx
@@ -1,0 +1,54 @@
+import { notFound, redirect } from "next/navigation"
+
+import { AdminPageContainer } from "@/components/admin/page-container"
+import { AdminPageHeader } from "@/components/admin/page-header"
+import { translations } from "@/lib/i18n/translations"
+import { listDepartments } from "@/lib/shipping/locations-api"
+import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
+import {
+  findMissingWeightProducts,
+  listShippingZones,
+  type ShippingZoneRecord,
+} from "@/lib/supabase/shipping-zones-api"
+import { ZoneForm } from "../../../components/zone-form"
+
+const copy = translations.es.shipping.zones
+
+export default async function EditShippingZonePage({
+  params,
+}: {
+  params: Promise<{ zoneId: string }>
+}) {
+  const { zoneId } = await params
+  const authorization = await authorizeActiveStoreAdmin()
+  if ("error" in authorization) {
+    redirect("/")
+  }
+
+  const { supabase, storeId } = authorization
+  const [zone, departments, missingWeightProducts] = await Promise.all([
+    findStoreZone(zoneId, supabase, storeId),
+    listDepartments(supabase),
+    findMissingWeightProducts(supabase, storeId),
+  ])
+
+  if (!zone) {
+    notFound()
+  }
+
+  return (
+    <AdminPageContainer maxWidth="4xl">
+      <AdminPageHeader title={copy.editTitle} subtitle={copy.sectionDescription} />
+      <ZoneForm zoneId={zone.id} zone={zone} departments={departments} missingWeightProducts={missingWeightProducts} />
+    </AdminPageContainer>
+  )
+}
+
+async function findStoreZone(
+  zoneId: string,
+  supabase: any,
+  storeId: string,
+): Promise<ShippingZoneRecord | null> {
+  const zones = await listShippingZones(supabase, storeId)
+  return zones.find((zone) => zone.id === zoneId) ?? null
+}

--- a/app/admin/settings/shipping/zones/new/page.tsx
+++ b/app/admin/settings/shipping/zones/new/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation"
+
+import { AdminPageContainer } from "@/components/admin/page-container"
+import { AdminPageHeader } from "@/components/admin/page-header"
+import { translations } from "@/lib/i18n/translations"
+import { listDepartments } from "@/lib/shipping/locations-api"
+import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
+import { findMissingWeightProducts } from "@/lib/supabase/shipping-zones-api"
+import { ZoneForm } from "../../components/zone-form"
+
+const copy = translations.es.shipping.zones
+
+export default async function CreateShippingZonePage() {
+  const authorization = await authorizeActiveStoreAdmin()
+  if ("error" in authorization) {
+    redirect("/")
+  }
+
+  const { supabase, storeId } = authorization
+  const [departments, missingWeightProducts] = await Promise.all([
+    listDepartments(supabase),
+    findMissingWeightProducts(supabase, storeId),
+  ])
+
+  return (
+    <AdminPageContainer maxWidth="4xl">
+      <AdminPageHeader title={copy.createTitle} subtitle={copy.sectionDescription} />
+      <ZoneForm zoneId={null} zone={null} departments={departments} missingWeightProducts={missingWeightProducts} />
+    </AdminPageContainer>
+  )
+}

--- a/app/admin/settings/shipping/zones/new/page.tsx
+++ b/app/admin/settings/shipping/zones/new/page.tsx
@@ -5,7 +5,7 @@ import { AdminPageHeader } from "@/components/admin/page-header"
 import { translations } from "@/lib/i18n/translations"
 import { listDepartments } from "@/lib/shipping/locations-api"
 import { authorizeActiveStoreAdmin } from "@/lib/supabase/active-store"
-import { findMissingWeightProducts } from "@/lib/supabase/shipping-zones-api"
+import { findClaimedDestinations, findMissingWeightProducts } from "@/lib/supabase/shipping-zones-api"
 import { ZoneForm } from "../../components/zone-form"
 
 const copy = translations.es.shipping.zones
@@ -17,15 +17,22 @@ export default async function CreateShippingZonePage() {
   }
 
   const { supabase, storeId } = authorization
-  const [departments, missingWeightProducts] = await Promise.all([
+  const [departments, missingWeightProducts, claimedDestinations] = await Promise.all([
     listDepartments(supabase),
     findMissingWeightProducts(supabase, storeId),
+    findClaimedDestinations(supabase, storeId),
   ])
 
   return (
     <AdminPageContainer maxWidth="4xl">
       <AdminPageHeader title={copy.createTitle} subtitle={copy.sectionDescription} />
-      <ZoneForm zoneId={null} zone={null} departments={departments} missingWeightProducts={missingWeightProducts} />
+      <ZoneForm
+        zoneId={null}
+        zone={null}
+        departments={departments}
+        missingWeightProducts={missingWeightProducts}
+        claimedDestinations={claimedDestinations}
+      />
     </AdminPageContainer>
   )
 }

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -9,6 +9,8 @@ import { Button } from "@/components/ui/button"
 import { Loader } from "@/components/ui/loader"
 import { ArrowLeft, ShoppingBag } from "lucide-react"
 import { buildLocalCartSummary } from "@/lib/cart/cart-summary"
+import { clearGuestCheckoutDraft } from "@/lib/checkout/guest-draft"
+import { formatAddressLine } from "@/lib/orders/order-format"
 import { formatPrice } from "@/lib/commerce/utils"
 import { useLanguage } from "@/contexts/language-context"
 import { toast } from "sonner"
@@ -260,6 +262,8 @@ export default function CheckoutPage() {
 
     toast.success(`Pedido creado: ${order.orderNumber}`)
 
+    clearGuestCheckoutDraft()
+
     // Redirigir a la página de éxito
     router.push(
       `/checkout/success?order=${encodeURIComponent(order.orderNumber)}&email=${encodeURIComponent(data.email)}`,
@@ -396,10 +400,10 @@ export default function CheckoutPage() {
                   <div className="p-4 bg-muted rounded-lg">
                     <p className="font-semibold mb-2">Dirección de Envío:</p>
                     <p className="text-sm">
-                      {customerData.address}, {customerData.city}
+                      {formatAddressLine([customerData.address, customerData.city])}
                     </p>
                     <p className="text-sm">
-                      {customerData.postalCode}, {customerData.country}
+                      {formatAddressLine([customerData.postalCode, customerData.country])}
                     </p>
                   </div>
                 </div>

--- a/app/checkout/success/checkout-success-client.tsx
+++ b/app/checkout/success/checkout-success-client.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { CheckCircle2, Home } from "lucide-react";
+import { formatAddressLine } from "@/lib/orders/order-format";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -205,11 +206,9 @@ export function CheckoutSuccessClient({
               </div>
               <div>
                 <h3 className="font-semibold mb-2">Dirección de Envío:</h3>
+                <p className="text-sm">{formatAddressLine([customerData.address, customerData.city])}</p>
                 <p className="text-sm">
-                  {customerData.address}, {customerData.city}
-                </p>
-                <p className="text-sm">
-                  {customerData.postalCode}, {customerData.country}
+                  {formatAddressLine([customerData.postalCode, customerData.country])}
                 </p>
               </div>
               {customerData.notes && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -267,6 +267,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     background-color: var(--background);
     color: var(--foreground);

--- a/app/globals.css
+++ b/app/globals.css
@@ -319,4 +319,9 @@
     min-height: 36px;
     min-width: 36px;
   }
+
+  [data-slot="checkbox"] {
+    min-height: unset;
+    min-width: unset;
+  }
 }

--- a/components/admin/shell/admin-sidebar.tsx
+++ b/components/admin/shell/admin-sidebar.tsx
@@ -138,38 +138,30 @@ function AdminNavGroupItem({
   onNavigate: () => void
 }) {
   const activeChildHref = longestMatchingHref(pathname, item.children)
-  const open = activeChildHref !== null
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton
-        asChild
-        isActive={open}
-        tooltip={item.label}
-        aria-expanded={open}
-      >
+      <SidebarMenuButton asChild isActive={activeChildHref !== null} tooltip={item.label}>
         <Link href={item.href} onClick={onNavigate}>
           <item.icon aria-hidden="true" />
           <span className="truncate">{item.label}</span>
         </Link>
       </SidebarMenuButton>
-      {open ? (
-        <SidebarMenuSub>
-          {item.children.map((child) => (
-            <SidebarMenuSubItem key={child.href}>
-              <SidebarMenuSubButton asChild isActive={child.href === activeChildHref}>
-                <Link
-                  href={child.href}
-                  onClick={onNavigate}
-                  aria-current={child.href === activeChildHref ? "page" : undefined}
-                >
-                  <span>{child.label}</span>
-                </Link>
-              </SidebarMenuSubButton>
-            </SidebarMenuSubItem>
-          ))}
-        </SidebarMenuSub>
-      ) : null}
+      <SidebarMenuSub>
+        {item.children.map((child) => (
+          <SidebarMenuSubItem key={child.href}>
+            <SidebarMenuSubButton asChild isActive={child.href === activeChildHref}>
+              <Link
+                href={child.href}
+                onClick={onNavigate}
+                aria-current={child.href === activeChildHref ? "page" : undefined}
+              >
+                <span>{child.label}</span>
+              </Link>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+        ))}
+      </SidebarMenuSub>
     </SidebarMenuItem>
   )
 }

--- a/components/admin/shell/admin-sidebar.tsx
+++ b/components/admin/shell/admin-sidebar.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react"
 
 import { isRouteOrDescendant } from "@/lib/admin/routes"
+import { translations } from "@/lib/i18n/translations"
 import {
   Sidebar,
   SidebarContent,
@@ -24,14 +25,25 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarPinToggle,
   useSidebar,
 } from "@/components/ui/sidebar"
+
+const copy = translations.es.admin
+
+interface AdminNavChild {
+  label: string
+  href: string
+}
 
 interface AdminNavItem {
   label: string
   href: string
   icon: LucideIcon
+  children?: AdminNavChild[]
 }
 
 // Solo secciones de la tienda activa: la consola de plataforma (Plan 12) vive
@@ -45,7 +57,15 @@ const NAV_ITEMS: AdminNavItem[] = [
   { label: "Chatbot", href: "/admin/chatbot", icon: Bot },
   { label: "Popup", href: "/admin/home-discount-popup", icon: Megaphone },
   { label: "Editor de tema", href: "/admin/theme", icon: Palette },
-  { label: "Configuración", href: "/admin/settings", icon: Settings },
+  {
+    label: "Configuración",
+    href: "/admin/settings",
+    icon: Settings,
+    children: [
+      { label: copy.settingsNav.general, href: "/admin/settings" },
+      { label: copy.settingsNav.shipping, href: "/admin/settings/shipping" },
+    ],
+  },
 ]
 
 export function AdminSidebar() {
@@ -69,7 +89,7 @@ export function AdminSidebar() {
 function AdminNavList() {
   const pathname = usePathname() ?? ""
   const { isMobile, setOpenMobile } = useSidebar()
-  const activeHref = activeNavHref(pathname, NAV_ITEMS)
+  const activeHref = longestMatchingHref(pathname, NAV_ITEMS)
 
   const closeDrawerOnMobile = () => {
     if (isMobile) setOpenMobile(false)
@@ -77,21 +97,80 @@ function AdminNavList() {
 
   return (
     <SidebarMenu>
-      {NAV_ITEMS.map(({ label, href, icon: Icon }) => (
-        <SidebarMenuItem key={href}>
-          <SidebarMenuButton asChild isActive={activeHref === href} tooltip={label}>
-            <Link
-              href={href}
-              onClick={closeDrawerOnMobile}
-              aria-current={activeHref === href ? "page" : undefined}
-            >
-              <Icon aria-hidden="true" />
-              <span>{label}</span>
-            </Link>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      ))}
+      {NAV_ITEMS.map((item) =>
+        hasChildren(item) ? (
+          <AdminNavGroupItem
+            key={item.href}
+            item={item}
+            pathname={pathname}
+            onNavigate={closeDrawerOnMobile}
+          />
+        ) : (
+          <SidebarMenuItem key={item.href}>
+            <SidebarMenuButton asChild isActive={activeHref === item.href} tooltip={item.label}>
+              <Link
+                href={item.href}
+                onClick={closeDrawerOnMobile}
+                aria-current={activeHref === item.href ? "page" : undefined}
+              >
+                <item.icon aria-hidden="true" />
+                <span>{item.label}</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ),
+      )}
     </SidebarMenu>
+  )
+}
+
+function hasChildren(item: AdminNavItem): item is AdminNavItem & { children: AdminNavChild[] } {
+  return item.children !== undefined
+}
+
+function AdminNavGroupItem({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: AdminNavItem & { children: AdminNavChild[] }
+  pathname: string
+  onNavigate: () => void
+}) {
+  const activeChildHref = longestMatchingHref(pathname, item.children)
+  const open = activeChildHref !== null
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        asChild
+        isActive={open}
+        tooltip={item.label}
+        aria-expanded={open}
+      >
+        <Link href={item.href} onClick={onNavigate}>
+          <item.icon aria-hidden="true" />
+          <span className="truncate">{item.label}</span>
+        </Link>
+      </SidebarMenuButton>
+      {open ? (
+        <SidebarMenuSub>
+          {item.children.map((child) => (
+            <SidebarMenuSubItem key={child.href}>
+              <SidebarMenuSubButton asChild isActive={child.href === activeChildHref}>
+                <Link
+                  href={child.href}
+                  onClick={onNavigate}
+                  aria-current={child.href === activeChildHref ? "page" : undefined}
+                >
+                  <span>{child.label}</span>
+                </Link>
+              </SidebarMenuSubButton>
+            </SidebarMenuSubItem>
+          ))}
+        </SidebarMenuSub>
+      ) : null}
+    </SidebarMenuItem>
   )
 }
 
@@ -99,7 +178,7 @@ function AdminNavList() {
 // path: the nav holds shortcuts, not the hierarchy, so a nested route without an
 // entry of its own (/admin/products/combos) highlights its section instead of
 // every ancestor in the nav.
-function activeNavHref(pathname: string, items: AdminNavItem[]): string | null {
+function longestMatchingHref(pathname: string, items: { href: string }[]): string | null {
   return items
     .filter((item) => isRouteOrDescendant(pathname, item.href))
     .sort((a, b) => b.href.length - a.href.length)[0]?.href ?? null

--- a/components/cart/add-to-cart.tsx
+++ b/components/cart/add-to-cart.tsx
@@ -28,6 +28,14 @@ interface AddToCartButtonProps extends ButtonProps {
   className?: string;
 }
 
+type ItemContext = {
+  productId: string;
+  isCombo: boolean;
+  isRealVariant: boolean;
+};
+
+const CART_QUANTITY_CEILING = 99;
+
 const getBaseProductVariant = (product: Product): ProductVariant => {
   return {
     id: product.id,
@@ -53,6 +61,7 @@ export function AddToCartButton({
   const localCart = useLocalCart();
   const [isLoading, startTransition] = useTransition();
   const [showQuantityModal, setShowQuantityModal] = useState(false);
+  const [selectableQuantity, setSelectableQuantity] = useState<number | null>(null);
 
   // Resolve variant locally only for variantless products (purely synchronous)
   const resolvedVariant = useMemo(() => {
@@ -78,98 +87,117 @@ export function AddToCartButton({
     return 'default';
   };
 
+  const resolveItemContext = (variantId: string): ItemContext => {
+    const productId = product.id;
+    const isCombo = isComboProduct(product);
+    const isRealVariant =
+      !isCombo && variantId !== productId && product.variants.length > 1;
+    return { productId, isCombo, isRealVariant };
+  };
+
+  const readStock = async (
+    variantId: string,
+    { productId, isCombo, isRealVariant }: ItemContext,
+  ): Promise<number | null> => {
+    if (isCombo) {
+      const { getComboStock } = await import('@/lib/supabase/combos-api');
+      return getComboStock(productId);
+    }
+
+    const { getProductStock, getVariantStock } = await import('@/lib/supabase/products-read');
+    return isRealVariant ? getVariantStock(variantId) : getProductStock(productId);
+  };
+
+  const cartQuantityFor = (variantId: string) =>
+    localCart.items.find((item) => item.id === variantId)?.quantity ?? 0;
+
+  const notifySoldOut = async () => {
+    const { toast } = await import('sonner');
+    toast.error(`${product.title} está agotado`, { duration: 4000 });
+  };
+
+  const notifyCartAlreadyHoldsAll = async () => {
+    const { toast } = await import('sonner');
+    toast.error(`Ya tienes la cantidad máxima disponible de ${product.title} en tu carrito`, {
+      duration: 4000,
+    });
+  };
+
+  const openQuantityModal = (variantId: string) => {
+    setSelectableQuantity(null);
+    setShowQuantityModal(true);
+
+    void readStock(variantId, resolveItemContext(variantId))
+      .then(async (stock) => {
+        if (stock === null) return;
+
+        const remaining = stock - cartQuantityFor(variantId);
+        if (remaining > 0) {
+          setSelectableQuantity(remaining);
+          return;
+        }
+
+        setShowQuantityModal(false);
+        await (stock === 0 ? notifySoldOut() : notifyCartAlreadyHoldsAll());
+      })
+      .catch((error: unknown) => {
+        console.error('[Cart] Error al resolver el stock disponible:', error);
+      });
+  };
+
   const handleAddToCart = (quantity: number) => {
     if (!resolvedVariant) return;
 
     startTransition(async () => {
       const variantId = resolvedVariant.id;
-      const productId = product.id;
-      const isCombo = isComboProduct(product);
+      const itemContext = resolveItemContext(variantId);
+      const { isCombo, isRealVariant } = itemContext;
 
-      // Determinar si es una variante o el producto base
-      // Si variantId !== productId, es una variante real
-      // Si variantId === productId, es el producto base o una variante por defecto
-      const isRealVariant = !isCombo && variantId !== productId && product.variants && product.variants.length > 1;
-
-      // Validar stock antes de agregar al carrito
       try {
-        const { getProductStock, getVariantStock } = await import('@/lib/supabase/products-read');
+        const stock = await readStock(variantId, itemContext);
 
-        let stock: number | null = null;
-
-        if (isCombo) {
-          const { getComboStock } = await import('@/lib/supabase/combos-api');
-          stock = await getComboStock(productId);
-        }
-        // Si es una variante real, obtener stock de la variante
-        else if (isRealVariant) {
-          stock = await getVariantStock(variantId);
-        } else {
-          // Es el producto base o variante por defecto, obtener stock del producto
-          stock = await getProductStock(productId);
-        }
-
-        // Si el producto rastrea inventario y hay stock limitado
         if (stock !== null) {
-          // Obtener cantidad actual en el carrito para este item
-          const existingItem = localCart.items.find(item => item.id === variantId);
-          const currentCartQuantity = existingItem?.quantity || 0;
-          const totalRequestedQuantity = currentCartQuantity + quantity;
-
-          // Validar que haya suficiente stock
           if (stock === 0) {
-            const { toast } = await import('sonner');
-            toast.error(`${product.title} está agotado`, {
-              duration: 4000,
-            });
+            await notifySoldOut();
             return;
           }
 
-          if (totalRequestedQuantity > stock) {
-            const availableQuantity = stock - currentCartQuantity;
+          const remaining = stock - cartQuantityFor(variantId);
+
+          if (remaining <= 0) {
+            await notifyCartAlreadyHoldsAll();
+            return;
+          }
+
+          if (quantity > remaining) {
             const { toast } = await import('sonner');
-
-            if (availableQuantity <= 0) {
-              toast.error(`Ya tienes la cantidad máxima disponible de ${product.title} en tu carrito`, {
-                duration: 4000,
-              });
-            } else {
-              toast.warning(`Solo hay ${availableQuantity} unidad${availableQuantity !== 1 ? 'es' : ''} disponible${availableQuantity !== 1 ? 's' : ''} de ${product.title}. Se agregará ${availableQuantity} ${availableQuantity === 1 ? 'unidad' : 'unidades'}`, {
-                duration: 4000,
-              });
-              // Ajustar cantidad al stock disponible
-              quantity = availableQuantity;
-            }
-
-            if (availableQuantity <= 0) {
-              return;
-            }
+            toast.warning(`Solo hay ${remaining} unidad${remaining !== 1 ? 'es' : ''} disponible${remaining !== 1 ? 's' : ''} de ${product.title}. Se agregará ${remaining} ${remaining === 1 ? 'unidad' : 'unidades'}`, {
+              duration: 4000,
+            });
+            quantity = remaining;
           }
         }
       } catch (error: any) {
-        // Si falla la validación, registrar error pero permitir agregar (no bloquear)
         console.error('[Cart] Error al validar stock:', error);
       }
 
       const variantPrice = resolvedVariant.price.amount;
       const formattedPrice = formatPrice(variantPrice, resolvedVariant.price.currencyCode);
 
-      // Obtener precio original si existe (compareAtPrice)
       let originalPrice: string | undefined;
       let salePrice: string | undefined;
 
       if (product.compareAtPrice && parseFloat(product.compareAtPrice.amount) > parseFloat(variantPrice)) {
-        // Hay descuento
         originalPrice = formatPrice(product.compareAtPrice.amount, product.compareAtPrice.currencyCode);
-        salePrice = formattedPrice; // Precio con descuento
+        salePrice = formattedPrice;
       }
 
       localCart.addToCart({
         id: resolvedVariant.id,
         name: product.title,
-        price: formattedPrice, // Precio base
+        price: formattedPrice,
         image: product.featuredImage?.url || product.images?.[0]?.url || '/placeholder.jpg',
-        category: product.categoryId,
+        category: product.categoryName,
         originalPrice: originalPrice,
         salePrice: salePrice,
         productId: isCombo ? undefined : product.id,
@@ -182,7 +210,6 @@ export function AddToCartButton({
         currencyCode: resolvedVariant.price.currencyCode,
       }, quantity);
 
-      // Mostrar notificación de éxito
       const { toast } = await import('sonner');
       toast.success(`${quantity} ${quantity === 1 ? 'unidad' : 'unidades'} de ${product.title} agregada${quantity === 1 ? '' : 's'} al carrito`, {
         duration: 3000,
@@ -196,7 +223,7 @@ export function AddToCartButton({
         onSubmit={e => {
           e.preventDefault();
           if (resolvedVariant) {
-            setShowQuantityModal(true);
+            openQuantityModal(resolvedVariant.id);
           }
         }}
         className={className}
@@ -249,7 +276,7 @@ export function AddToCartButton({
       onConfirm={handleAddToCart}
       productName={product.title}
       productImage={product.featuredImage?.url || product.images?.[0]?.url}
-      maxQuantity={99}
+      maxQuantity={Math.min(selectableQuantity ?? CART_QUANTITY_CEILING, CART_QUANTITY_CEILING)}
       initialQuantity={1}
     />
     </>

--- a/components/checkout/guest-checkout-form.tsx
+++ b/components/checkout/guest-checkout-form.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useForm, type UseFormReturn } from "react-hook-form"
+import { useEffect } from "react"
+import { useForm, useWatch, type UseFormReturn } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { toast } from "sonner"
 
@@ -11,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { FormField } from "@/components/ui/form-field"
 import { Input } from "@/components/ui/input"
 import { enabledPaymentMethodIds } from "@/lib/checkout/payment-methods"
+import { readGuestCheckoutDraft, saveGuestCheckoutDraft } from "@/lib/checkout/guest-draft"
 import { guestCheckoutFormSchema, type GuestCheckoutFormValues } from "@/lib/checkout/schemas"
 import type { ShippingDestination } from "@/lib/shipping/schemas"
 
@@ -78,6 +80,24 @@ export function GuestCheckoutForm({
     resolver: zodResolver(guestCheckoutFormSchema),
     defaultValues: DEFAULT_VALUES,
   })
+
+  const { reset, control } = form
+  const watchedValues = useWatch({ control })
+  const { isDirty } = form.formState
+
+  useEffect(() => {
+    const draft = readGuestCheckoutDraft()
+    if (draft) {
+      reset({ ...DEFAULT_VALUES, ...draft })
+    }
+  }, [reset])
+
+  useEffect(() => {
+    if (!isDirty) {
+      return
+    }
+    saveGuestCheckoutDraft(watchedValues as Partial<GuestCheckoutFormValues>)
+  }, [watchedValues, isDirty])
 
   const submitValidatedForm = (values: GuestCheckoutFormValues) => {
     onComplete({

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -450,7 +450,7 @@ export function Header() {
               setShowSuggestions(true)
             }
           }}
-          className="pl-10 lg:pl-14 pr-4 h-9 lg:h-10 rounded-full w-full font-inter font-medium text-sm lg:text-base border"
+          className="pl-10 lg:pl-14 pr-4 h-9 lg:h-10 rounded-full w-full font-inter font-medium text-sm lg:text-base border [&::-webkit-search-cancel-button]:appearance-none"
           style={{
             backgroundColor: header.searchBgColor || "var(--muted)",
             borderColor: header.searchBorderColor || "var(--border)",
@@ -521,6 +521,70 @@ export function Header() {
     </Button>
   )
 
+  const handleLogout = async () => {
+    const wasOnAdminPage = pathname === '/admin' || pathname === '/dashboard'
+
+    await logout()
+
+    if (isAdmin && wasOnAdminPage) {
+      router.push('/')
+    } else {
+      router.refresh()
+    }
+
+    toast.success(t.header.sessionClosed, {
+      description: t.header.sessionClosedDescription,
+      duration: 3000,
+    })
+  }
+
+  const renderAccountMenuContent = () => (
+    <DropdownMenuContent align="end" style={{ backgroundColor: "var(--background)", borderColor: "var(--border)" }}>
+      <DropdownMenuLabel style={{ color: "var(--foreground)" }}>
+        {isAdmin
+          ? "Administrador"
+          : user?.first_name && user?.last_name
+            ? `${user.first_name} ${user.last_name}`
+            : user?.email || "Usuario"}
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
+      <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
+        <Link href="/auth/cuenta">
+          <User className="mr-2 h-4 w-4" />
+          {t.nav.account}
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
+        <Link href="/orders">
+          <Package className="mr-2 h-4 w-4" />
+          {t.nav.orders}
+        </Link>
+      </DropdownMenuItem>
+      {isAdmin && (
+        <>
+          <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
+          <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
+            <Link href="/dashboard">
+              <LayoutDashboard className="mr-2 h-4 w-4" />
+              {t.nav.dashboard}
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
+            <Link href="/admin">
+              <Edit className="mr-2 h-4 w-4" />
+              {t.admin.pageEditor}
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
+        </>
+      )}
+      <DropdownMenuItem onClick={handleLogout} style={{ color: "var(--foreground)" }}>
+        <LogOut className="mr-2 h-4 w-4" />
+        {t.auth.logout}
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  )
+
   // Iconos de acción (cuenta, wishlist, carrito), compartidos por las 3 variantes
   const renderActionIcons = () => (
     <>
@@ -545,66 +609,7 @@ export function Header() {
               </span>
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" style={{ backgroundColor: "var(--background)", borderColor: "var(--border)" }}>
-            <DropdownMenuLabel style={{ color: "var(--foreground)" }}>
-              {isAdmin
-                ? "Administrador"
-                : user?.first_name && user?.last_name
-                  ? `${user.first_name} ${user.last_name}`
-                  : user?.email || "Usuario"}
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-            <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-              <Link href="/auth/cuenta">
-                <User className="mr-2 h-4 w-4" />
-                {t.nav.account}
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-              <Link href="/orders">
-                <Package className="mr-2 h-4 w-4" />
-                {t.nav.orders}
-              </Link>
-            </DropdownMenuItem>
-            {isAdmin && (
-              <>
-                <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-                <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                  <Link href="/dashboard">
-                    <LayoutDashboard className="mr-2 h-4 w-4" />
-                    {t.nav.dashboard}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                  <Link href="/admin">
-                    <Edit className="mr-2 h-4 w-4" />
-                    {t.admin.pageEditor}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-              </>
-            )}
-            <DropdownMenuItem
-              onClick={async () => {
-                const wasOnAdminPage = pathname === '/admin' || pathname === '/dashboard'
-
-                await logout()
-
-                if (isAdmin && wasOnAdminPage) {
-                  router.push('/')
-                }
-
-                toast.success(t.header.sessionClosed, {
-                  description: t.header.sessionClosedDescription,
-                  duration: 3000,
-                })
-              }}
-              style={{ color: "var(--foreground)" }}
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              {t.auth.logout}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
+          {renderAccountMenuContent()}
         </DropdownMenu>
       ) : (
         <Button
@@ -877,66 +882,7 @@ export function Header() {
                       <User className="h-4 w-4" style={{ color: header.loginButtonColor || "var(--foreground)" }} />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" style={{ backgroundColor: "var(--background)", borderColor: "var(--border)" }}>
-                    <DropdownMenuLabel style={{ color: "var(--foreground)" }}>
-                      {isAdmin
-                        ? "Administrador"
-                        : user?.first_name && user?.last_name 
-                          ? `${user.first_name} ${user.last_name}`
-                          : user?.email || "Usuario"}
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-                    <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                      <Link href="/auth/cuenta">
-                        <User className="mr-2 h-4 w-4" />
-                        {t.nav.account}
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                      <Link href="/orders">
-                        <Package className="mr-2 h-4 w-4" />
-                        {t.nav.orders}
-                      </Link>
-                    </DropdownMenuItem>
-                    {isAdmin && (
-                      <>
-                        <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-                        <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                          <Link href="/dashboard">
-                            <LayoutDashboard className="mr-2 h-4 w-4" />
-                            {t.nav.dashboard}
-                          </Link>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem asChild style={{ color: "var(--foreground)" }}>
-                          <Link href="/admin">
-                            <Edit className="mr-2 h-4 w-4" />
-                            {t.admin.pageEditor}
-                          </Link>
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator style={{ backgroundColor: "var(--border)" }} />
-                      </>
-                    )}
-                    <DropdownMenuItem
-                      onClick={async () => {
-                        const wasOnAdminPage = pathname === '/admin' || pathname === '/dashboard'
-
-                        await logout()
-
-                        if (isAdmin && wasOnAdminPage) {
-                          router.push('/')
-                        }
-
-                        toast.success("Sesión cerrada", {
-                          description: "Has cerrado sesión exitosamente",
-                          duration: 3000,
-                        })
-                      }}
-                      style={{ color: "var(--foreground)" }}
-                    >
-                      <LogOut className="mr-2 h-4 w-4" />
-                      {t.auth.logout}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
+                  {renderAccountMenuContent()}
                 </DropdownMenu>
               ) : (
                 <Button
@@ -1006,7 +952,7 @@ export function Header() {
                     setShowSuggestions(true)
                   }
                 }}
-                className="pl-10 pr-10 h-10 rounded-full w-full text-sm border"
+                className="pl-10 pr-10 h-10 rounded-full w-full text-sm border [&::-webkit-search-cancel-button]:appearance-none"
                 style={{
                   backgroundColor: header.searchBgColor || "var(--muted)",
                   borderColor: header.searchBorderColor || "var(--border)",
@@ -1048,7 +994,7 @@ export function Header() {
       {/* Menú lateral */}
       <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
         <SheetContent
-          side="left"
+          side="right"
           className="w-[300px] sm:w-[400px] p-0 flex flex-col"
           style={{ backgroundColor: "var(--background)" }}
         >

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted-foreground placeholder:opacity-60 selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className,

--- a/lib/admin/routes.ts
+++ b/lib/admin/routes.ts
@@ -30,6 +30,8 @@ const ADMIN_ROUTES: Record<string, AdminRoute> = {
   "/admin/home-discount-popup": { kind: "static", label: "Popup" },
   "/admin/settings": { kind: "static", label: "Configuración" },
   "/admin/settings/shipping": { kind: "static", label: "Envío" },
+  "/admin/settings/shipping/zones/new": { kind: "static", label: "Crear" },
+  [`/admin/settings/shipping/zones/${DYNAMIC_SEGMENT}/edit`]: { kind: "static", label: "Editar" },
 }
 
 const DYNAMIC_ROUTE_PATTERNS = Object.keys(ADMIN_ROUTES).filter((pattern) =>

--- a/lib/checkout/guest-draft.ts
+++ b/lib/checkout/guest-draft.ts
@@ -1,0 +1,53 @@
+import { guestCheckoutFormSchema, type GuestCheckoutFormValues } from "@/lib/checkout/schemas";
+
+const GUEST_CHECKOUT_DRAFT_STORAGE_KEY = "osoria_checkout_guest_draft";
+
+/**
+ * Reads the guest checkout draft saved on this browser.
+ *
+ * @returns the fields written so far, or null when there is no readable draft.
+ *   A draft is always partial -- it is written while the form is still being
+ *   filled -- so it is validated field by field, never against the full schema.
+ */
+export function readGuestCheckoutDraft(): Partial<GuestCheckoutFormValues> | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(GUEST_CHECKOUT_DRAFT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = guestCheckoutFormSchema.partial().safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch (error) {
+    console.warn("[Checkout] No se pudo leer el borrador del checkout:", error);
+    return null;
+  }
+}
+
+export function saveGuestCheckoutDraft(values: Partial<GuestCheckoutFormValues>): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(GUEST_CHECKOUT_DRAFT_STORAGE_KEY, JSON.stringify(values));
+  } catch (error) {
+    console.warn("[Checkout] No se pudo guardar el borrador del checkout:", error);
+  }
+}
+
+export function clearGuestCheckoutDraft(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(GUEST_CHECKOUT_DRAFT_STORAGE_KEY);
+  } catch (error) {
+    console.warn("[Checkout] No se pudo borrar el borrador del checkout:", error);
+  }
+}

--- a/lib/commerce/types.ts
+++ b/lib/commerce/types.ts
@@ -20,6 +20,7 @@ export type Product = {
   productKind?: 'product' | 'combo';
   comboDetails?: ComboCatalogDetails;
   categoryId?: string;
+  categoryName?: string;
   description: string;
   descriptionHtml: string;
   featuredImage: Image;

--- a/lib/home-discount-popup.ts
+++ b/lib/home-discount-popup.ts
@@ -200,6 +200,9 @@ export function normalizeHomeDiscountPopupConfig(
   };
 }
 
+const MISSING_REDIRECT_CTA_URL_MESSAGE =
+  "El CTA de redirección necesita una URL http(s) válida.";
+const MISSING_COPY_COUPON_MESSAGE = "El CTA de copiar cupón necesita un código.";
 const INVALID_DELAY_SECONDS_MESSAGE = `El delay debe estar entre ${MIN_DELAY_SECONDS} y ${MAX_DELAY_SECONDS} segundos`;
 const INVALID_FREQUENCY_HOURS_MESSAGE = `La frecuencia debe estar entre ${MIN_FREQUENCY_HOURS} y ${MAX_FREQUENCY_HOURS} horas`;
 const INVALID_VISIBLE_DURATION_MESSAGE = `La duración visible debe estar entre ${MIN_VISIBLE_DURATION_SECONDS} y ${MAX_VISIBLE_DURATION_SECONDS} segundos`;
@@ -237,7 +240,24 @@ export const homeDiscountPopupFormSchema = z.object({
       INVALID_VISIBLE_DURATION_MESSAGE,
     ),
   ctaMode: z.enum(["redirect", "copy_coupon"]),
-});
+})
+  .superRefine((values, ctx) => {
+    if (values.ctaMode === "redirect" && !sanitizePublicUrl(values.ctaUrl)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["ctaUrl"],
+        message: MISSING_REDIRECT_CTA_URL_MESSAGE,
+      });
+    }
+
+    if (values.ctaMode === "copy_coupon" && !values.coupon.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["coupon"],
+        message: MISSING_COPY_COUPON_MESSAGE,
+      });
+    }
+  });
 
 export type HomeDiscountPopupFormValues = z.infer<typeof homeDiscountPopupFormSchema>;
 

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -199,14 +199,17 @@ export interface Translations {
       nameLabel: string
       namePlaceholder: string
       destinationsLabel: string
-      departmentPlaceholder: string
-      addWholeDepartmentButton: string
-      addMunicipalityButton: string
+      selectAllDepartmentsButton: string
+      clearDestinationsButton: string
+      selectedDestinationsCountLabel: string
+      selectedMunicipalitiesCountLabel: string
+      showMunicipalitiesButton: string
+      hideMunicipalitiesButton: string
+      claimedByPrefix: string
       municipalitySearchPlaceholder: string
       loadingMunicipalities: string
       noMunicipalitiesFound: string
       wholeDepartmentPrefix: string
-      removeDestinationLabel: string
       destinationsColumn: string
       basisColumn: string
       actionsColumn: string
@@ -661,14 +664,17 @@ export const translations: Record<Language, Translations> = {
         nameLabel: 'Nombre de la zona',
         namePlaceholder: 'Ej. Eje Cafetero',
         destinationsLabel: 'Destinos',
-        departmentPlaceholder: 'Selecciona un departamento',
-        addWholeDepartmentButton: 'Agregar departamento completo',
-        addMunicipalityButton: 'Agregar municipio…',
+        selectAllDepartmentsButton: 'Seleccionar todos',
+        clearDestinationsButton: 'Limpiar',
+        selectedDestinationsCountLabel: 'destinos seleccionados',
+        selectedMunicipalitiesCountLabel: 'municipios seleccionados',
+        showMunicipalitiesButton: 'Ver municipios',
+        hideMunicipalitiesButton: 'Ocultar municipios',
+        claimedByPrefix: 'Ya asignado a la zona',
         municipalitySearchPlaceholder: 'Buscar municipio…',
         loadingMunicipalities: 'Cargando municipios…',
         noMunicipalitiesFound: 'Sin resultados',
         wholeDepartmentPrefix: 'Todo:',
-        removeDestinationLabel: 'Quitar destino',
         destinationsColumn: 'Destinos',
         basisColumn: 'Tarifa',
         actionsColumn: 'Acciones',
@@ -1108,14 +1114,17 @@ export const translations: Record<Language, Translations> = {
         nameLabel: 'Zone name',
         namePlaceholder: 'E.g. Coffee Region',
         destinationsLabel: 'Destinations',
-        departmentPlaceholder: 'Select a department',
-        addWholeDepartmentButton: 'Add the whole department',
-        addMunicipalityButton: 'Add municipality…',
+        selectAllDepartmentsButton: 'Select all',
+        clearDestinationsButton: 'Clear',
+        selectedDestinationsCountLabel: 'destinations selected',
+        selectedMunicipalitiesCountLabel: 'municipalities selected',
+        showMunicipalitiesButton: 'Show municipalities',
+        hideMunicipalitiesButton: 'Hide municipalities',
+        claimedByPrefix: 'Already assigned to zone',
         municipalitySearchPlaceholder: 'Search municipality…',
         loadingMunicipalities: 'Loading municipalities…',
         noMunicipalitiesFound: 'No results',
         wholeDepartmentPrefix: 'Whole:',
-        removeDestinationLabel: 'Remove destination',
         destinationsColumn: 'Destinations',
         basisColumn: 'Rate',
         actionsColumn: 'Actions',
@@ -1554,14 +1563,17 @@ export const translations: Record<Language, Translations> = {
         nameLabel: 'Nome da zona',
         namePlaceholder: 'Ex. Eixo Cafeeiro',
         destinationsLabel: 'Destinos',
-        departmentPlaceholder: 'Selecione um departamento',
-        addWholeDepartmentButton: 'Adicionar departamento completo',
-        addMunicipalityButton: 'Adicionar município…',
+        selectAllDepartmentsButton: 'Selecionar todos',
+        clearDestinationsButton: 'Limpar',
+        selectedDestinationsCountLabel: 'destinos selecionados',
+        selectedMunicipalitiesCountLabel: 'municípios selecionados',
+        showMunicipalitiesButton: 'Ver municípios',
+        hideMunicipalitiesButton: 'Ocultar municípios',
+        claimedByPrefix: 'Já atribuído à zona',
         municipalitySearchPlaceholder: 'Buscar município…',
         loadingMunicipalities: 'Carregando municípios…',
         noMunicipalitiesFound: 'Sem resultados',
         wholeDepartmentPrefix: 'Todo:',
-        removeDestinationLabel: 'Remover destino',
         destinationsColumn: 'Destinos',
         basisColumn: 'Tarifa',
         actionsColumn: 'Ações',

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -354,6 +354,10 @@ export interface Translations {
     administration: string
     changeTheme: string
     changeFont: string
+    settingsNav: {
+      general: string
+      shipping: string
+    }
   }
   // Página no encontrada (404)
   notFound: {
@@ -797,6 +801,10 @@ export const translations: Record<Language, Translations> = {
       administration: 'Administración',
       changeTheme: 'Cambiar tema',
       changeFont: 'Cambiar fuente',
+      settingsNav: {
+        general: 'General',
+        shipping: 'Envío',
+      },
     },
     notFound: {
       heading: 'Página no encontrada',
@@ -1237,6 +1245,10 @@ export const translations: Record<Language, Translations> = {
       administration: 'Administration',
       changeTheme: 'Change theme',
       changeFont: 'Change font',
+      settingsNav: {
+        general: 'General',
+        shipping: 'Shipping',
+      },
     },
     notFound: {
       heading: 'Page Not Found',
@@ -1676,6 +1688,10 @@ export const translations: Record<Language, Translations> = {
       administration: 'Administração',
       changeTheme: 'Mudar tema',
       changeFont: 'Mudar fonte',
+      settingsNav: {
+        general: 'Geral',
+        shipping: 'Envio',
+      },
     },
     notFound: {
       heading: 'Página não encontrada',

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -187,6 +187,9 @@ export interface Translations {
     contactPhoneInvalidCta: string
     // D3/D5/D6/D8/D10: zonas de envío, sus destinos y su escalera de tarifas (S7).
     zones: {
+      coordinateModeTitle: string
+      coordinateModeDescription: string
+      coordinateModeCta: string
       sectionTitle: string
       sectionDescription: string
       addButton: string
@@ -211,6 +214,7 @@ export interface Translations {
       noMunicipalitiesFound: string
       wholeDepartmentPrefix: string
       destinationsColumn: string
+      moreDestinationsLabel: string
       basisColumn: string
       actionsColumn: string
       basisLabel: string
@@ -652,6 +656,10 @@ export const translations: Record<Language, Translations> = {
         'Guardaste un teléfono, pero no arma un enlace válido de WhatsApp. Revisa el número en Configuración.',
       contactPhoneInvalidCta: 'Corregir en Configuración',
       zones: {
+        coordinateModeTitle: 'Esta tienda coordina el envío por WhatsApp',
+        coordinateModeDescription:
+          'No necesitas zonas ni tarifas: cada envío se acuerda directo con el cliente. Si quieres cobrar envío automático por zona, cambia el modo de envío.',
+        coordinateModeCta: 'Ir al modo de envío',
         sectionTitle: 'Zonas de envío',
         sectionDescription: 'Define las zonas de entrega, sus destinos y su escalera de tarifas.',
         addButton: 'Agregar zona',
@@ -676,6 +684,7 @@ export const translations: Record<Language, Translations> = {
         noMunicipalitiesFound: 'Sin resultados',
         wholeDepartmentPrefix: 'Todo:',
         destinationsColumn: 'Destinos',
+        moreDestinationsLabel: '+{count} más',
         basisColumn: 'Tarifa',
         actionsColumn: 'Acciones',
         basisLabel: 'Tipo de tarifa',
@@ -1102,6 +1111,10 @@ export const translations: Record<Language, Translations> = {
         'You saved a phone, but it does not build a valid WhatsApp link. Check the number in Settings.',
       contactPhoneInvalidCta: 'Fix it in Settings',
       zones: {
+        coordinateModeTitle: 'This store coordinates shipping over WhatsApp',
+        coordinateModeDescription:
+          "You don't need zones or rates: every shipment is arranged directly with the customer. If you want to charge automatic shipping by zone, change the shipping mode.",
+        coordinateModeCta: 'Go to shipping mode',
         sectionTitle: 'Shipping zones',
         sectionDescription: 'Define your delivery zones, their destinations and their rate ladder.',
         addButton: 'Add zone',
@@ -1126,6 +1139,7 @@ export const translations: Record<Language, Translations> = {
         noMunicipalitiesFound: 'No results',
         wholeDepartmentPrefix: 'Whole:',
         destinationsColumn: 'Destinations',
+        moreDestinationsLabel: '+{count} more',
         basisColumn: 'Rate',
         actionsColumn: 'Actions',
         basisLabel: 'Rate type',
@@ -1551,6 +1565,10 @@ export const translations: Record<Language, Translations> = {
         'Você salvou um telefone, mas ele não gera um link válido do WhatsApp. Revise o número em Configurações.',
       contactPhoneInvalidCta: 'Corrigir em Configurações',
       zones: {
+        coordinateModeTitle: 'Esta loja combina o frete pelo WhatsApp',
+        coordinateModeDescription:
+          'Você não precisa de zonas nem tarifas: cada frete é combinado direto com o cliente. Se quiser cobrar frete automático por zona, mude o modo de frete.',
+        coordinateModeCta: 'Ir para o modo de frete',
         sectionTitle: 'Zonas de frete',
         sectionDescription: 'Defina as zonas de entrega, seus destinos e sua escada de tarifas.',
         addButton: 'Adicionar zona',
@@ -1575,6 +1593,7 @@ export const translations: Record<Language, Translations> = {
         noMunicipalitiesFound: 'Sem resultados',
         wholeDepartmentPrefix: 'Todo:',
         destinationsColumn: 'Destinos',
+        moreDestinationsLabel: '+{count} mais',
         basisColumn: 'Tarifa',
         actionsColumn: 'Ações',
         basisLabel: 'Tipo de tarifa',

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -203,7 +203,12 @@ export interface Translations {
       namePlaceholder: string
       destinationsLabel: string
       selectAllDepartmentsButton: string
+      selectedAllDestinationsToast: string
       clearDestinationsButton: string
+      clearDestinationsConfirmTitle: string
+      clearDestinationsConfirmDescription: string
+      clearDestinationsConfirmButton: string
+      clearedDestinationsToast: string
       selectedDestinationsCountLabel: string
       selectedMunicipalitiesCountLabel: string
       showMunicipalitiesButton: string
@@ -212,6 +217,7 @@ export interface Translations {
       municipalitySearchPlaceholder: string
       loadingMunicipalities: string
       noMunicipalitiesFound: string
+      municipalitiesLoadError: string
       wholeDepartmentPrefix: string
       destinationsColumn: string
       moreDestinationsLabel: string
@@ -673,7 +679,12 @@ export const translations: Record<Language, Translations> = {
         namePlaceholder: 'Ej. Eje Cafetero',
         destinationsLabel: 'Destinos',
         selectAllDepartmentsButton: 'Seleccionar todos',
+        selectedAllDestinationsToast: 'Se seleccionaron los {count} destinos disponibles, reemplazando cualquier selección anterior.',
         clearDestinationsButton: 'Limpiar',
+        clearDestinationsConfirmTitle: '¿Vaciar los destinos seleccionados?',
+        clearDestinationsConfirmDescription: 'Se perderán los {count} destinos que elegiste. Esta acción no se puede deshacer.',
+        clearDestinationsConfirmButton: 'Vaciar',
+        clearedDestinationsToast: 'Se vació la selección de destinos',
         selectedDestinationsCountLabel: 'destinos seleccionados',
         selectedMunicipalitiesCountLabel: 'municipios seleccionados',
         showMunicipalitiesButton: 'Ver municipios',
@@ -682,6 +693,7 @@ export const translations: Record<Language, Translations> = {
         municipalitySearchPlaceholder: 'Buscar municipio…',
         loadingMunicipalities: 'Cargando municipios…',
         noMunicipalitiesFound: 'Sin resultados',
+        municipalitiesLoadError: 'No pudimos cargar los municipios.',
         wholeDepartmentPrefix: 'Todo:',
         destinationsColumn: 'Destinos',
         moreDestinationsLabel: '+{count} más',
@@ -1128,7 +1140,12 @@ export const translations: Record<Language, Translations> = {
         namePlaceholder: 'E.g. Coffee Region',
         destinationsLabel: 'Destinations',
         selectAllDepartmentsButton: 'Select all',
+        selectedAllDestinationsToast: 'Selected all {count} available destinations, replacing any previous selection.',
         clearDestinationsButton: 'Clear',
+        clearDestinationsConfirmTitle: 'Clear the selected destinations?',
+        clearDestinationsConfirmDescription: "You'll lose the {count} destinations you picked. This action cannot be undone.",
+        clearDestinationsConfirmButton: 'Clear',
+        clearedDestinationsToast: 'Destinations selection cleared',
         selectedDestinationsCountLabel: 'destinations selected',
         selectedMunicipalitiesCountLabel: 'municipalities selected',
         showMunicipalitiesButton: 'Show municipalities',
@@ -1137,6 +1154,7 @@ export const translations: Record<Language, Translations> = {
         municipalitySearchPlaceholder: 'Search municipality…',
         loadingMunicipalities: 'Loading municipalities…',
         noMunicipalitiesFound: 'No results',
+        municipalitiesLoadError: "We couldn't load the municipalities.",
         wholeDepartmentPrefix: 'Whole:',
         destinationsColumn: 'Destinations',
         moreDestinationsLabel: '+{count} more',
@@ -1582,7 +1600,12 @@ export const translations: Record<Language, Translations> = {
         namePlaceholder: 'Ex. Eixo Cafeeiro',
         destinationsLabel: 'Destinos',
         selectAllDepartmentsButton: 'Selecionar todos',
+        selectedAllDestinationsToast: 'Foram selecionados os {count} destinos disponíveis, substituindo qualquer seleção anterior.',
         clearDestinationsButton: 'Limpar',
+        clearDestinationsConfirmTitle: 'Esvaziar os destinos selecionados?',
+        clearDestinationsConfirmDescription: 'Você vai perder os {count} destinos que escolheu. Esta ação não pode ser desfeita.',
+        clearDestinationsConfirmButton: 'Esvaziar',
+        clearedDestinationsToast: 'Seleção de destinos esvaziada',
         selectedDestinationsCountLabel: 'destinos selecionados',
         selectedMunicipalitiesCountLabel: 'municípios selecionados',
         showMunicipalitiesButton: 'Ver municípios',
@@ -1591,6 +1614,7 @@ export const translations: Record<Language, Translations> = {
         municipalitySearchPlaceholder: 'Buscar município…',
         loadingMunicipalities: 'Carregando municípios…',
         noMunicipalitiesFound: 'Sem resultados',
+        municipalitiesLoadError: 'Não conseguimos carregar os municípios.',
         wholeDepartmentPrefix: 'Todo:',
         destinationsColumn: 'Destinos',
         moreDestinationsLabel: '+{count} mais',

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -192,6 +192,8 @@ export interface Translations {
       addButton: string
       createTitle: string
       editTitle: string
+      formTitle: string
+      formDescription: string
       emptyTitle: string
       emptyDescription: string
       nameLabel: string
@@ -652,6 +654,8 @@ export const translations: Record<Language, Translations> = {
         addButton: 'Agregar zona',
         createTitle: 'Nueva zona de envío',
         editTitle: 'Editar zona de envío',
+        formTitle: 'Datos de la zona',
+        formDescription: 'Nombre, destinos y escalera de tarifas de la zona.',
         emptyTitle: 'Todavía no hay zonas de envío',
         emptyDescription: 'Agrega una zona para empezar a cobrar envío según el destino.',
         nameLabel: 'Nombre de la zona',
@@ -1097,6 +1101,8 @@ export const translations: Record<Language, Translations> = {
         addButton: 'Add zone',
         createTitle: 'New shipping zone',
         editTitle: 'Edit shipping zone',
+        formTitle: 'Zone details',
+        formDescription: 'Name, destinations and rate ladder for the zone.',
         emptyTitle: 'No shipping zones yet',
         emptyDescription: 'Add a zone to start charging shipping by destination.',
         nameLabel: 'Zone name',
@@ -1541,6 +1547,8 @@ export const translations: Record<Language, Translations> = {
         addButton: 'Adicionar zona',
         createTitle: 'Nova zona de frete',
         editTitle: 'Editar zona de frete',
+        formTitle: 'Dados da zona',
+        formDescription: 'Nome, destinos e escada de tarifas da zona.',
         emptyTitle: 'Ainda não há zonas de frete',
         emptyDescription: 'Adicione uma zona para começar a cobrar frete por destino.',
         nameLabel: 'Nome da zona',

--- a/lib/orders/order-format.ts
+++ b/lib/orders/order-format.ts
@@ -1,3 +1,7 @@
 export function formatOrderDateTime(value: string | null | undefined): string {
   return value ? new Date(value).toLocaleString("es-ES") : "";
 }
+
+export function formatAddressLine(parts: Array<string | null | undefined>): string {
+  return parts.map((part) => part?.trim()).filter(Boolean).join(", ");
+}

--- a/lib/products/adapter.ts
+++ b/lib/products/adapter.ts
@@ -265,6 +265,7 @@ export function adaptSupabaseProduct(item: StoreItemWithDetails): Product {
     productKind: isCombo ? 'combo' : 'product',
     comboDetails: item.combo,
     categoryId: item.category?.id,
+    categoryName: item.category?.category_name,
     description: description.length > 200 ? description.substring(0, 200) + '...' : description,
     descriptionHtml: item.item_description_html || `<p>${description}</p>`,
     featuredImage,

--- a/lib/shipping/locations-api.ts
+++ b/lib/shipping/locations-api.ts
@@ -1,6 +1,9 @@
+import { sanitizeIlikeSearchTerm } from "@/lib/security/postgrest-search"
 import { getSupabaseEcommerce } from "@/lib/supabase/client"
 import { ECOMMERCE_TABLES, ECOMMERCE_VIEWS } from "@/lib/supabase/contract"
 import { withTimeout } from "@/lib/supabase/with-timeout"
+
+export const MUNICIPALITY_SEARCH_MIN_LENGTH = 2
 
 export type Department = {
   code: string
@@ -79,6 +82,33 @@ export async function listMunicipalitiesByDepartment(
 
   if (result.error) {
     throw new Error(`No se pudieron leer los municipios: ${result.error.message}`)
+  }
+
+  return (result.data ?? []).map(toMunicipality)
+}
+
+export async function searchMunicipalities(
+  query: string,
+  limit: number,
+  client: EcommerceClient = getSupabaseEcommerce(),
+): Promise<Municipality[]> {
+  if (!client) return []
+
+  const sanitizedQuery = sanitizeIlikeSearchTerm(query)
+  if (sanitizedQuery.length < MUNICIPALITY_SEARCH_MIN_LENGTH) return []
+
+  const result = (await withTimeout(
+    coLocations(client)
+      .select("id, department_code, department_name, municipality_code, municipality_name")
+      .ilike("municipality_name", `%${sanitizedQuery}%`)
+      .order("municipality_name")
+      .limit(limit),
+    LOCATIONS_TIMEOUT_MS,
+    "searchMunicipalities",
+  )) as { data: CoLocationRow[] | null; error: any }
+
+  if (result.error) {
+    throw new Error(`No se pudieron buscar los municipios: ${result.error.message}`)
   }
 
   return (result.data ?? []).map(toMunicipality)

--- a/lib/supabase/auth-api.ts
+++ b/lib/supabase/auth-api.ts
@@ -25,6 +25,9 @@ async function withTimeout<T>(
 // formulario deba distinguir para quien está registrándose.
 const PREPARE_AUTH_REDIRECT_ERROR = 'No se pudo iniciar el registro. Intenta de nuevo en un momento.'
 
+const PREPARE_RECOVERY_REDIRECT_ERROR =
+  'No se pudo enviar el correo de recuperación de contraseña. Intenta de nuevo en un momento.'
+
 /**
  * Registrar un nuevo usuario.
  *
@@ -557,7 +560,7 @@ export async function resetPassword(
 
     const prepared = await prepareAuthRedirect({ email, purpose: 'recovery', path: '/auth/reset-password', turnstileToken })
     if (!prepared.ok) {
-      return { success: false, error: PREPARE_AUTH_REDIRECT_ERROR }
+      return { success: false, error: PREPARE_RECOVERY_REDIRECT_ERROR }
     }
 
     // `redirectTo` es el nombre real de la opción: resetPasswordForEmail ignora

--- a/lib/supabase/memberships-api.ts
+++ b/lib/supabase/memberships-api.ts
@@ -116,9 +116,15 @@ type StoreUserRow = {
   store_user_roles: StoreRoleLinks;
 };
 
-// The active store's team: members joined to their profile and store role.
-// Every query is scoped by the passed storeId — that explicit filter is the
-// tenant isolation, since the service client bypasses RLS.
+/**
+ * The active store's team: members joined to their profile and store role.
+ *
+ * Every query is scoped by the passed storeId — that explicit filter is the
+ * tenant isolation, since the service client bypasses RLS. The `user_profiles`
+ * embed names its foreign key because `store_users` references `user_profiles`
+ * twice (`user_id` and `granted_by`), and an unqualified embed is ambiguous to
+ * PostgREST, which answers PGRST201.
+ */
 export async function listStoreMembers(
   storeId: string,
   supabaseOverride?: any,
@@ -131,7 +137,7 @@ export async function listStoreMembers(
   const { data, error } = await service
     .from(ECOMMERCE_TABLES.storeUsers)
     .select(
-      "user_id, granted_by, user_profiles(email, first_name, last_name), store_user_roles(roles(role_name))",
+      "user_id, granted_by, user_profiles!store_users_user_id_fkey(email, first_name, last_name), store_user_roles(roles(role_name))",
     )
     .eq("store_id", storeId);
 

--- a/lib/supabase/orders-api.ts
+++ b/lib/supabase/orders-api.ts
@@ -1582,9 +1582,10 @@ export async function createOrder(
 export async function getOrderById(
   orderId: string,
   storeId: string,
+  supabaseOverride?: any,
 ): Promise<OrderWithItems | null> {
   try {
-    const supabase = getSupabaseEcommerce();
+    const supabase = supabaseOverride ?? getSupabaseEcommerce();
     if (!supabase) {
       console.error("[Orders] Supabase no configurado");
       return null;

--- a/lib/supabase/products-api.ts
+++ b/lib/supabase/products-api.ts
@@ -223,8 +223,11 @@ export async function getItems(
         .from(ECOMMERCE_VIEWS.storeItemsLegacy)
         .select(STORE_ITEMS_SELECT, { count: 'exact' })
         .eq('store_id', currentStoreId!) // Filtrar por tienda (currentStoreId ya está validado)
-        .eq('is_active', is_active)
         .eq('is_available_for_sale', is_available_for_sale)
+
+      if (is_active !== null) {
+        query = query.eq('is_active', is_active)
+      }
 
       // Filtros opcionales
       if (category_id) {
@@ -278,7 +281,7 @@ export async function getItems(
       const combos = await listCombos({
         store_id: currentStoreId,
         category_id,
-        includeInactive: is_active === false,
+        includeInactive: is_active !== true,
       })
       const comboItems = comboItemsMatching(combos, {
         isAvailableForSale: is_available_for_sale,

--- a/lib/supabase/shipping-zones-api.ts
+++ b/lib/supabase/shipping-zones-api.ts
@@ -286,6 +286,8 @@ async function replaceZoneRates(supabase: any, zoneId: string, ladder: ShippingR
   return !insertResult.error
 }
 
+const UNKNOWN_ZONE_NAME = "otra zona"
+
 type ExistingDestination = { zoneId: string; departmentCode: string; municipalityCode: string | null }
 
 async function fetchStoreDestinations(
@@ -374,7 +376,34 @@ async function findDestinationConflictError(
 
 async function fetchZoneName(supabase: any, zoneId: string): Promise<string> {
   const result = await supabase.from(ECOMMERCE_TABLES.shippingZones).select("name").eq("id", zoneId).maybeSingle()
-  return result.data?.name ?? "otra zona"
+  return result.data?.name ?? UNKNOWN_ZONE_NAME
+}
+
+export type ClaimedDestination = {
+  departmentCode: string
+  municipalityCode: string | null
+  zoneName: string
+}
+
+export async function findClaimedDestinations(
+  supabase: any,
+  storeId: string,
+  excludeZoneId?: string,
+): Promise<ClaimedDestination[]> {
+  const existingDestinations = await fetchStoreDestinations(supabase, storeId, excludeZoneId)
+  const zoneNameByZoneId = await mapZoneNames(supabase, existingDestinations.map((destination) => destination.zoneId))
+
+  return existingDestinations.map((destination) => ({
+    departmentCode: destination.departmentCode,
+    municipalityCode: destination.municipalityCode,
+    zoneName: zoneNameByZoneId.get(destination.zoneId) ?? UNKNOWN_ZONE_NAME,
+  }))
+}
+
+async function mapZoneNames(supabase: any, zoneIds: string[]): Promise<Map<string, string>> {
+  const uniqueZoneIds = [...new Set(zoneIds)]
+  const names = await Promise.all(uniqueZoneIds.map((zoneId) => fetchZoneName(supabase, zoneId)))
+  return new Map(uniqueZoneIds.map((zoneId, index) => [zoneId, names[index]]))
 }
 
 type LocationNames = { departments: Map<string, string>; municipalities: Map<string, string> }

--- a/lib/supabase/shipping-zones-api.ts
+++ b/lib/supabase/shipping-zones-api.ts
@@ -391,19 +391,24 @@ export async function findClaimedDestinations(
   excludeZoneId?: string,
 ): Promise<ClaimedDestination[]> {
   const existingDestinations = await fetchStoreDestinations(supabase, storeId, excludeZoneId)
-  const zoneNameByZoneId = await mapZoneNames(supabase, existingDestinations.map((destination) => destination.zoneId))
+  const uniqueZoneIds = [...new Set(existingDestinations.map((destination) => destination.zoneId))]
+  const zoneNamesResult =
+    uniqueZoneIds.length === 0
+      ? { data: [], error: null }
+      : await supabase.from(ECOMMERCE_TABLES.shippingZones).select("id, name").in("id", uniqueZoneIds)
+  if (zoneNamesResult.error) {
+    throw new Error("No se pudieron leer los nombres de las zonas", { cause: zoneNamesResult.error })
+  }
+
+  const zoneNameByZoneId = new Map<string, string>(
+    (zoneNamesResult.data ?? []).map((zone: { id: string; name: string }) => [zone.id, zone.name]),
+  )
 
   return existingDestinations.map((destination) => ({
     departmentCode: destination.departmentCode,
     municipalityCode: destination.municipalityCode,
     zoneName: zoneNameByZoneId.get(destination.zoneId) ?? UNKNOWN_ZONE_NAME,
   }))
-}
-
-async function mapZoneNames(supabase: any, zoneIds: string[]): Promise<Map<string, string>> {
-  const uniqueZoneIds = [...new Set(zoneIds)]
-  const names = await Promise.all(uniqueZoneIds.map((zoneId) => fetchZoneName(supabase, zoneId)))
-  return new Map(uniqueZoneIds.map((zoneId, index) => [zoneId, names[index]]))
 }
 
 type LocationNames = { departments: Map<string, string>; municipalities: Map<string, string> }

--- a/lib/types/products.ts
+++ b/lib/types/products.ts
@@ -139,7 +139,8 @@ export interface GetItemsParams {
   store_id?: string // ID de la tienda para filtrar productos
   item_kind?: 'all' | 'products' | 'combos'
   category_id?: string
-  is_active?: boolean
+  /** `null` asks for both states; omitting it filters to the active ones. */
+  is_active?: boolean | null
   is_featured?: boolean
   is_available_for_sale?: boolean
   on_sale?: boolean

--- a/lib/utils/store-host.ts
+++ b/lib/utils/store-host.ts
@@ -100,6 +100,8 @@ export function resolveStoreLookupSubdomain(
 // lib/stores/schemas.ts RESERVED_SUBDOMAINS keeps it off tenants).
 const PLATFORM_ADMIN_SUBDOMAIN = "admin";
 
+const DNS_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
 export function isPlatformAdminHost(host: string | null | undefined): boolean {
   return resolveStoreSubdomain(host) === PLATFORM_ADMIN_SUBDOMAIN;
 }
@@ -126,6 +128,25 @@ export function resolveDeploymentRootHost(
  */
 export function toPlatformAdminHost(host: string | null | undefined): string {
   return `${PLATFORM_ADMIN_SUBDOMAIN}.${resolveDeploymentRootHost(host)}`;
+}
+
+/**
+ * A tenant's own host derived from the current one, port preserved:
+ * admin.localhost:3000 + "tienda2" → tienda2.localhost:3000,
+ * admin.osoria.help + "default" → default.osoria.help. The mirror of
+ * toPlatformAdminHost: every cookie here is host-only, so a store is entered by
+ * going to its own host, never by setting something on the console's.
+ */
+export function toStoreHost(
+  subdomain: string,
+  host: string | null | undefined,
+): string {
+  const label = subdomain.trim().toLowerCase();
+  if (!DNS_LABEL_PATTERN.test(label)) {
+    throw new Error("The tenant subdomain must be a validated DNS label.");
+  }
+
+  return `${label}.${resolveDeploymentRootHost(host)}`;
 }
 
 function stripStorefrontLabels(hostname: string): string {

--- a/supabase/migrations/20260807000900_ecommerce_untracked_inventory_stays_put.sql
+++ b/supabase/migrations/20260807000900_ecommerce_untracked_inventory_stays_put.sql
@@ -1,0 +1,140 @@
+-- ecommerce.decrement_inventory: un ítem sin seguimiento de inventario deja de
+-- mover su contador. El WHERE sigue decidiendo si la línea pasa; el SET pasa a
+-- decidir si el contador se mueve. Idempotencia, inventory_movements y el
+-- cálculo de faltantes quedan igual.
+
+create or replace function ecommerce.decrement_inventory(
+  p_order_id uuid,
+  p_store_id uuid,
+  p_items jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'ecommerce', 'public'
+as $$
+declare
+  v_item jsonb;
+  v_variant_id uuid;
+  v_product_id uuid;
+  v_quantity integer;
+  v_track_inventory boolean;
+  v_current_quantity integer;
+  v_missing jsonb := '[]'::jsonb;
+  v_claimed uuid;
+begin
+  if p_items is null then
+    return v_missing;
+  end if;
+
+  -- Idempotency claim: the UPDATE and the decrements below run in this
+  -- function's own single-statement transaction, so a concurrent retry
+  -- claiming the SAME order_id blocks on the row lock until this one
+  -- commits, then sees inventory_decremented_at already set -- it can never
+  -- both decide "not yet decremented" and both proceed.
+  update ecommerce.orders
+     set inventory_decremented_at = now()
+   where id = p_order_id
+     and inventory_decremented_at is null
+  returning id into v_claimed;
+
+  if v_claimed is null then
+    -- Already decremented for this order by an earlier attempt (or the
+    -- order doesn't exist): converged already, nothing left to do.
+    return v_missing;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_variant_id := (v_item->>'variant_id')::uuid;
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_quantity := coalesce((v_item->>'quantity')::integer, 0);
+
+    if v_quantity <= 0 then
+      continue;
+    end if;
+
+    if v_variant_id is not null then
+      update ecommerce.item_variants
+        set inventory_quantity = case
+              when track_inventory then inventory_quantity - v_quantity
+              else inventory_quantity
+            end
+        where id = v_variant_id
+          and (track_inventory = false or inventory_quantity >= v_quantity)
+      returning track_inventory
+        into v_track_inventory;
+
+      if found then
+        -- Solo se registra movimiento para decrementos de variante: la
+        -- tabla inventory_movements exige variant_id NOT NULL, así que los
+        -- decrementos a nivel producto-sin-variante no se pueden loguear
+        -- ahí (se omiten más abajo). También evitamos loguear cuando no se
+        -- pudo resolver un store_id: eso sería un fallo de una tabla de
+        -- auditoría, no debe hacer fallar (ni revertir) el descuento real.
+        if v_track_inventory and p_store_id is not null then
+          insert into ecommerce.inventory_movements
+            (store_id, variant_id, movement_type, quantity, reason, related_order_id)
+          values
+            (p_store_id, v_variant_id, 'out', -v_quantity, 'order_sale', p_order_id);
+        end if;
+      else
+        select inventory_quantity, track_inventory
+          into v_current_quantity, v_track_inventory
+          from ecommerce.item_variants
+          where id = v_variant_id;
+
+        if found then
+          -- El registro existe: por construcción del WHERE de arriba, solo
+          -- se llega acá cuando track_inventory = true y no había stock
+          -- suficiente. Es un faltante real.
+          v_missing := v_missing || jsonb_build_object(
+            'variant_id', v_variant_id,
+            'product_id', v_product_id,
+            'requested', v_quantity,
+            'available', coalesce(v_current_quantity, 0)
+          );
+        end if;
+        -- Si la variante no existe en absoluto, se trata como producto
+        -- externo/no rastreado (p. ej. remanente de Shopify): no es
+        -- faltante, mismo criterio que el resto del código de órdenes.
+      end if;
+
+      continue;
+    end if;
+
+    if v_product_id is not null then
+      -- Sin RETURNING: los decrementos a nivel producto (sin variante) no
+      -- registran movimiento en inventory_movements (esa tabla exige
+      -- variant_id NOT NULL), así que no hace falta leer inventory_quantity
+      -- ni track_inventory acá; FOUND ya refleja si el UPDATE afectó una fila.
+      update ecommerce.store_items
+        set inventory_quantity = case
+              when track_inventory then inventory_quantity - v_quantity
+              else inventory_quantity
+            end
+        where id = v_product_id
+          and (track_inventory = false or inventory_quantity >= v_quantity);
+
+      if not found then
+        select inventory_quantity, track_inventory
+          into v_current_quantity, v_track_inventory
+          from ecommerce.store_items
+          where id = v_product_id;
+
+        if found then
+          v_missing := v_missing || jsonb_build_object(
+            'variant_id', null,
+            'product_id', v_product_id,
+            'requested', v_quantity,
+            'available', coalesce(v_current_quantity, 0)
+          );
+        end if;
+        -- Producto inexistente: externo/no rastreado, no es faltante.
+      end if;
+    end if;
+  end loop;
+
+  return v_missing;
+end;
+$$;

--- a/tests/admin/_helpers/find-element-of-type.ts
+++ b/tests/admin/_helpers/find-element-of-type.ts
@@ -1,0 +1,13 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react"
+
+export function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
+  if (!isValidElement(node)) return null
+  if (node.type === type) return node
+
+  const children = (node.props as { children?: ReactNode }).children
+  for (const child of Children.toArray(children)) {
+    const found = findElementOfType(child, type)
+    if (found) return found
+  }
+  return null
+}

--- a/tests/admin/_helpers/shipping-zone-fixture.ts
+++ b/tests/admin/_helpers/shipping-zone-fixture.ts
@@ -1,0 +1,16 @@
+import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+
+export const ZONE: ShippingZoneRecord = {
+  id: "zone-1",
+  name: "Eje Cafetero",
+  destinations: [
+    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
+  ],
+  rateLadder: {
+    basis: "order_value",
+    ranges: [
+      { from: "0", to: "50000", amount: "5000" },
+      { from: "50000", to: "", amount: "0" },
+    ],
+  },
+}

--- a/tests/admin/admin-breadcrumb.test.tsx
+++ b/tests/admin/admin-breadcrumb.test.tsx
@@ -15,6 +15,7 @@ const ORDER_ID = "0c9f9a1e-1c4c-4f0a-9d1f-6a1b2c3d4e5f"
 const PRODUCT_ID = "7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e"
 const COMBO_ID = "11111111-1111-4111-8111-111111111111"
 const CATEGORY_ID = "22222222-2222-4222-8222-222222222222"
+const ZONE_ID = "33333333-3333-4333-8333-333333333333"
 
 function labelsOf(pathname: string, entityLabel?: string): string[] {
   return adminBreadcrumbTrail(pathname, entityLabel).map((step) => step.label)
@@ -84,6 +85,24 @@ describe("adminBreadcrumbTrail", () => {
       "Admin",
       "Productos",
       "Categorías",
+      "Editar",
+    ])
+  })
+
+  it("nests the shipping zone create screen under shipping settings", () => {
+    expect(labelsOf("/admin/settings/shipping/zones/new")).toEqual([
+      "Admin",
+      "Configuración",
+      "Envío",
+      "Crear",
+    ])
+  })
+
+  it("nests the shipping zone edit screen under shipping settings, skipping the zone id", () => {
+    expect(labelsOf(`/admin/settings/shipping/zones/${ZONE_ID}/edit`)).toEqual([
+      "Admin",
+      "Configuración",
+      "Envío",
       "Editar",
     ])
   })

--- a/tests/admin/admin-order-detail-page.test.tsx
+++ b/tests/admin/admin-order-detail-page.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement } from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -30,6 +24,7 @@ vi.mock("next/navigation", () => ({
 }))
 
 import AdminOrderDetailPage from "@/app/admin/orders/[id]/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const ORDER: OrderWithItems = {
   id: "0c9f9a1e-1c4c-4f0a-9d1f-6a1b2c3d4e5f",
@@ -54,18 +49,6 @@ const ORDER: OrderWithItems = {
   created_at: "2026-07-10T12:00:00.000Z",
   updated_at: "2026-07-10T12:00:00.000Z",
   items: [],
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
 }
 
 describe("AdminOrderDetailPage", () => {

--- a/tests/admin/admin-order-detail-page.test.tsx
+++ b/tests/admin/admin-order-detail-page.test.tsx
@@ -51,11 +51,13 @@ const ORDER: OrderWithItems = {
   items: [],
 }
 
+const AUTHORIZED_CLIENT = { tag: "service-client" }
+
 describe("AdminOrderDetailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     authorizeActiveStoreAdmin.mockResolvedValue({
-      supabase: {},
+      supabase: AUTHORIZED_CLIENT,
       storeId: "store-1",
       userId: "user-1",
     })
@@ -72,6 +74,13 @@ describe("AdminOrderDetailPage", () => {
     expect(header).not.toBeNull()
     expect(header?.props.entityLabel).toBe(`Pedido ${ORDER.order_number}`)
     expect(header?.props.entityLabel).not.toContain(ORDER.id)
+  })
+
+  it("consulta el pedido con el cliente autorizado, no con el cliente anónimo", async () => {
+    await AdminOrderDetailPage({ params: Promise.resolve({ id: ORDER.id }) })
+
+    expect(getOrderById).toHaveBeenCalledTimes(1)
+    expect(getOrderById.mock.calls[0][2]).toBe(AUTHORIZED_CLIENT)
   })
 })
 

--- a/tests/admin/admin-orders-page.test.tsx
+++ b/tests/admin/admin-orders-page.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const { authorizeActiveStoreAdmin, getOrders, redirect } = vi.hoisted(() => ({
+  authorizeActiveStoreAdmin: vi.fn(),
+  getOrders: vi.fn(),
+  redirect: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/active-store", () => ({ authorizeActiveStoreAdmin }))
+vi.mock("@/lib/supabase/orders-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/orders-api")>()
+  return { ...actual, getOrders }
+})
+vi.mock("next/navigation", () => ({ redirect, usePathname: () => "/admin/orders" }))
+
+import AdminOrdersPage from "@/app/admin/orders/page"
+
+const AUTHORIZED_CLIENT = { tag: "service-client" }
+
+describe("AdminOrdersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authorizeActiveStoreAdmin.mockResolvedValue({
+      supabase: AUTHORIZED_CLIENT,
+      storeId: "store-1",
+      userId: "user-1",
+    })
+    getOrders.mockResolvedValue({ orders: [], total: 0 })
+  })
+
+  it("consulta los pedidos con el cliente autorizado, no con el cliente anónimo", async () => {
+    await AdminOrdersPage({ searchParams: Promise.resolve({}) })
+
+    expect(getOrders).toHaveBeenCalledTimes(1)
+    expect(getOrders.mock.calls[0][1]).toBe(AUTHORIZED_CLIENT)
+  })
+
+  it("acota la consulta a la tienda activa", async () => {
+    await AdminOrdersPage({ searchParams: Promise.resolve({}) })
+
+    expect(getOrders.mock.calls[0][0]).toMatchObject({ storeId: "store-1" })
+  })
+})

--- a/tests/admin/admin-products-page-inactive.test.tsx
+++ b/tests/admin/admin-products-page-inactive.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const { authorizeActiveStoreAdmin, getItems, redirect } = vi.hoisted(() => ({
+  authorizeActiveStoreAdmin: vi.fn(),
+  getItems: vi.fn(),
+  redirect: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/active-store", () => ({ authorizeActiveStoreAdmin }))
+vi.mock("@/lib/supabase/products-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/products-api")>()
+  return { ...actual, getItems }
+})
+vi.mock("next/navigation", () => ({ redirect, usePathname: () => "/admin/products" }))
+
+import AdminProductsPage from "@/app/admin/products/page"
+
+describe("AdminProductsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authorizeActiveStoreAdmin.mockResolvedValue({
+      supabase: {},
+      storeId: "store-1",
+      userId: "user-1",
+    })
+    getItems.mockResolvedValue({ items: [], total: 0 })
+  })
+
+  it("pide los productos de los dos estados, no solo los activos", async () => {
+    await AdminProductsPage({ searchParams: Promise.resolve({}) })
+
+    expect(getItems).toHaveBeenCalledTimes(1)
+    expect(getItems.mock.calls[0][0]).toMatchObject({ is_active: null })
+  })
+
+  it("sigue acotando el listado a la tienda activa", async () => {
+    await AdminProductsPage({ searchParams: Promise.resolve({}) })
+
+    expect(getItems.mock.calls[0][0]).toMatchObject({ store_id: "store-1" })
+  })
+})

--- a/tests/admin/admin-sidebar.test.tsx
+++ b/tests/admin/admin-sidebar.test.tsx
@@ -116,6 +116,56 @@ describe("AdminSidebar highlight", () => {
   })
 })
 
+describe("AdminSidebar Configuración submenu", () => {
+  it("expands on /admin/settings/shipping and marks Envío as the current page", () => {
+    mockedPathname = "/admin/settings/shipping"
+    renderSidebar()
+
+    expect(activeNavLabel()).toBe("Envío")
+    expect(screen.getByRole("link", { name: "Configuración" })).not.toHaveAttribute("aria-current")
+    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("expands on /admin/settings and marks General as the current page", () => {
+    mockedPathname = "/admin/settings"
+    renderSidebar()
+
+    expect(activeNavLabel()).toBe("General")
+    expect(screen.getByRole("link", { name: "Configuración" })).not.toHaveAttribute("aria-current")
+  })
+
+  it("leaves the group collapsed on an unrelated route", () => {
+    mockedPathname = "/admin/products"
+    renderSidebar()
+
+    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("link", { name: "Envío" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "General" })).not.toBeInTheDocument()
+  })
+
+  it("re-collapses on an already-mounted sidebar navigating to an unrelated route", () => {
+    mockedPathname = "/admin/settings/shipping"
+    const { rerender } = render(
+      <SidebarProvider defaultPinned>
+        <AdminSidebar />
+      </SidebarProvider>,
+    )
+
+    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "true")
+
+    mockedPathname = "/admin/products"
+    rerender(
+      <SidebarProvider defaultPinned>
+        <AdminSidebar />
+      </SidebarProvider>,
+    )
+
+    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("link", { name: "Envío" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "General" })).not.toBeInTheDocument()
+  })
+})
+
 describe("AdminSidebar pinned vs peeking", () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/tests/admin/admin-sidebar.test.tsx
+++ b/tests/admin/admin-sidebar.test.tsx
@@ -126,6 +126,13 @@ describe("AdminSidebar Configuración submenu", () => {
     expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "true")
   })
 
+  it("keeps Envío highlighted on the zone create screen, its child route with no nav entry", () => {
+    mockedPathname = "/admin/settings/shipping/zones/new"
+    renderSidebar()
+
+    expect(activeNavLabel()).toBe("Envío")
+  })
+
   it("expands on /admin/settings and marks General as the current page", () => {
     mockedPathname = "/admin/settings"
     renderSidebar()

--- a/tests/admin/admin-sidebar.test.tsx
+++ b/tests/admin/admin-sidebar.test.tsx
@@ -123,7 +123,6 @@ describe("AdminSidebar Configuración submenu", () => {
 
     expect(activeNavLabel()).toBe("Envío")
     expect(screen.getByRole("link", { name: "Configuración" })).not.toHaveAttribute("aria-current")
-    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "true")
   })
 
   it("keeps Envío highlighted on the zone create screen, its child route with no nav entry", () => {
@@ -141,16 +140,18 @@ describe("AdminSidebar Configuración submenu", () => {
     expect(screen.getByRole("link", { name: "Configuración" })).not.toHaveAttribute("aria-current")
   })
 
-  it("leaves the group collapsed on an unrelated route", () => {
+  it("always renders Envío and General under Configuración, with no aria-expanded state to announce", () => {
     mockedPathname = "/admin/products"
     renderSidebar()
 
-    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "false")
-    expect(screen.queryByRole("link", { name: "Envío" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: "General" })).not.toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Configuración" })).not.toHaveAttribute("aria-expanded")
+    expect(screen.getByRole("link", { name: "Envío" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "General" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Envío" })).not.toHaveAttribute("aria-current")
+    expect(screen.getByRole("link", { name: "General" })).not.toHaveAttribute("aria-current")
   })
 
-  it("re-collapses on an already-mounted sidebar navigating to an unrelated route", () => {
+  it("keeps the submenu mounted on an already-mounted sidebar navigating to an unrelated route", () => {
     mockedPathname = "/admin/settings/shipping"
     const { rerender } = render(
       <SidebarProvider defaultPinned>
@@ -158,7 +159,7 @@ describe("AdminSidebar Configuración submenu", () => {
       </SidebarProvider>,
     )
 
-    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("link", { name: "Envío" })).toBeInTheDocument()
 
     mockedPathname = "/admin/products"
     rerender(
@@ -167,9 +168,9 @@ describe("AdminSidebar Configuración submenu", () => {
       </SidebarProvider>,
     )
 
-    expect(screen.getByRole("link", { name: "Configuración" })).toHaveAttribute("aria-expanded", "false")
-    expect(screen.queryByRole("link", { name: "Envío" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: "General" })).not.toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Envío" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "General" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Envío" })).not.toHaveAttribute("aria-current")
   })
 })
 

--- a/tests/admin/categories-screens.test.tsx
+++ b/tests/admin/categories-screens.test.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, type ComponentProps, type ReactElement, type ReactNode } from "react"
+import { type ComponentProps, type ReactElement, type ReactNode } from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -40,6 +40,7 @@ import EditCategoryPage from "@/app/admin/products/categories/[id]/edit/page"
 import { CategoriesTable } from "@/app/admin/products/categories/components/categories-table"
 import CreateCategoryPage from "@/app/admin/products/categories/create/page"
 import AdminCategoriesPage from "@/app/admin/products/categories/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
@@ -63,18 +64,6 @@ function categoryFixture(
     updated_at: "2026-01-01",
     productCount,
   }
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
 }
 
 function categoryFormOf(page: ReactNode) {

--- a/tests/admin/chatbot-page.test.tsx
+++ b/tests/admin/chatbot-page.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatbotConfigForm } from "@/app/admin/chatbot/components/chatbot-config-form"
@@ -23,21 +17,10 @@ vi.mock("@/lib/supabase/chatbot-api", async (importOriginal) => {
 vi.mock("next/navigation", () => ({ redirect }))
 
 import ChatbotConfigPage from "@/app/admin/chatbot/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
-}
 
 describe("ChatbotConfigPage", () => {
   beforeEach(() => {

--- a/tests/admin/combos-screens.test.tsx
+++ b/tests/admin/combos-screens.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement, type ReactNode } from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -44,6 +38,7 @@ import EditComboPage from "@/app/admin/products/combos/[id]/edit/page"
 import { CombosTable } from "@/app/admin/products/combos/components/combos-table"
 import CreateComboPage from "@/app/admin/products/combos/create/page"
 import AdminCombosPage from "@/app/admin/products/combos/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
@@ -74,18 +69,6 @@ function comboFixture(id: string, name: string): ComboCatalogDetails {
     availability: { isAvailable: true, derivedStock: 5, blockingComponents: [] },
     components: [],
   }
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
 }
 
 function comboFormOf(page: ReactNode) {

--- a/tests/admin/home-discount-popup-page.test.tsx
+++ b/tests/admin/home-discount-popup-page.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { HomeDiscountPopupForm } from "@/app/admin/home-discount-popup/components/home-discount-popup-form"
@@ -21,6 +15,7 @@ vi.mock("@/lib/home-discount-popup-admin", () => ({ loadHomeDiscountPopupConfig 
 vi.mock("next/navigation", () => ({ redirect }))
 
 import HomeDiscountPopupConfigPage from "@/app/admin/home-discount-popup/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
@@ -33,18 +28,6 @@ const ACTIVE_STORE_CONFIG = normalizeHomeDiscountPopupConfig({
   coupon: "HOME10",
   ctaMode: "copy_coupon",
 })
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
-}
 
 describe("HomeDiscountPopupConfigPage", () => {
   beforeEach(() => {

--- a/tests/admin/shipping-settings-page.test.tsx
+++ b/tests/admin/shipping-settings-page.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ShippingContactPendingNotice } from "@/app/admin/settings/shipping/components/shipping-contact-pending-notice"
@@ -33,6 +27,7 @@ vi.mock("@/lib/supabase/store-identity-api", () => ({ loadStoreIdentity }))
 vi.mock("next/navigation", () => ({ redirect }))
 
 import ShippingSettingsPage from "@/app/admin/settings/shipping/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
@@ -46,18 +41,6 @@ const COMPLETE_IDENTITY = {
   commercialAddress: "Bogotá, Colombia",
   replyToVerifiedAt: "2026-01-01T00:00:00.000Z",
   orderMailboxVerifiedAt: "2026-01-01T00:00:00.000Z",
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
 }
 
 describe("ShippingSettingsPage", () => {

--- a/tests/admin/shipping-zone-editor.test.tsx
+++ b/tests/admin/shipping-zone-editor.test.tsx
@@ -26,7 +26,8 @@ beforeAll(() => {
 })
 
 import { ShippingZonesSection } from "@/app/admin/settings/shipping/components/zone-editor"
-import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import { translations } from "@/lib/i18n/translations"
+import type { ShippingZoneDestinationView, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
 
 const ZONE: ShippingZoneRecord = {
   id: "zone-1",
@@ -43,27 +44,60 @@ const ZONE: ShippingZoneRecord = {
   },
 }
 
+function destinationsInDepartment(departmentName: string, count: number): ShippingZoneDestinationView[] {
+  return Array.from({ length: count }, (_, index) => ({
+    departmentCode: "05",
+    departmentName,
+    municipalityCode: `0500${index + 1}`,
+    municipalityName: `Municipio ${index + 1}`,
+  }))
+}
+
+const ZONE_WITH_MANY_DESTINATIONS: ShippingZoneRecord = {
+  ...ZONE,
+  id: "zone-2",
+  destinations: destinationsInDepartment("ANTIOQUIA", 5),
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe("ShippingZonesSection", () => {
   it("shows the empty state when the store has no zones yet", () => {
-    render(<ShippingZonesSection zones={[]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection mode="own_rates" zones={[]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByText(/Agrega una zona/)).toBeInTheDocument()
   })
 
+  it("renders both the empty state's title and its description", () => {
+    render(<ShippingZonesSection mode="own_rates" zones={[]} unmatchedDestinationAction="block" />)
+
+    expect(screen.getByText(translations.es.shipping.zones.emptyTitle)).toBeInTheDocument()
+    expect(screen.getByText(translations.es.shipping.zones.emptyDescription)).toBeInTheDocument()
+  })
+
   it("lists an existing zone with its destination and its rate basis", () => {
-    render(<ShippingZonesSection zones={[ZONE]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection mode="own_rates" zones={[ZONE]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByText("Eje Cafetero")).toBeInTheDocument()
     expect(screen.getByText("MEDELLÍN")).toBeInTheDocument()
     expect(screen.getByText("Por valor del pedido")).toBeInTheDocument()
   })
 
+  it("caps a zone's visible destination badges at three and labels the rest", () => {
+    render(<ShippingZonesSection mode="own_rates" zones={[ZONE_WITH_MANY_DESTINATIONS]} unmatchedDestinationAction="block" />)
+
+    expect(screen.getByText("Municipio 1")).toBeInTheDocument()
+    expect(screen.getByText("Municipio 2")).toBeInTheDocument()
+    expect(screen.getByText("Municipio 3")).toBeInTheDocument()
+    expect(screen.queryByText("Municipio 4")).not.toBeInTheDocument()
+    expect(screen.queryByText("Municipio 5")).not.toBeInTheDocument()
+    expect(screen.getByText("+2 más")).toBeInTheDocument()
+  })
+
   it("sends 'Agregar zona' to its own creation screen instead of opening a dialog", () => {
-    render(<ShippingZonesSection zones={[]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection mode="own_rates" zones={[]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByRole("link", { name: /Agregar zona/ })).toHaveAttribute(
       "href",
@@ -72,11 +106,32 @@ describe("ShippingZonesSection", () => {
   })
 
   it("sends each row's edit action to its own edit screen instead of opening a dialog", () => {
-    render(<ShippingZonesSection zones={[ZONE]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection mode="own_rates" zones={[ZONE]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByRole("link", { name: /Editar zona de envío/ })).toHaveAttribute(
       "href",
       `/admin/settings/shipping/zones/${ZONE.id}/edit`,
     )
+  })
+
+  it("replaces the zones-and-rates apparatus with a WhatsApp explanation in coordinate mode", () => {
+    render(<ShippingZonesSection mode="coordinate" zones={[ZONE]} unmatchedDestinationAction="block" />)
+
+    expect(screen.getByText(translations.es.shipping.zones.coordinateModeTitle)).toBeInTheDocument()
+    expect(screen.queryByText(translations.es.shipping.zones.sectionTitle)).not.toBeInTheDocument()
+    expect(screen.queryByText(translations.es.shipping.zones.unmatchedDestinationTitle)).not.toBeInTheDocument()
+    expect(screen.queryByText("Eje Cafetero")).not.toBeInTheDocument()
+    expect(screen.getByRole("link", { name: translations.es.shipping.zones.coordinateModeCta })).toHaveAttribute(
+      "href",
+      "#shipping-mode",
+    )
+  })
+
+  it("still shows the zones apparatus for an own_rates store", () => {
+    render(<ShippingZonesSection mode="own_rates" zones={[ZONE]} unmatchedDestinationAction="block" />)
+
+    expect(screen.getByText(translations.es.shipping.zones.sectionTitle)).toBeInTheDocument()
+    expect(screen.getByText(translations.es.shipping.zones.unmatchedDestinationTitle)).toBeInTheDocument()
+    expect(screen.queryByText(translations.es.shipping.zones.coordinateModeTitle)).not.toBeInTheDocument()
   })
 })

--- a/tests/admin/shipping-zone-editor.test.tsx
+++ b/tests/admin/shipping-zone-editor.test.tsx
@@ -1,28 +1,14 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
-import { useForm } from "react-hook-form"
 
-const {
-  saveShippingZoneAction,
-  deleteShippingZoneAction,
-  listShippingDepartmentsAction,
-  listShippingMunicipalitiesAction,
-  updateUnmatchedDestinationActionAction,
-  routerRefresh,
-} = vi.hoisted(() => ({
-  saveShippingZoneAction: vi.fn(),
+const { deleteShippingZoneAction, updateUnmatchedDestinationActionAction, routerRefresh } = vi.hoisted(() => ({
   deleteShippingZoneAction: vi.fn(),
-  listShippingDepartmentsAction: vi.fn(),
-  listShippingMunicipalitiesAction: vi.fn(),
   updateUnmatchedDestinationActionAction: vi.fn(),
   routerRefresh: vi.fn(),
 }))
 
 vi.mock("@/app/admin/settings/shipping/actions", () => ({
-  saveShippingZoneAction,
   deleteShippingZoneAction,
-  listShippingDepartmentsAction,
-  listShippingMunicipalitiesAction,
   updateUnmatchedDestinationActionAction,
 }))
 
@@ -30,9 +16,6 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: routerRefresh }),
 }))
 
-// jsdom doesn't implement ResizeObserver; the Radix Dialog/Select/Popover
-// this screen carries measure themselves as soon as they mount (same stub
-// tests/admin/product-form.test.tsx already needs for its own Radix fields).
 beforeAll(() => {
   class ResizeObserverStub {
     observe() {}
@@ -43,9 +26,7 @@ beforeAll(() => {
 })
 
 import { ShippingZonesSection } from "@/app/admin/settings/shipping/components/zone-editor"
-import { RateLadderField } from "@/app/admin/settings/shipping/components/rate-ladder-field"
-import type { ZoneEditorFormValues } from "@/lib/shipping/schemas"
-import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
 
 const ZONE: ShippingZoneRecord = {
   id: "zone-1",
@@ -64,201 +45,38 @@ const ZONE: ShippingZoneRecord = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  listShippingDepartmentsAction.mockResolvedValue([])
 })
 
 describe("ShippingZonesSection", () => {
   it("shows the empty state when the store has no zones yet", () => {
-    render(<ShippingZonesSection zones={[]} missingWeightProducts={[]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection zones={[]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByText(/Agrega una zona/)).toBeInTheDocument()
   })
 
   it("lists an existing zone with its destination and its rate basis", () => {
-    render(<ShippingZonesSection zones={[ZONE]} missingWeightProducts={[]} unmatchedDestinationAction="block" />)
+    render(<ShippingZonesSection zones={[ZONE]} unmatchedDestinationAction="block" />)
 
     expect(screen.getByText("Eje Cafetero")).toBeInTheDocument()
     expect(screen.getByText("MEDELLÍN")).toBeInTheDocument()
     expect(screen.getByText("Por valor del pedido")).toBeInTheDocument()
   })
 
-  it("opens the editor with the zone's current name pre-filled", async () => {
-    render(<ShippingZonesSection zones={[ZONE]} missingWeightProducts={[]} unmatchedDestinationAction="block" />)
+  it("sends 'Agregar zona' to its own creation screen instead of opening a dialog", () => {
+    render(<ShippingZonesSection zones={[]} unmatchedDestinationAction="block" />)
 
-    fireEvent.click(screen.getAllByRole("button", { name: /Editar zona de envío/ })[0])
-
-    expect(await screen.findByDisplayValue("Eje Cafetero")).toBeInTheDocument()
-  })
-
-  // Round-3 fix: the dialog's create-vs-edit decision has to survive `zones`
-  // no longer containing the zone being edited (e.g. a server refresh landed
-  // while the dialog stayed open) -- ZoneForm used to re-derive the id from
-  // the (now missing) zone record and would have submitted a CREATE instead
-  // of the intended edit.
-  it("still submits an EDIT of the original zone when it drops out of the zones list while the dialog stays open", async () => {
-    saveShippingZoneAction.mockResolvedValue({ success: true })
-
-    const { rerender } = render(
-      <ShippingZonesSection zones={[ZONE]} missingWeightProducts={[]} unmatchedDestinationAction="block" />,
+    expect(screen.getByRole("link", { name: /Agregar zona/ })).toHaveAttribute(
+      "href",
+      "/admin/settings/shipping/zones/new",
     )
-
-    fireEvent.click(screen.getAllByRole("button", { name: /Editar zona de envío/ })[0])
-    await screen.findByDisplayValue("Eje Cafetero")
-
-    rerender(<ShippingZonesSection zones={[]} missingWeightProducts={[]} unmatchedDestinationAction="block" />)
-
-    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
-
-    await waitFor(() => expect(saveShippingZoneAction).toHaveBeenCalled())
-    expect(saveShippingZoneAction.mock.calls[0][1]).toBe(ZONE.id)
-  })
-})
-
-function RateLadderHarness({
-  basis = "order_value",
-  ranges = [{ from: "0", to: "", amount: "" }],
-  missingWeightProducts = [],
-}: {
-  basis?: "flat" | "order_value" | "weight"
-  ranges?: { from: string; to: string; amount: string }[]
-  missingWeightProducts?: MissingWeightProduct[]
-}) {
-  const { control } = useForm<ZoneEditorFormValues>({
-    defaultValues: {
-      name: "",
-      destinations: [],
-      rateLadder: { basis, amount: "0", ranges },
-    },
   })
 
-  return <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
-}
+  it("sends each row's edit action to its own edit screen instead of opening a dialog", () => {
+    render(<ShippingZonesSection zones={[ZONE]} unmatchedDestinationAction="block" />)
 
-describe("RateLadderField", () => {
-  it("adds and removes range rows", () => {
-    render(<RateLadderHarness />)
-
-    expect(screen.getAllByLabelText("Desde")).toHaveLength(1)
-
-    fireEvent.click(screen.getByRole("button", { name: /Agregar rango/ }))
-    expect(screen.getAllByLabelText("Desde")).toHaveLength(2)
-
-    fireEvent.click(screen.getAllByRole("button", { name: "Quitar rango" })[0])
-    expect(screen.getAllByLabelText("Desde")).toHaveLength(1)
-  })
-
-  it("cannot remove the last remaining range row", () => {
-    render(<RateLadderHarness />)
-
-    expect(screen.getByRole("button", { name: "Quitar rango" })).toBeDisabled()
-  })
-
-  it("warns when the ladder does not reach an open-ended last rung (D6's no-gaps rule)", () => {
-    render(<RateLadderHarness />)
-
-    fireEvent.change(screen.getByLabelText("Hasta"), { target: { value: "50000" } })
-    fireEvent.change(screen.getByLabelText("Monto"), { target: { value: "5000" } })
-
-    expect(screen.getByText(/último rango/)).toBeInTheDocument()
-  })
-
-  it("warns about an overlap when two ranges cover the same order-value band", () => {
-    render(
-      <RateLadderHarness
-        ranges={[
-          { from: "0", to: "30000", amount: "3000" },
-          { from: "20000", to: "", amount: "0" },
-        ]}
-      />,
+    expect(screen.getByRole("link", { name: /Editar zona de envío/ })).toHaveAttribute(
+      "href",
+      `/admin/settings/shipping/zones/${ZONE.id}/edit`,
     )
-
-    expect(screen.getByText(/superponen/)).toBeInTheDocument()
-  })
-
-  // Isolated from any other fixture: pins the half-open boundary semantics
-  // (a shared endpoint is neither a gap nor an overlap) as its own case.
-  it("shows no warning when two ranges touch exactly at the boundary", () => {
-    render(
-      <RateLadderHarness
-        ranges={[
-          { from: "0", to: "20000", amount: "3000" },
-          { from: "20000", to: "", amount: "0" },
-        ]}
-      />,
-    )
-
-    expect(screen.queryByText(/superponen/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/vacío/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/último rango/)).not.toBeInTheDocument()
-  })
-
-  it("says nothing about missing weight for a non-weight basis, even with products missing it", () => {
-    render(<RateLadderHarness basis="order_value" missingWeightProducts={[{ id: "item-1", name: "Café Especial" }]} />)
-
-    expect(screen.queryByText("Faltan productos con peso cargado")).not.toBeInTheDocument()
-  })
-
-  it("lists products missing weight, with a link to each, for the weight basis (D8)", () => {
-    render(<RateLadderHarness basis="weight" missingWeightProducts={[{ id: "item-1", name: "Café Especial" }]} />)
-
-    expect(screen.getByText("Faltan productos con peso cargado")).toBeInTheDocument()
-    expect(screen.getByText(/Café Especial/)).toBeInTheDocument()
-    expect(screen.getByRole("link", { name: "Editar producto" })).toHaveAttribute("href", "/admin/products/item-1/edit")
-  })
-
-  // P1: nothing anywhere used to say a 0 amount means free shipping.
-  it("hints that a 0 Monto means free shipping for that range", () => {
-    render(<RateLadderHarness />)
-
-    expect(
-      screen.getByText("Un rango con Monto en 0 es envío gratis para ese tramo."),
-    ).toBeInTheDocument()
-  })
-
-  // P1: the row used to be a fixed 4-column grid with no breakpoint.
-  it("stacks a range row into two columns on narrow screens and back to four at sm", () => {
-    render(<RateLadderHarness />)
-
-    const rowContainer = screen.getByLabelText("Desde").closest("div")?.parentElement
-    expect(rowContainer).toHaveClass("grid-cols-2")
-    expect(rowContainer).toHaveClass("sm:grid-cols-[1fr_1fr_1fr_auto]")
-  })
-
-  // P0 (second half) + P1: the live gap/overlap indicator used to disappear
-  // the instant any row's amount was blank, and only ever showed the FIRST
-  // issue with the same neutral weight as an informational notice.
-  it("shows every gap/overlap issue as a destructive alert, surviving a still-blank row amount", () => {
-    render(
-      <RateLadderHarness
-        ranges={[
-          { from: "10000", to: "30000", amount: "" },
-          { from: "20000", to: "", amount: "0" },
-        ]}
-      />,
-    )
-
-    expect(screen.getByText(/primer rango/)).toBeInTheDocument()
-    expect(screen.getByText(/superponen/)).toBeInTheDocument()
-    expect(screen.getByRole("alert")).toHaveClass("text-destructive")
-  })
-})
-
-// P0: looseRateLadderFieldSchema never validates the ladder, so a blank or
-// invalid row only ever surfaces on submit -- these pin that it now lands on
-// the exact field RateLadderField renders, not just a generic toast.
-describe("ShippingZonesSection ladder validation on save (P0)", () => {
-  it("flags the exact row field and blocks the save when a ladder amount is blank", async () => {
-    render(<ShippingZonesSection zones={[ZONE]} missingWeightProducts={[]} unmatchedDestinationAction="block" />)
-
-    fireEvent.click(screen.getAllByRole("button", { name: /Editar zona de envío/ })[0])
-    await screen.findByDisplayValue("Eje Cafetero")
-
-    const amountInputs = screen.getAllByLabelText("Monto")
-    fireEvent.change(amountInputs[0], { target: { value: "" } })
-    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
-
-    await waitFor(() => expect(amountInputs[0]).toHaveAttribute("aria-invalid", "true"))
-    expect(await screen.findByText("El monto no puede ser negativo")).toBeInTheDocument()
-    expect(saveShippingZoneAction).not.toHaveBeenCalled()
   })
 })

--- a/tests/admin/shipping-zone-form.test.tsx
+++ b/tests/admin/shipping-zone-form.test.tsx
@@ -2,15 +2,18 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { useForm } from "react-hook-form"
 
-const { saveShippingZoneAction, listShippingMunicipalitiesAction, routerPush } = vi.hoisted(() => ({
-  saveShippingZoneAction: vi.fn(),
-  listShippingMunicipalitiesAction: vi.fn(),
-  routerPush: vi.fn(),
-}))
+const { saveShippingZoneAction, listShippingMunicipalitiesAction, searchShippingMunicipalitiesAction, routerPush } =
+  vi.hoisted(() => ({
+    saveShippingZoneAction: vi.fn(),
+    listShippingMunicipalitiesAction: vi.fn(),
+    searchShippingMunicipalitiesAction: vi.fn(),
+    routerPush: vi.fn(),
+  }))
 
 vi.mock("@/app/admin/settings/shipping/actions", () => ({
   saveShippingZoneAction,
   listShippingMunicipalitiesAction,
+  searchShippingMunicipalitiesAction,
 }))
 
 vi.mock("next/navigation", () => ({
@@ -28,8 +31,9 @@ beforeAll(() => {
 
 import { ZoneForm } from "@/app/admin/settings/shipping/components/zone-form"
 import { RateLadderField } from "@/app/admin/settings/shipping/components/rate-ladder-field"
+import type { Department } from "@/lib/shipping/locations-api"
 import type { ZoneEditorFormValues } from "@/lib/shipping/schemas"
-import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import type { ClaimedDestination, MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
 
 const ZONE: ShippingZoneRecord = {
   id: "zone-1",
@@ -46,9 +50,15 @@ const ZONE: ShippingZoneRecord = {
   },
 }
 
+const DEPARTMENTS: Department[] = [
+  { code: "05", name: "ANTIOQUIA" },
+  { code: "76", name: "VALLE DEL CAUCA" },
+]
+
 beforeEach(() => {
   vi.clearAllMocks()
   listShippingMunicipalitiesAction.mockResolvedValue([])
+  searchShippingMunicipalitiesAction.mockResolvedValue([])
 })
 
 describe("ZoneForm", () => {
@@ -76,6 +86,107 @@ describe("ZoneForm", () => {
 
     await waitFor(() => expect(saveShippingZoneAction).toHaveBeenCalled())
     expect(saveShippingZoneAction.mock.calls[0][1]).toBe("zone-route-param")
+  })
+})
+
+describe("ZoneForm destinations picker", () => {
+  it("renders a destination already claimed by another zone as disabled, naming the owning zone", () => {
+    const claimedDestinations: ClaimedDestination[] = [
+      { departmentCode: "05", municipalityCode: null, zoneName: "Costa Caribe" },
+    ]
+    render(
+      <ZoneForm
+        zoneId={null}
+        zone={null}
+        departments={DEPARTMENTS}
+        missingWeightProducts={[]}
+        claimedDestinations={claimedDestinations}
+      />,
+    )
+
+    expect(screen.getByText('Ya asignado a la zona "Costa Caribe"')).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeDisabled()
+    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).toBeEnabled()
+  })
+
+  it("selects every department at once with 'Seleccionar todos', and clears everything with 'Limpiar'", () => {
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Seleccionar todos" }))
+
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).toBeChecked()
+    expect(screen.getByText("2 destinos seleccionados")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Limpiar" }))
+
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).not.toBeChecked()
+    expect(screen.getByText("0 destinos seleccionados")).toBeInTheDocument()
+  })
+
+  it("skips a department already claimed whole by another zone when 'Seleccionar todos' runs", () => {
+    const claimedDestinations: ClaimedDestination[] = [
+      { departmentCode: "05", municipalityCode: null, zoneName: "Costa Caribe" },
+    ]
+    render(
+      <ZoneForm
+        zoneId={null}
+        zone={null}
+        departments={DEPARTMENTS}
+        missingWeightProducts={[]}
+        claimedDestinations={claimedDestinations}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Seleccionar todos" }))
+
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).toBeChecked()
+  })
+
+  it("selecting a whole department clears its municipios selected individually, so the two can never coexist for the same department", async () => {
+    listShippingMunicipalitiesAction.mockResolvedValue([
+      { id: 1, code: "05001", name: "MEDELLÍN", departmentCode: "05", departmentName: "ANTIOQUIA" },
+      { id: 2, code: "05002", name: "ABEJORRAL", departmentCode: "05", departmentName: "ANTIOQUIA" },
+    ])
+    saveShippingZoneAction.mockResolvedValue({ success: true })
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Ver municipios" })[0])
+    await screen.findByRole("checkbox", { name: "MEDELLÍN" })
+    fireEvent.click(screen.getByRole("checkbox", { name: "MEDELLÍN" }))
+    expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toBeChecked()
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "ANTIOQUIA" }))
+
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toBeDisabled()
+    expect(screen.getByRole("checkbox", { name: "ABEJORRAL" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "ABEJORRAL" })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText("Nombre de la zona"), { target: { value: "Zona Test" } })
+    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
+
+    await waitFor(() => expect(saveShippingZoneAction).toHaveBeenCalled())
+    expect(saveShippingZoneAction.mock.calls[0][0].destinations).toEqual([{ departmentCode: "05", municipalityCode: null }])
+  })
+
+  it("finds a municipio through the global search, disambiguated by department, and adds it on select", async () => {
+    searchShippingMunicipalitiesAction.mockResolvedValue([
+      { id: 3, code: "76001", name: "CALI", departmentCode: "76", departmentName: "VALLE DEL CAUCA" },
+    ])
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByText("Buscar municipio…"))
+    fireEvent.change(screen.getByPlaceholderText("Buscar municipio…"), { target: { value: "cali" } })
+
+    await waitFor(() => expect(searchShippingMunicipalitiesAction).toHaveBeenCalledWith("cali"), { timeout: 2000 })
+    const result = await screen.findByText("CALI (VALLE DEL CAUCA)")
+    fireEvent.click(result)
+
+    expect(screen.getByText("1 destinos seleccionados")).toBeInTheDocument()
   })
 })
 

--- a/tests/admin/shipping-zone-form.test.tsx
+++ b/tests/admin/shipping-zone-form.test.tsx
@@ -31,24 +31,11 @@ beforeAll(() => {
 
 import { ZoneForm } from "@/app/admin/settings/shipping/components/zone-form"
 import { RateLadderField } from "@/app/admin/settings/shipping/components/rate-ladder-field"
+import { translations } from "@/lib/i18n/translations"
 import type { Department } from "@/lib/shipping/locations-api"
 import type { ZoneEditorFormValues } from "@/lib/shipping/schemas"
-import type { ClaimedDestination, MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
-
-const ZONE: ShippingZoneRecord = {
-  id: "zone-1",
-  name: "Eje Cafetero",
-  destinations: [
-    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
-  ],
-  rateLadder: {
-    basis: "order_value",
-    ranges: [
-      { from: "0", to: "50000", amount: "5000" },
-      { from: "50000", to: "", amount: "0" },
-    ],
-  },
-}
+import type { ClaimedDestination, MissingWeightProduct } from "@/lib/supabase/shipping-zones-api"
+import { ZONE } from "./_helpers/shipping-zone-fixture"
 
 const DEPARTMENTS: Department[] = [
   { code: "05", name: "ANTIOQUIA" },
@@ -105,11 +92,50 @@ describe("ZoneForm destinations picker", () => {
     )
 
     expect(screen.getByText('Ya asignado a la zona "Costa Caribe"')).toBeInTheDocument()
-    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeDisabled()
-    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).toBeEnabled()
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).not.toHaveAttribute("aria-disabled")
   })
 
-  it("selects every department at once with 'Seleccionar todos', and clears everything with 'Limpiar'", () => {
+  it("connects a claimed checkbox to its reason through aria-describedby, and keeps the row reachable instead of using native disabled", () => {
+    const claimedDestinations: ClaimedDestination[] = [
+      { departmentCode: "05", municipalityCode: null, zoneName: "Costa Caribe" },
+    ]
+    render(
+      <ZoneForm
+        zoneId={null}
+        zone={null}
+        departments={DEPARTMENTS}
+        missingWeightProducts={[]}
+        claimedDestinations={claimedDestinations}
+      />,
+    )
+
+    const checkbox = screen.getByRole("checkbox", { name: "ANTIOQUIA" })
+    expect(checkbox).not.toBeDisabled()
+
+    const describedById = checkbox.getAttribute("aria-describedby")
+    expect(describedById).toBeTruthy()
+    expect(document.getElementById(describedById as string)).toHaveTextContent(
+      'Ya asignado a la zona "Costa Caribe"',
+    )
+
+    fireEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it("names the destinations group for assistive technology and wires its validation error to it", async () => {
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    const group = screen.getByRole("group", { name: "Destinos" })
+    expect(group).not.toHaveAttribute("aria-describedby")
+
+    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
+
+    const errorMessage = await screen.findByText("Agrega al menos un destino a la zona")
+    expect(group.getAttribute("aria-describedby")).toBe(errorMessage.id)
+  })
+
+  it("selects every department at once with 'Seleccionar todos', and clears everything with 'Limpiar' once confirmed", async () => {
     render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Seleccionar todos" }))
@@ -119,10 +145,26 @@ describe("ZoneForm destinations picker", () => {
     expect(screen.getByText("2 destinos seleccionados")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Limpiar" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Vaciar" }))
 
     expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).not.toBeChecked()
     expect(screen.getByRole("checkbox", { name: "VALLE DEL CAUCA" })).not.toBeChecked()
     expect(screen.getByText("0 destinos seleccionados")).toBeInTheDocument()
+  })
+
+  it("requires confirmation before 'Limpiar' wipes a non-empty destinations selection, and does nothing on cancel", async () => {
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Seleccionar todos" }))
+    fireEvent.click(screen.getByRole("button", { name: "Limpiar" }))
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA", hidden: true })).toBeChecked()
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }))
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeChecked()
   })
 
   it("skips a department already claimed whole by another zone when 'Seleccionar todos' runs", () => {
@@ -162,9 +204,9 @@ describe("ZoneForm destinations picker", () => {
 
     expect(screen.getByRole("checkbox", { name: "ANTIOQUIA" })).toBeChecked()
     expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toBeChecked()
-    expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toBeDisabled()
+    expect(screen.getByRole("checkbox", { name: "MEDELLÍN" })).toHaveAttribute("aria-disabled", "true")
     expect(screen.getByRole("checkbox", { name: "ABEJORRAL" })).toBeChecked()
-    expect(screen.getByRole("checkbox", { name: "ABEJORRAL" })).toBeDisabled()
+    expect(screen.getByRole("checkbox", { name: "ABEJORRAL" })).toHaveAttribute("aria-disabled", "true")
 
     fireEvent.change(screen.getByLabelText("Nombre de la zona"), { target: { value: "Zona Test" } })
     fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
@@ -187,6 +229,66 @@ describe("ZoneForm destinations picker", () => {
     fireEvent.click(result)
 
     expect(screen.getByText("1 destinos seleccionados")).toBeInTheDocument()
+  })
+
+  it("clears the previous query's results and shows the load-error state instead of 'Sin resultados' when a search rejects", async () => {
+    searchShippingMunicipalitiesAction.mockResolvedValueOnce([
+      { id: 1, code: "05001", name: "MEDELLÍN", departmentCode: "05", departmentName: "ANTIOQUIA" },
+    ])
+    render(<ZoneForm zoneId={null} zone={null} departments={DEPARTMENTS} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByText("Buscar municipio…"))
+    fireEvent.change(screen.getByPlaceholderText("Buscar municipio…"), { target: { value: "med" } })
+    await screen.findByText("MEDELLÍN (ANTIOQUIA)")
+
+    searchShippingMunicipalitiesAction.mockRejectedValueOnce(new Error("timeout"))
+    fireEvent.change(screen.getByPlaceholderText("Buscar municipio…"), { target: { value: "sopo" } })
+
+    await waitFor(() => expect(searchShippingMunicipalitiesAction).toHaveBeenCalledWith("sopo"), { timeout: 2000 })
+    expect(await screen.findByText(translations.es.shipping.zones.municipalitiesLoadError)).toBeInTheDocument()
+    expect(screen.queryByText("MEDELLÍN (ANTIOQUIA)")).not.toBeInTheDocument()
+    expect(screen.queryByText(translations.es.shipping.zones.noMunicipalitiesFound)).not.toBeInTheDocument()
+  })
+
+  it("connects a claimed search result to its reason for assistive technology", async () => {
+    searchShippingMunicipalitiesAction.mockResolvedValue([
+      { id: 3, code: "76001", name: "CALI", departmentCode: "76", departmentName: "VALLE DEL CAUCA" },
+    ])
+    const claimedDestinations: ClaimedDestination[] = [
+      { departmentCode: "76", municipalityCode: "76001", zoneName: "Costa Caribe" },
+    ]
+    render(
+      <ZoneForm
+        zoneId={null}
+        zone={null}
+        departments={DEPARTMENTS}
+        missingWeightProducts={[]}
+        claimedDestinations={claimedDestinations}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("Buscar municipio…"))
+    fireEvent.change(screen.getByPlaceholderText("Buscar municipio…"), { target: { value: "cali" } })
+
+    await waitFor(() => expect(searchShippingMunicipalitiesAction).toHaveBeenCalledWith("cali"), { timeout: 2000 })
+    const option = await screen.findByRole("option", { name: /CALI/ })
+
+    expect(option).toHaveAttribute("aria-disabled", "true")
+    const describedById = option.getAttribute("aria-describedby")
+    expect(describedById).toBeTruthy()
+    expect(document.getElementById(describedById as string)).toHaveTextContent(
+      'Ya asignado a la zona "Costa Caribe"',
+    )
+  })
+})
+
+describe("ZoneForm heading structure", () => {
+  it("renders the card title as a real, level-2 heading", () => {
+    render(<ZoneForm zoneId={null} zone={null} departments={[]} missingWeightProducts={[]} />)
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: translations.es.shipping.zones.formTitle }),
+    ).toBeInTheDocument()
   })
 })
 

--- a/tests/admin/shipping-zone-form.test.tsx
+++ b/tests/admin/shipping-zone-form.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { useForm } from "react-hook-form"
+
+const { saveShippingZoneAction, listShippingMunicipalitiesAction, routerPush } = vi.hoisted(() => ({
+  saveShippingZoneAction: vi.fn(),
+  listShippingMunicipalitiesAction: vi.fn(),
+  routerPush: vi.fn(),
+}))
+
+vi.mock("@/app/admin/settings/shipping/actions", () => ({
+  saveShippingZoneAction,
+  listShippingMunicipalitiesAction,
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.ResizeObserver = ResizeObserverStub
+})
+
+import { ZoneForm } from "@/app/admin/settings/shipping/components/zone-form"
+import { RateLadderField } from "@/app/admin/settings/shipping/components/rate-ladder-field"
+import type { ZoneEditorFormValues } from "@/lib/shipping/schemas"
+import type { MissingWeightProduct, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+
+const ZONE: ShippingZoneRecord = {
+  id: "zone-1",
+  name: "Eje Cafetero",
+  destinations: [
+    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
+  ],
+  rateLadder: {
+    basis: "order_value",
+    ranges: [
+      { from: "0", to: "50000", amount: "5000" },
+      { from: "50000", to: "", amount: "0" },
+    ],
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listShippingMunicipalitiesAction.mockResolvedValue([])
+})
+
+describe("ZoneForm", () => {
+  it("pre-fills the zone's current name when editing", () => {
+    render(<ZoneForm zoneId={ZONE.id} zone={ZONE} departments={[]} missingWeightProducts={[]} />)
+
+    expect(screen.getByDisplayValue("Eje Cafetero")).toBeInTheDocument()
+  })
+
+  it("submits a CREATE through saveShippingZoneAction when zoneId is null", async () => {
+    saveShippingZoneAction.mockResolvedValue({ success: true })
+    render(<ZoneForm zoneId={null} zone={ZONE} departments={[]} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
+
+    await waitFor(() => expect(saveShippingZoneAction).toHaveBeenCalled())
+    expect(saveShippingZoneAction.mock.calls[0][1]).toBeUndefined()
+  })
+
+  it("preserves the old dialog's create-vs-edit regression: submits an EDIT of the given zoneId, never a value derived from the zone record", async () => {
+    saveShippingZoneAction.mockResolvedValue({ success: true })
+    render(<ZoneForm zoneId="zone-route-param" zone={ZONE} departments={[]} missingWeightProducts={[]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
+
+    await waitFor(() => expect(saveShippingZoneAction).toHaveBeenCalled())
+    expect(saveShippingZoneAction.mock.calls[0][1]).toBe("zone-route-param")
+  })
+})
+
+function RateLadderHarness({
+  basis = "order_value",
+  ranges = [{ from: "0", to: "", amount: "" }],
+  missingWeightProducts = [],
+}: {
+  basis?: "flat" | "order_value" | "weight"
+  ranges?: { from: string; to: string; amount: string }[]
+  missingWeightProducts?: MissingWeightProduct[]
+}) {
+  const { control } = useForm<ZoneEditorFormValues>({
+    defaultValues: {
+      name: "",
+      destinations: [],
+      rateLadder: { basis, amount: "0", ranges },
+    },
+  })
+
+  return <RateLadderField control={control} missingWeightProducts={missingWeightProducts} />
+}
+
+describe("RateLadderField", () => {
+  it("adds and removes range rows", () => {
+    render(<RateLadderHarness />)
+
+    expect(screen.getAllByLabelText("Desde")).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole("button", { name: /Agregar rango/ }))
+    expect(screen.getAllByLabelText("Desde")).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Quitar rango" })[0])
+    expect(screen.getAllByLabelText("Desde")).toHaveLength(1)
+  })
+
+  it("cannot remove the last remaining range row", () => {
+    render(<RateLadderHarness />)
+
+    expect(screen.getByRole("button", { name: "Quitar rango" })).toBeDisabled()
+  })
+
+  it("warns when the ladder does not reach an open-ended last rung (D6's no-gaps rule)", () => {
+    render(<RateLadderHarness />)
+
+    fireEvent.change(screen.getByLabelText("Hasta"), { target: { value: "50000" } })
+    fireEvent.change(screen.getByLabelText("Monto"), { target: { value: "5000" } })
+
+    expect(screen.getByText(/último rango/)).toBeInTheDocument()
+  })
+
+  it("warns about an overlap when two ranges cover the same order-value band", () => {
+    render(
+      <RateLadderHarness
+        ranges={[
+          { from: "0", to: "30000", amount: "3000" },
+          { from: "20000", to: "", amount: "0" },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(/superponen/)).toBeInTheDocument()
+  })
+
+  // Isolated from any other fixture: pins the half-open boundary semantics
+  // (a shared endpoint is neither a gap nor an overlap) as its own case.
+  it("shows no warning when two ranges touch exactly at the boundary", () => {
+    render(
+      <RateLadderHarness
+        ranges={[
+          { from: "0", to: "20000", amount: "3000" },
+          { from: "20000", to: "", amount: "0" },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText(/superponen/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/vacío/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/último rango/)).not.toBeInTheDocument()
+  })
+
+  it("says nothing about missing weight for a non-weight basis, even with products missing it", () => {
+    render(<RateLadderHarness basis="order_value" missingWeightProducts={[{ id: "item-1", name: "Café Especial" }]} />)
+
+    expect(screen.queryByText("Faltan productos con peso cargado")).not.toBeInTheDocument()
+  })
+
+  it("lists products missing weight, with a link to each, for the weight basis (D8)", () => {
+    render(<RateLadderHarness basis="weight" missingWeightProducts={[{ id: "item-1", name: "Café Especial" }]} />)
+
+    expect(screen.getByText("Faltan productos con peso cargado")).toBeInTheDocument()
+    expect(screen.getByText(/Café Especial/)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Editar producto" })).toHaveAttribute("href", "/admin/products/item-1/edit")
+  })
+
+  // P1: nothing anywhere used to say a 0 amount means free shipping.
+  it("hints that a 0 Monto means free shipping for that range", () => {
+    render(<RateLadderHarness />)
+
+    expect(
+      screen.getByText("Un rango con Monto en 0 es envío gratis para ese tramo."),
+    ).toBeInTheDocument()
+  })
+
+  // P1: the row used to be a fixed 4-column grid with no breakpoint.
+  it("stacks a range row into two columns on narrow screens and back to four at sm", () => {
+    render(<RateLadderHarness />)
+
+    const rowContainer = screen.getByLabelText("Desde").closest("div")?.parentElement
+    expect(rowContainer).toHaveClass("grid-cols-2")
+    expect(rowContainer).toHaveClass("sm:grid-cols-[1fr_1fr_1fr_auto]")
+  })
+
+  // P0 (second half) + P1: the live gap/overlap indicator used to disappear
+  // the instant any row's amount was blank, and only ever showed the FIRST
+  // issue with the same neutral weight as an informational notice.
+  it("shows every gap/overlap issue as a destructive alert, surviving a still-blank row amount", () => {
+    render(
+      <RateLadderHarness
+        ranges={[
+          { from: "10000", to: "30000", amount: "" },
+          { from: "20000", to: "", amount: "0" },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(/primer rango/)).toBeInTheDocument()
+    expect(screen.getByText(/superponen/)).toBeInTheDocument()
+    expect(screen.getByRole("alert")).toHaveClass("text-destructive")
+  })
+})
+
+// P0: looseRateLadderFieldSchema never validates the ladder, so a blank or
+// invalid row only ever surfaces on submit -- these pin that it now lands on
+// the exact field RateLadderField renders, not just a generic toast.
+describe("ZoneForm ladder validation on save (P0)", () => {
+  it("flags the exact row field and blocks the save when a ladder amount is blank", async () => {
+    render(<ZoneForm zoneId={ZONE.id} zone={ZONE} departments={[]} missingWeightProducts={[]} />)
+
+    const amountInputs = screen.getAllByLabelText("Monto")
+    fireEvent.change(amountInputs[0], { target: { value: "" } })
+    fireEvent.click(screen.getByRole("button", { name: "Guardar zona" }))
+
+    await waitFor(() => expect(amountInputs[0]).toHaveAttribute("aria-invalid", "true"))
+    expect(await screen.findByText("El monto no puede ser negativo")).toBeInTheDocument()
+    expect(saveShippingZoneAction).not.toHaveBeenCalled()
+  })
+})

--- a/tests/admin/shipping-zone-screens.test.tsx
+++ b/tests/admin/shipping-zone-screens.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import type { ComponentProps, ReactElement, ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
@@ -42,31 +36,11 @@ vi.mock("@/app/admin/settings/shipping/actions", () => ({
 import CreateShippingZonePage from "@/app/admin/settings/shipping/zones/new/page"
 import EditShippingZonePage from "@/app/admin/settings/shipping/zones/[zoneId]/edit/page"
 import { ZoneForm } from "@/app/admin/settings/shipping/components/zone-form"
-import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+import { findElementOfType } from "./_helpers/find-element-of-type"
+import { ZONE } from "./_helpers/shipping-zone-fixture"
 
 const SERVICE = { marker: "service-client" }
 const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
-
-const ZONE: ShippingZoneRecord = {
-  id: "zone-1",
-  name: "Eje Cafetero",
-  destinations: [
-    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
-  ],
-  rateLadder: { basis: "flat", amount: "5000" },
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
-}
 
 function zoneFormOf(page: ReactNode) {
   return findElementOfType(page, ZoneForm) as ReactElement<ComponentProps<typeof ZoneForm>> | null

--- a/tests/admin/shipping-zone-screens.test.tsx
+++ b/tests/admin/shipping-zone-screens.test.tsx
@@ -1,0 +1,121 @@
+import {
+  Children,
+  isValidElement,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { authorizeActiveStoreAdmin, listDepartments, findMissingWeightProducts, listShippingZones, notFound, redirect } =
+  vi.hoisted(() => ({
+    authorizeActiveStoreAdmin: vi.fn(),
+    listDepartments: vi.fn(),
+    findMissingWeightProducts: vi.fn(),
+    listShippingZones: vi.fn(),
+    notFound: vi.fn(),
+    redirect: vi.fn(),
+  }))
+
+const { saveShippingZoneAction, listShippingMunicipalitiesAction } = vi.hoisted(() => ({
+  saveShippingZoneAction: vi.fn(),
+  listShippingMunicipalitiesAction: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/active-store", () => ({ authorizeActiveStoreAdmin }))
+vi.mock("@/lib/shipping/locations-api", () => ({ listDepartments }))
+vi.mock("@/lib/supabase/shipping-zones-api", () => ({ findMissingWeightProducts, listShippingZones }))
+vi.mock("next/navigation", () => ({ notFound, redirect }))
+vi.mock("@/app/admin/settings/shipping/actions", () => ({
+  saveShippingZoneAction,
+  listShippingMunicipalitiesAction,
+}))
+
+import CreateShippingZonePage from "@/app/admin/settings/shipping/zones/new/page"
+import EditShippingZonePage from "@/app/admin/settings/shipping/zones/[zoneId]/edit/page"
+import { ZoneForm } from "@/app/admin/settings/shipping/components/zone-form"
+import type { ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
+
+const SERVICE = { marker: "service-client" }
+const GRANT = { supabase: SERVICE, storeId: "store-1", userId: "user-1" }
+
+const ZONE: ShippingZoneRecord = {
+  id: "zone-1",
+  name: "Eje Cafetero",
+  destinations: [
+    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
+  ],
+  rateLadder: { basis: "flat", amount: "5000" },
+}
+
+function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
+  if (!isValidElement(node)) return null
+  if (node.type === type) return node
+
+  const children = (node.props as { children?: ReactNode }).children
+  for (const child of Children.toArray(children)) {
+    const found = findElementOfType(child, type)
+    if (found) return found
+  }
+  return null
+}
+
+function zoneFormOf(page: ReactNode) {
+  return findElementOfType(page, ZoneForm) as ReactElement<ComponentProps<typeof ZoneForm>> | null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authorizeActiveStoreAdmin.mockResolvedValue(GRANT)
+  listDepartments.mockResolvedValue([])
+  findMissingWeightProducts.mockResolvedValue([])
+  listShippingZones.mockResolvedValue([ZONE])
+})
+
+describe("CreateShippingZonePage", () => {
+  it("opens an empty form with no zone to pre-fill from", async () => {
+    const page = await CreateShippingZonePage()
+    const form = zoneFormOf(page)
+
+    expect(form?.props.zoneId).toBeNull()
+    expect(form?.props.zone).toBeNull()
+  })
+
+  it("redirects instead of loading when the active store admin gate denies access", async () => {
+    authorizeActiveStoreAdmin.mockResolvedValue({ error: "Acceso denegado", status: 403 })
+    redirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT")
+    })
+
+    await expect(CreateShippingZonePage()).rejects.toThrow("NEXT_REDIRECT")
+    expect(redirect).toHaveBeenCalledWith("/")
+  })
+})
+
+describe("EditShippingZonePage", () => {
+  it("loads the zone named by the route, not the first one of the store, and hands its id to the form", async () => {
+    const page = await EditShippingZonePage({ params: Promise.resolve({ zoneId: ZONE.id }) })
+    const form = zoneFormOf(page)
+
+    expect(form?.props.zoneId).toBe(ZONE.id)
+    expect(form?.props.zone).toBe(ZONE)
+    expect(notFound).not.toHaveBeenCalled()
+  })
+
+  it("scopes the lookup to the active store with the granted client", async () => {
+    await EditShippingZonePage({ params: Promise.resolve({ zoneId: ZONE.id }) })
+
+    expect(listShippingZones).toHaveBeenCalledWith(SERVICE, "store-1")
+  })
+
+  it("404s on a zoneId outside the active store instead of opening a blank form", async () => {
+    listShippingZones.mockResolvedValue([])
+    notFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND")
+    })
+
+    await expect(
+      EditShippingZonePage({ params: Promise.resolve({ zoneId: ZONE.id }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND")
+  })
+})

--- a/tests/admin/shipping-zone-screens.test.tsx
+++ b/tests/admin/shipping-zone-screens.test.tsx
@@ -7,15 +7,23 @@ import {
 } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { authorizeActiveStoreAdmin, listDepartments, findMissingWeightProducts, listShippingZones, notFound, redirect } =
-  vi.hoisted(() => ({
-    authorizeActiveStoreAdmin: vi.fn(),
-    listDepartments: vi.fn(),
-    findMissingWeightProducts: vi.fn(),
-    listShippingZones: vi.fn(),
-    notFound: vi.fn(),
-    redirect: vi.fn(),
-  }))
+const {
+  authorizeActiveStoreAdmin,
+  listDepartments,
+  findClaimedDestinations,
+  findMissingWeightProducts,
+  listShippingZones,
+  notFound,
+  redirect,
+} = vi.hoisted(() => ({
+  authorizeActiveStoreAdmin: vi.fn(),
+  listDepartments: vi.fn(),
+  findClaimedDestinations: vi.fn(),
+  findMissingWeightProducts: vi.fn(),
+  listShippingZones: vi.fn(),
+  notFound: vi.fn(),
+  redirect: vi.fn(),
+}))
 
 const { saveShippingZoneAction, listShippingMunicipalitiesAction } = vi.hoisted(() => ({
   saveShippingZoneAction: vi.fn(),
@@ -24,7 +32,7 @@ const { saveShippingZoneAction, listShippingMunicipalitiesAction } = vi.hoisted(
 
 vi.mock("@/lib/supabase/active-store", () => ({ authorizeActiveStoreAdmin }))
 vi.mock("@/lib/shipping/locations-api", () => ({ listDepartments }))
-vi.mock("@/lib/supabase/shipping-zones-api", () => ({ findMissingWeightProducts, listShippingZones }))
+vi.mock("@/lib/supabase/shipping-zones-api", () => ({ findClaimedDestinations, findMissingWeightProducts, listShippingZones }))
 vi.mock("next/navigation", () => ({ notFound, redirect }))
 vi.mock("@/app/admin/settings/shipping/actions", () => ({
   saveShippingZoneAction,
@@ -68,6 +76,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   authorizeActiveStoreAdmin.mockResolvedValue(GRANT)
   listDepartments.mockResolvedValue([])
+  findClaimedDestinations.mockResolvedValue([])
   findMissingWeightProducts.mockResolvedValue([])
   listShippingZones.mockResolvedValue([ZONE])
 })
@@ -79,6 +88,17 @@ describe("CreateShippingZonePage", () => {
 
     expect(form?.props.zoneId).toBeNull()
     expect(form?.props.zone).toBeNull()
+  })
+
+  it("loads the store's claimed destinations with no zone excluded, since there is no zone yet", async () => {
+    const claimed = [{ departmentCode: "05", municipalityCode: null, zoneName: "Zona Norte" }]
+    findClaimedDestinations.mockResolvedValue(claimed)
+
+    const page = await CreateShippingZonePage()
+    const form = zoneFormOf(page)
+
+    expect(findClaimedDestinations).toHaveBeenCalledWith(SERVICE, "store-1")
+    expect(form?.props.claimedDestinations).toBe(claimed)
   })
 
   it("redirects instead of loading when the active store admin gate denies access", async () => {
@@ -106,6 +126,12 @@ describe("EditShippingZonePage", () => {
     await EditShippingZonePage({ params: Promise.resolve({ zoneId: ZONE.id }) })
 
     expect(listShippingZones).toHaveBeenCalledWith(SERVICE, "store-1")
+  })
+
+  it("loads claimed destinations excluding the zone being edited, so its own current destinations never show as claimed", async () => {
+    await EditShippingZonePage({ params: Promise.resolve({ zoneId: ZONE.id }) })
+
+    expect(findClaimedDestinations).toHaveBeenCalledWith(SERVICE, "store-1", ZONE.id)
   })
 
   it("404s on a zoneId outside the active store instead of opening a blank form", async () => {

--- a/tests/admin/shipping-zones-section.test.tsx
+++ b/tests/admin/shipping-zones-section.test.tsx
@@ -25,24 +25,10 @@ beforeAll(() => {
   global.ResizeObserver = ResizeObserverStub
 })
 
-import { ShippingZonesSection } from "@/app/admin/settings/shipping/components/zone-editor"
+import { ShippingZonesSection } from "@/app/admin/settings/shipping/components/zones-section"
 import { translations } from "@/lib/i18n/translations"
 import type { ShippingZoneDestinationView, ShippingZoneRecord } from "@/lib/supabase/shipping-zones-api"
-
-const ZONE: ShippingZoneRecord = {
-  id: "zone-1",
-  name: "Eje Cafetero",
-  destinations: [
-    { departmentCode: "05", departmentName: "ANTIOQUIA", municipalityCode: "05001", municipalityName: "MEDELLÍN" },
-  ],
-  rateLadder: {
-    basis: "order_value",
-    ranges: [
-      { from: "0", to: "50000", amount: "5000" },
-      { from: "50000", to: "", amount: "0" },
-    ],
-  },
-}
+import { ZONE } from "./_helpers/shipping-zone-fixture"
 
 function destinationsInDepartment(departmentName: string, count: number): ShippingZoneDestinationView[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -133,5 +119,16 @@ describe("ShippingZonesSection", () => {
     expect(screen.getByText(translations.es.shipping.zones.sectionTitle)).toBeInTheDocument()
     expect(screen.getByText(translations.es.shipping.zones.unmatchedDestinationTitle)).toBeInTheDocument()
     expect(screen.queryByText(translations.es.shipping.zones.coordinateModeTitle)).not.toBeInTheDocument()
+  })
+
+  it("renders both section titles as real, level-2 headings", () => {
+    render(<ShippingZonesSection mode="own_rates" zones={[ZONE]} unmatchedDestinationAction="block" />)
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: translations.es.shipping.zones.sectionTitle }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: translations.es.shipping.zones.unmatchedDestinationTitle }),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/admin/store-settings-page.test.tsx
+++ b/tests/admin/store-settings-page.test.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react"
+import { type ComponentProps, type ReactElement } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { StoreIdentityPanel } from "@/app/admin/settings/components/store-identity-panel"
@@ -19,6 +13,7 @@ vi.mock("@/lib/supabase/active-store", () => ({ authorizeActiveStoreAdmin }))
 vi.mock("next/navigation", () => ({ redirect }))
 
 import StoreSettingsPage from "@/app/admin/settings/page"
+import { findElementOfType } from "./_helpers/find-element-of-type"
 
 const ACTIVE_STORE_ID = "store-1"
 
@@ -52,18 +47,6 @@ function createSupabaseMock(storeRow: { store_name: string; is_public: boolean; 
     return { select, eq, maybeSingle }
   })
   return { from }
-}
-
-function findElementOfType(node: ReactNode, type: unknown): ReactElement | null {
-  if (!isValidElement(node)) return null
-  if (node.type === type) return node
-
-  const children = (node.props as { children?: ReactNode }).children
-  for (const child of Children.toArray(children)) {
-    const found = findElementOfType(child, type)
-    if (found) return found
-  }
-  return null
 }
 
 describe("StoreSettingsPage", () => {

--- a/tests/checkout/guest-draft.test.ts
+++ b/tests/checkout/guest-draft.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  clearGuestCheckoutDraft,
+  readGuestCheckoutDraft,
+  saveGuestCheckoutDraft,
+} from "@/lib/checkout/guest-draft"
+
+describe("borrador del checkout de invitado", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("devuelve null cuando no hay nada guardado", () => {
+    expect(readGuestCheckoutDraft()).toBeNull()
+  })
+
+  it("sobrevive a la recarga con los campos ya escritos", () => {
+    saveGuestCheckoutDraft({
+      customer_first_name: "Nicolás",
+      customer_email: "nicolas@example.org",
+      shipping_city: "BOGOTÁ, D.C.",
+    })
+
+    expect(readGuestCheckoutDraft()).toMatchObject({
+      customer_first_name: "Nicolás",
+      customer_email: "nicolas@example.org",
+      shipping_city: "BOGOTÁ, D.C.",
+    })
+  })
+
+  it("se borra cuando el pedido se realiza", () => {
+    saveGuestCheckoutDraft({ customer_first_name: "Nicolás" })
+    clearGuestCheckoutDraft()
+
+    expect(readGuestCheckoutDraft()).toBeNull()
+  })
+
+  it("ignora un borrador corrupto en vez de romper el checkout", () => {
+    window.localStorage.setItem("osoria_checkout_guest_draft", "{no es json")
+
+    expect(readGuestCheckoutDraft()).toBeNull()
+  })
+})

--- a/tests/components/input-placeholder-contrast.test.tsx
+++ b/tests/components/input-placeholder-contrast.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { Input } from "@/components/ui/input"
+
+describe("Input placeholder", () => {
+  it("se atenúa con el token muted y además con opacidad", () => {
+    render(<Input placeholder="Juan" aria-label="nombre" />)
+
+    const input = screen.getByLabelText("nombre")
+    expect(input.className).toContain("placeholder:text-muted-foreground")
+    expect(input.className).toContain("placeholder:opacity-60")
+  })
+
+  it("atenúa el placeholder, nunca el input entero", () => {
+    render(<Input placeholder="Juan" defaultValue="Nicolás" aria-label="nombre" />)
+
+    const classes = screen.getByLabelText("nombre").className.split(/\s+/)
+    expect(classes).toContain("placeholder:opacity-60")
+    expect(classes.some((name) => /^opacity-\d+$/.test(name))).toBe(false)
+  })
+})

--- a/tests/lib/home-discount-popup-form-schema.test.ts
+++ b/tests/lib/home-discount-popup-form-schema.test.ts
@@ -79,3 +79,44 @@ describe("home discount popup form schema", () => {
     expect(result.success).toBe(true)
   })
 })
+
+describe("homeDiscountPopupFormSchema CTA destination", () => {
+  const redirectWithoutUrl = { ...validInput, ctaMode: "redirect" as const, ctaUrl: null }
+
+  it("rejects the redirect mode with no URL", () => {
+    const result = homeDiscountPopupFormSchema.safeParse(redirectWithoutUrl)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === "ctaUrl")).toBe(true)
+    }
+  })
+
+  it("rejects a URL that is not http(s)", () => {
+    const result = homeDiscountPopupFormSchema.safeParse({
+      ...redirectWithoutUrl,
+      ctaUrl: "javascript:alert(1)",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts the redirect mode with a valid URL", () => {
+    const result = homeDiscountPopupFormSchema.safeParse({
+      ...redirectWithoutUrl,
+      ctaUrl: "https://osoria.help/promos",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects the copy-coupon mode with no code", () => {
+    const result = homeDiscountPopupFormSchema.safeParse({
+      ...validInput,
+      ctaMode: "copy_coupon" as const,
+      coupon: "   ",
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/tests/orders/address-line-format.test.ts
+++ b/tests/orders/address-line-format.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { formatAddressLine } from "@/lib/orders/order-format"
+
+describe("formatAddressLine", () => {
+  it("omite las partes vacías en vez de dejar una coma huérfana", () => {
+    expect(formatAddressLine(["", "Colombia"])).toBe("Colombia")
+    expect(formatAddressLine([null, "Colombia"])).toBe("Colombia")
+    expect(formatAddressLine([undefined, "Colombia"])).toBe("Colombia")
+    expect(formatAddressLine(["   ", "Colombia"])).toBe("Colombia")
+  })
+
+  it("une con coma las partes que sí tienen valor", () => {
+    expect(formatAddressLine(["Carrera 10 #20-30", "BOGOTÁ, D.C."])).toBe(
+      "Carrera 10 #20-30, BOGOTÁ, D.C.",
+    )
+  })
+
+  it("devuelve cadena vacía cuando no hay ninguna parte", () => {
+    expect(formatAddressLine([null, undefined, ""])).toBe("")
+  })
+})

--- a/tests/products/untracked-inventory.test.ts
+++ b/tests/products/untracked-inventory.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATION = join(
+  process.cwd(),
+  "supabase/migrations/20260807000900_ecommerce_untracked_inventory_stays_put.sql",
+)
+
+describe("ecommerce.decrement_inventory", () => {
+  const sql = readFileSync(MIGRATION, "utf8")
+
+  it("deja quieto el contador de las variantes sin seguimiento", () => {
+    expect(sql).toContain("update ecommerce.item_variants")
+    expect(sql).toMatch(
+      /update ecommerce\.item_variants\s+set inventory_quantity = case\s+when track_inventory then inventory_quantity - v_quantity\s+else inventory_quantity\s+end/,
+    )
+  })
+
+  it("deja quieto el contador de los productos sin seguimiento", () => {
+    expect(sql).toMatch(
+      /update ecommerce\.store_items\s+set inventory_quantity = case\s+when track_inventory then inventory_quantity - v_quantity\s+else inventory_quantity\s+end/,
+    )
+  })
+
+  it("no vuelve a restar incondicionalmente en ninguna de las dos ramas", () => {
+    expect(sql).not.toMatch(/set inventory_quantity = inventory_quantity - v_quantity/)
+  })
+
+  it("conserva el WHERE que nunca bloquea una venta sin seguimiento", () => {
+    const guards = sql.match(/track_inventory = false or inventory_quantity >= v_quantity/g)
+    expect(guards).toHaveLength(2)
+  })
+})

--- a/tests/security/memberships-api.test.ts
+++ b/tests/security/memberships-api.test.ts
@@ -294,7 +294,7 @@ describe("listStoreMembers support signal", () => {
     const members = await listStoreMembers("store-1");
 
     expect(chains.store_users.select).toHaveBeenCalledWith(
-      "user_id, granted_by, user_profiles(email, first_name, last_name), store_user_roles(roles(role_name))",
+      "user_id, granted_by, user_profiles!store_users_user_id_fkey(email, first_name, last_name), store_user_roles(roles(role_name))",
     );
     expect(members).toEqual([
       expect.objectContaining({ userId: "super-1", role: "admin", isSupportAccess: true }),

--- a/tests/security/store-host-crossing.test.ts
+++ b/tests/security/store-host-crossing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { toPlatformAdminHost, toStoreHost } from "@/lib/utils/store-host"
+
+describe("toStoreHost", () => {
+  it("cruza del host de la consola al de la tienda conservando el puerto", () => {
+    expect(toStoreHost("tienda2", "admin.localhost:3000")).toBe("tienda2.localhost:3000")
+  })
+
+  it("cruza en el dominio real", () => {
+    expect(toStoreHost("default", "admin.osoria.help")).toBe("default.osoria.help")
+  })
+
+  it("es el espejo exacto de toPlatformAdminHost", () => {
+    const storeHost = toStoreHost("default", "admin.osoria.help")
+    expect(toPlatformAdminHost(storeHost)).toBe("admin.osoria.help")
+  })
+
+  it("normaliza el subdominio a minúsculas", () => {
+    expect(toStoreHost("  Default  ", "admin.osoria.help")).toBe("default.osoria.help")
+  })
+})
+
+describe("toStoreHost rejects anything that is not a DNS label", () => {
+  it.each(["evil.com/", "a@b", "tienda2:8080", "sub.dominio", "TIENDA_2", "", "-tienda"])(
+    "rejects %j",
+    (subdomain) => {
+      expect(() => toStoreHost(subdomain, "admin.osoria.help")).toThrow()
+    },
+  )
+
+  it("still accepts a real label", () => {
+    expect(toStoreHost("tienda-2", "admin.osoria.help")).toBe("tienda-2.osoria.help")
+  })
+})

--- a/tests/shipping/locations-api.test.ts
+++ b/tests/shipping/locations-api.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
-import { listDepartments, listMunicipalitiesByDepartment } from "@/lib/shipping/locations-api"
+import {
+  MUNICIPALITY_SEARCH_MIN_LENGTH,
+  listDepartments,
+  listMunicipalitiesByDepartment,
+  searchMunicipalities,
+} from "@/lib/shipping/locations-api"
 
 type CoLocationRow = {
   id: number
@@ -39,27 +44,46 @@ function createDivipolaDouble(coLocationRows: CoLocationRow[]) {
   }
 
   function select(relationRows: Record<string, unknown>[], columns: string) {
-    const filters: { column: string; value: unknown }[] = []
+    const equalityFilters: { column: string; value: unknown }[] = []
+    const ilikeFilters: { column: string; pattern: string }[] = []
     let sortColumn: string | null = null
+    let limitCount: number | null = null
+
+    function matches(row: Record<string, unknown>): boolean {
+      const matchesEquality = equalityFilters.every(({ column, value }) => row[column] === value)
+      const matchesIlike = ilikeFilters.every(({ column, pattern }) =>
+        String(row[column]).toLowerCase().includes(pattern.replace(/%/g, "").toLowerCase()),
+      )
+      return matchesEquality && matchesIlike
+    }
 
     const builder = {
       eq(column: string, value: unknown) {
-        filters.push({ column, value })
+        equalityFilters.push({ column, value })
+        return builder
+      },
+      ilike(column: string, pattern: string) {
+        ilikeFilters.push({ column, pattern })
         return builder
       },
       order(column: string) {
         sortColumn = column
         return builder
       },
+      limit(count: number) {
+        limitCount = count
+        return builder
+      },
       then(onFulfilled: (result: { data: unknown; error: null }) => unknown) {
-        const matched = relationRows.filter((row) => filters.every(({ column, value }) => row[column] === value))
+        const matched = relationRows.filter(matches)
         const sorted = sortColumn
           ? [...matched].sort((a, b) => (String(a[sortColumn as string]) < String(b[sortColumn as string]) ? -1 : 1))
           : matched
         // The row cap applies after ORDER BY, same as PostgREST's own
         // response slicing -- never before.
-        const paged = sorted.slice(0, POSTGREST_MAX_ROWS)
-        const projected = paged.map((row) => projectColumns(row, columns))
+        const capped = sorted.slice(0, POSTGREST_MAX_ROWS)
+        const limited = limitCount === null ? capped : capped.slice(0, limitCount)
+        const projected = limited.map((row) => projectColumns(row, columns))
         return Promise.resolve({ data: projected, error: null }).then(onFulfilled)
       },
     }
@@ -93,6 +117,27 @@ function coLocationRow(overrides: Partial<CoLocationRow> & Pick<CoLocationRow, "
     municipality_name: "MEDELLÍN",
     ...overrides,
   }
+}
+
+function buildDepartmentCatalog(departmentCount: number, municipiosPerDepartment: number): CoLocationRow[] {
+  const rows: CoLocationRow[] = []
+  let id = 1
+  for (let d = 1; d <= departmentCount; d++) {
+    const departmentCode = String(d).padStart(2, "0")
+    const departmentName = `DEPARTAMENTO ${departmentCode}`
+    for (let m = 1; m <= municipiosPerDepartment; m++) {
+      rows.push(
+        coLocationRow({
+          id: id++,
+          department_code: departmentCode,
+          department_name: departmentName,
+          municipality_code: `${departmentCode}${String(m).padStart(3, "0")}`,
+          municipality_name: `MUNICIPIO ${m}`,
+        }),
+      )
+    }
+  }
+  return rows
 }
 
 describe("listMunicipalitiesByDepartment", () => {
@@ -168,24 +213,7 @@ describe("listDepartments", () => {
   // simply never show.
   it("hits PostgREST's row cap when read off co_locations directly (reproduces Finding 1 -- must pass through co_departments instead)", async () => {
     const departmentCount = 40
-    const municipiosPerDepartment = 30
-    const rows: CoLocationRow[] = []
-    let id = 1
-    for (let d = 1; d <= departmentCount; d++) {
-      const departmentCode = String(d).padStart(2, "0")
-      const departmentName = `DEPARTAMENTO ${departmentCode}`
-      for (let m = 1; m <= municipiosPerDepartment; m++) {
-        rows.push(
-          coLocationRow({
-            id: id++,
-            department_code: departmentCode,
-            department_name: departmentName,
-            municipality_code: `${departmentCode}${String(m).padStart(3, "0")}`,
-            municipality_name: `MUNICIPIO ${m}`,
-          }),
-        )
-      }
-    }
+    const rows = buildDepartmentCatalog(departmentCount, 30)
     expect(rows.length).toBeGreaterThan(POSTGREST_MAX_ROWS)
 
     const client = createDivipolaDouble(rows)
@@ -194,5 +222,36 @@ describe("listDepartments", () => {
 
     expect(departments).toHaveLength(departmentCount)
     expect(departments.map((department) => department.code)).toContain("40")
+  })
+})
+
+describe("searchMunicipalities", () => {
+  it("finds a municipio past PostgREST's row cap, proving the filter runs in the database rather than after an unfiltered fetch (search variant of Finding 1)", async () => {
+    const rows = buildDepartmentCatalog(40, 30)
+    const needleIndex = rows.findIndex((row) => row.department_code === "40" && row.municipality_code === "40015")
+    rows[needleIndex] = { ...rows[needleIndex], municipality_name: "SANTUARIO DEL SOL" }
+    const client = createDivipolaDouble(rows)
+
+    const results = await searchMunicipalities("santuario", 50, client)
+
+    expect(results).toEqual([
+      { id: rows[needleIndex].id, code: "40015", name: "SANTUARIO DEL SOL", departmentCode: "40", departmentName: "DEPARTAMENTO 40" },
+    ])
+  })
+
+  it("sends a limit to the database, never returning more results than requested even with many matches", async () => {
+    const rows = buildDepartmentCatalog(5, 30)
+    const client = createDivipolaDouble(rows)
+
+    const results = await searchMunicipalities("municipio", 10, client)
+
+    expect(results.length).toBeLessThanOrEqual(10)
+  })
+
+  it("returns nothing for a query shorter than the minimum search length, without ever reaching the database", async () => {
+    const client = createDivipolaDouble([coLocationRow({ id: 1, municipality_name: "MEDELLÍN" })])
+    const tooShortQuery = "m".repeat(MUNICIPALITY_SEARCH_MIN_LENGTH - 1)
+
+    expect(await searchMunicipalities(tooShortQuery, 50, client)).toEqual([])
   })
 })

--- a/tests/shipping/zones-api.test.ts
+++ b/tests/shipping/zones-api.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 
-import { deleteShippingZone, listShippingZones, saveShippingZone, type SaveShippingZoneInput } from "@/lib/supabase/shipping-zones-api"
+import {
+  deleteShippingZone,
+  findClaimedDestinations,
+  listShippingZones,
+  saveShippingZone,
+  type SaveShippingZoneInput,
+} from "@/lib/supabase/shipping-zones-api"
 import { createShippingSupabase } from "./fake-supabase"
 
 const ANTIOQUIA_MEDELLIN = {
@@ -208,5 +214,41 @@ describe("deleteShippingZone", () => {
     const ownStoreResult = await deleteShippingZone(supabase as any, STORE_ID, "zone-1")
     expect(ownStoreResult.success).toBe(true)
     expect(tables.get("shipping_zones")).toHaveLength(1)
+  })
+})
+
+describe("findClaimedDestinations", () => {
+  it("names the owning zone for each destination already claimed by another zone of the same store", async () => {
+    const { supabase } = createShippingSupabase({
+      co_locations: [ANTIOQUIA_MEDELLIN],
+      shipping_zones: [
+        { id: "zone-north", store_id: STORE_ID, name: "Zona Norte" },
+        { id: "zone-south", store_id: STORE_ID, name: "Zona Sur" },
+      ],
+      shipping_zone_destinations: [
+        { id: "dest-1", zone_id: "zone-north", store_id: STORE_ID, department_code: "05", municipality_code: null },
+        { id: "dest-2", zone_id: "zone-south", store_id: STORE_ID, department_code: "76", municipality_code: "76001" },
+      ],
+    })
+
+    const claimed = await findClaimedDestinations(supabase as any, STORE_ID)
+
+    expect(claimed).toEqual([
+      { departmentCode: "05", municipalityCode: null, zoneName: "Zona Norte" },
+      { departmentCode: "76", municipalityCode: "76001", zoneName: "Zona Sur" },
+    ])
+  })
+
+  it("excludes the given zone's own destinations from what it reports as claimed", async () => {
+    const { supabase } = createShippingSupabase({
+      shipping_zones: [{ id: "zone-north", store_id: STORE_ID, name: "Zona Norte" }],
+      shipping_zone_destinations: [
+        { id: "dest-1", zone_id: "zone-north", store_id: STORE_ID, department_code: "05", municipality_code: null },
+      ],
+    })
+
+    const claimed = await findClaimedDestinations(supabase as any, STORE_ID, "zone-north")
+
+    expect(claimed).toEqual([])
   })
 })

--- a/tests/shipping/zones-api.test.ts
+++ b/tests/shipping/zones-api.test.ts
@@ -251,4 +251,34 @@ describe("findClaimedDestinations", () => {
 
     expect(claimed).toEqual([])
   })
+
+  it("throws when the zone-name lookup fails, instead of labelling every destination as an unknown zone", async () => {
+    const supabase = {
+      from: (table: string) => {
+        if (table === "shipping_zone_destinations") {
+          return {
+            select: () => ({
+              eq: () =>
+                Promise.resolve({
+                  data: [{ zone_id: "zone-north", department_code: "05", municipality_code: null }],
+                  error: null,
+                }),
+            }),
+          }
+        }
+        if (table === "shipping_zones") {
+          return {
+            select: () => ({
+              in: () => Promise.resolve({ data: null, error: { message: "statement timeout" } }),
+            }),
+          }
+        }
+        throw new Error(`unexpected table ${table}`)
+      },
+    }
+
+    await expect(findClaimedDestinations(supabase as any, STORE_ID)).rejects.toThrow(
+      "No se pudieron leer los nombres de las zonas",
+    )
+  })
 })


### PR DESCRIPTION
Cierra quince hallazgos de las dos rondas de QA sobre "Cumbre Dorada Café". Los cuatro que dependían de datos se verificaron contra producción por `psql`.

## Los cuatro que rompían el admin

**Pedidos invisibles** (H4) — `getSupabaseEcommerce()` devuelve un cliente de **navegador**. Invocado desde un Server Component no lleva cookies, así que la petición sale como `anon`; las políticas RLS de `ecommerce.orders` son `to authenticated`, de modo que la consulta no matcheaba ninguna política y devolvía **cero filas sin error**. Comprobado en producción: `set role anon` → 0, `postgres` → 5. `app/api/admin/orders/route.ts` ya pasaba el cliente autorizado; las páginas no seguían ese patrón. Ahora reenvían `authorization.supabase`, y `getOrderById` gana el `supabaseOverride` que `getOrders` y `getOrderByNumber` ya tenían.

**"Equipo" no cargaba** (H19) **y el detalle de tienda del super admin reventaba** (H10) — una sola causa. `20260718000100_ecommerce_privilege_separation.sql` añadió `store_users.granted_by → user_profiles(id)`, así que `store_users` referencia `user_profiles` **dos veces**; el embed pelado `user_profiles(...)` quedó ambiguo y PostgREST responde `PGRST201`. `listStoreMembers` lanzaba, y con ella `listStoreOwners`, que es lo que tumbaba el render del detalle de tienda. El embed ahora nombra el FK.

**Stock negativo** (H15) — `decrement_inventory` consultaba `track_inventory` **solo en el WHERE**, para no bloquear la venta, y restaba el contador igual. El WHERE decide si la línea pasa; el SET decide si el contador se mueve. Migración `20260807000900`.

## El resto

Columna Stock que mostraba `0` para inventario no rastreado (H1) · tope de cantidad fijo en 99 (H2) · UUID de categoría en el carrito (H3) · coma huérfana `, Colombia` (H13) · placeholders del checkout indistinguibles de valores reales (H11) · recargar el checkout borraba el formulario (H12) · producto desactivado desaparecía del admin sin filtro (H18) · el error de recuperación de contraseña hablaba de "registro" (H14) · "Mis pedidos" seguía visible tras cerrar sesión · "Entrar a tienda" no hacía nada · lupa sobre la ✕ nativa de `type="search"` · menú móvil que salía por el lado contrario a su icono · contenido que saltaba al abrir un panel lateral · título "Crear Nuevo Producto" · pop-up que guardaba un CTA de redirección sin URL.

Sobre **"Entrar a tienda"**: empujaba a `/admin` dentro del host de la consola, donde el proxy devuelve al listado toda ruta ajena al tier plataforma — de ahí el "no hace nada". Ahora navega al host de la tienda. **Consecuencia esperada:** las cookies son host-only por diseño, así que el super admin hace login una vez en ese subdominio. Es el precio de esa decisión, no una regresión.

## Verificación

`pnpm lint:full` 0 · `pnpm typecheck:full` 0 · `pnpm test` **312 archivos / 2628 tests** ✓ (medido con este cambio aislado).

Cobertura nueva: 7 archivos de test, 3 extendidos. Los dos primeros hallazgos se probaron en ambos sentidos — sin el arreglo fallan.

Revisión de seguridad: **limpia**, sin hallazgos. Se aplicó su única recomendación — validar la etiqueta DNS dentro de `toStoreHost` en vez de depender de un CHECK `NOT VALID`.

## Notas para quien revise

- **`pnpm typecheck` y `pnpm lint` no son la puerta real.** `tsconfig.quality.json` incluye solo cinco rutas y no cubre `components/` ni la mayor parte de `app/`; dejaron pasar dos errores de tipo reales que solo vio `typecheck:full`. Si el CI usa las variantes cortas, no está midiendo lo que parece.
- **`tests/security/memberships-api.test.ts` afirmaba el string de consulta defectuoso** y pasaba, porque el mock no emula la ambigüedad de PostgREST. Corregido.
- **La suite es inestable bajo carga**: en varias corridas fallaron por timeout `theme-custom-editor` y `login-password-recovery-entry`, ambos verdes en aislamiento y ajenos a este cambio. Deuda preexistente.
- **Residual aceptado**: el modal de cantidad abre al instante y corrige su tope cuando llega el stock, así que durante un momento muestra el techo de 99. La validación al confirmar sigue acotando.
- Requiere aplicar la migración: `pnpm supabase:reset` en local.

## Fuera de alcance, a propósito

Cuatro decisiones abiertas (registro con correo duplicado, recuperación en la consola de plataforma, limpieza del stock negativo ya existente en producción, y la convención de citas `D<n>` en comentarios) y cinco funcionalidades pedidas como bugs (filtro de pedidos por estado, categoría en línea, refresco de stock en vivo, gestión de imágenes, pasarelas de pago). H0 no reproduce contra el código.
