### PR TITLE
fix(theme): el catálogo de temas deja de llenarse con una fila por tienda

### DIFF
--- a/lib/theme-font/runtime-contract.ts
+++ b/lib/theme-font/runtime-contract.ts
@@ -78,7 +78,7 @@ export const DEFAULT_RUNTIME_THEME: RuntimeTheme = {
   sections: DEFAULT_RUNTIME_THEME_DEFINITION.sections,
 };
 
-const THEME_COLOR_KEYS: (keyof ThemeColors)[] = [
+export const THEME_COLOR_KEYS: (keyof ThemeColors)[] = [
   "primary",
   "secondary",
   "accent",

--- a/scripts/seed-default-store.mjs
+++ b/scripts/seed-default-store.mjs
@@ -19,8 +19,6 @@
 //     (compare_at_price), featured flags, and 3 combos
 //   - product images uploaded to the public `products` bucket
 //   - a designed home: ecommerce.component_styles (per-section look + copy),
-//     ecommerce.home_section_layout (section order/visibility), and a coffee
-//     theme in ecommerce.app_themes + ecommerce.app_theme_versions
 //
 // Default-store subdomain decision (evidence in proxy.ts + lib/utils/store.ts):
 //   The apex domain resolves the storefront through getStoreBySubdomain('default')
@@ -556,6 +554,8 @@ const COFFEE_COLORS_DARK = {
   muted: "#372A1D",
   mutedForeground: "#BBA98F",
 };
+
+const BASE_THEME_NAME = "Boutique";
 
 const COFFEE_THEME = {
   themeName: "Cumbre Dorada",
@@ -1351,13 +1351,8 @@ async function ensureHomeComposition(ecommerce, storeId) {
   );
 }
 
-// Seeds the coffee theme: an app_themes preset row (full 10-color light
-// palette) plus one CURRENT app_theme_versions row carrying the two-axis
-// definition in `variables` and the resolved font pairing in `fonts`. Idempotent
-// per store: re-running updates the existing coffee version in place (no history
-// growth) and respects the one-current-per-store partial-unique index.
 async function ensureTheme(ecommerce, storeId) {
-  const themeId = await ensureAppTheme(ecommerce);
+  const baseThemeId = await resolveBaseThemeId(ecommerce);
   const fontPairingId = await resolveFontPairingId(ecommerce, COFFEE_THEME.fontPairingName);
 
   // variables jsonb = ThemeDefinition; getActiveTheme lifts fontPairingId from
@@ -1370,7 +1365,7 @@ async function ensureTheme(ecommerce, storeId) {
     .from("app_theme_versions")
     .select("id")
     .eq("store_id", storeId)
-    .eq("theme_id", themeId)
+    .eq("theme_id", baseThemeId)
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle();
@@ -1388,7 +1383,7 @@ async function ensureTheme(ecommerce, storeId) {
 
     const { error } = await ecommerce
       .from("app_theme_versions")
-      .update({ variables, fonts, is_current: true, is_custom: false })
+      .update({ variables, fonts, is_current: true, is_custom: true })
       .eq("id", existing.id);
     if (error) throw new Error(`Could not update app_theme_versions: ${error.message}`);
   } else {
@@ -1402,46 +1397,32 @@ async function ensureTheme(ecommerce, storeId) {
     const { error } = await ecommerce.from("app_theme_versions").insert({
       id: crypto.randomUUID(),
       store_id: storeId,
-      theme_id: themeId,
+      theme_id: baseThemeId,
       variables,
       fonts,
       is_current: true,
-      is_custom: false,
+      is_custom: true,
     });
     if (error) throw new Error(`Could not insert app_theme_versions: ${error.message}`);
   }
 
   console.log(
-    `${LOG} theme applied: "${COFFEE_THEME.themeName}" (theme_id=${themeId}, fontPairingId=${fontPairingId ?? "null"}).`,
+    `${LOG} theme applied: "${COFFEE_THEME.themeName}" (theme_id=${baseThemeId}, fontPairingId=${fontPairingId ?? "null"}).`,
   );
 }
 
-// Upserts the coffee preset in the shared app_themes catalog by theme_name
-// (unique). `colors` is the full 10-color light palette so normalizeThemeRecord
-// accepts it. is_active stays false: per-store activation is via app_theme_versions.
-async function ensureAppTheme(ecommerce) {
-  const { data: existing, error: readError } = await ecommerce
-    .from("app_themes")
-    .select("id")
-    .eq("theme_name", COFFEE_THEME.themeName)
-    .maybeSingle();
-  if (readError) throw new Error(`Could not read app_themes: ${readError.message}`);
-
-  if (existing) {
-    const { error } = await ecommerce
-      .from("app_themes")
-      .update({ colors: COFFEE_COLORS_LIGHT, updated_at: nowIso() })
-      .eq("id", existing.id);
-    if (error) throw new Error(`Could not update app_themes: ${error.message}`);
-    return existing.id;
-  }
-
+async function resolveBaseThemeId(ecommerce) {
   const { data, error } = await ecommerce
     .from("app_themes")
-    .insert({ theme_name: COFFEE_THEME.themeName, colors: COFFEE_COLORS_LIGHT, is_active: false })
     .select("id")
-    .single();
-  if (error) throw new Error(`Could not insert app_themes: ${error.message}`);
+    .eq("theme_name", BASE_THEME_NAME)
+    .maybeSingle();
+  if (error) throw new Error(`Could not read app_themes: ${error.message}`);
+  if (!data?.id) {
+    throw new Error(
+      `Base theme "${BASE_THEME_NAME}" not found in ecommerce.app_themes; run migration 20260807000800_ecommerce_seed_base_theme_presets.sql first.`,
+    );
+  }
   return data.id;
 }
 

--- a/supabase/migrations/20260807000800_ecommerce_seed_base_theme_presets.sql
+++ b/supabase/migrations/20260807000800_ecommerce_seed_base_theme_presets.sql
@@ -1,0 +1,27 @@
+insert into ecommerce.app_themes (theme_name, colors, is_active)
+values
+  ('Tech', '{"primary":"#4a5568","secondary":"#5daba8","accent":"#5daba8","background":"#ffffff","foreground":"#1a1a1a","card":"#ffffff","cardForeground":"#1a1a1a","border":"#e2e8f0","muted":"#f7fafc","mutedForeground":"#718096"}'::jsonb, false),
+  ('Minimal', '{"primary":"#1b1b18","secondary":"#eceae5","accent":"#8a8574","background":"#f6f5f2","foreground":"#1b1b18","card":"#fdfdfb","cardForeground":"#1b1b18","border":"#dcdad1","muted":"#edece7","mutedForeground":"#7a776b"}'::jsonb, false),
+  ('Suave', '{"primary":"#ec6a80","secondary":"#fdeef0","accent":"#4faa98","background":"#fffdfb","foreground":"#4a3b34","card":"#ffffff","cardForeground":"#4a3b34","border":"#f2e7e2","muted":"#f8f1ee","mutedForeground":"#a2908a"}'::jsonb, false),
+  ('Bold', '{"primary":"#0a0a0a","secondary":"#f0f0f0","accent":"#ff2d55","background":"#ffffff","foreground":"#0a0a0a","card":"#ffffff","cardForeground":"#0a0a0a","border":"#0a0a0a","muted":"#ededed","mutedForeground":"#4d4d4d"}'::jsonb, false),
+  ('Boutique', '{"primary":"#b0603f","secondary":"#f2e5d5","accent":"#7d8b57","background":"#fbf4ec","foreground":"#4a3527","card":"#fffaf3","cardForeground":"#4a3527","border":"#e7d7c3","muted":"#f0e4d4","mutedForeground":"#997f66"}'::jsonb, false)
+on conflict (theme_name) do nothing;
+
+update ecommerce.app_theme_versions
+set theme_id = (select id from ecommerce.app_themes where theme_name = 'Boutique'),
+    is_custom = true
+where theme_id = (select id from ecommerce.app_themes where theme_name = 'Cumbre Dorada');
+
+do $$
+begin
+  if exists (
+    select 1
+    from ecommerce.app_theme_versions v
+    join ecommerce.app_themes t on t.id = v.theme_id
+    where t.theme_name in ('Cumbre Dorada', 'default')
+  ) then
+    raise exception 'app_theme_versions still references a non-base app_themes row (Cumbre Dorada/default); refusing to delete';
+  end if;
+end $$;
+
+delete from ecommerce.app_themes where theme_name in ('Cumbre Dorada', 'default');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,3 +1,2 @@
 -- Safe local/demo seed only. Never put production data here.
-insert into ecommerce.app_themes (theme_name, colors, is_active) values ('default', '{"primary":"#111827","secondary":"#f59e0b","background":"#ffffff","foreground":"#111827"}'::jsonb, true) on conflict (theme_name) do nothing;
 insert into ecommerce.app_fonts (font_name, font_family, font_display_name, google_font_url, css_font_family, is_active) values ('system', 'system-ui', 'System UI', null, 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', true) on conflict (font_name) do nothing;

--- a/tests/quality/theme-base-catalog.test.ts
+++ b/tests/quality/theme-base-catalog.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { THEME_PRESETS } from "@/lib/theme-font/theme-presets";
+import { THEME_COLOR_KEYS } from "@/lib/theme-font/runtime-contract";
+
+const MIGRATIONS_DIR = join(process.cwd(), "supabase/migrations");
+const APP_THEMES_TUPLE = /\(\s*'([^']+)'\s*,\s*'([^']*)'::jsonb\s*,\s*(?:true|false)\s*\)/g;
+
+function seededThemeColorsByName(): Record<string, unknown> {
+  const insertStatements = readdirSync(MIGRATIONS_DIR)
+    .filter((entry) => entry.endsWith(".sql"))
+    .map((entry) => readFileSync(join(MIGRATIONS_DIR, entry), "utf8"))
+    .join("\n")
+    .match(/insert into ecommerce\.app_themes[\s\S]*?;/g) ?? [];
+
+  const colorsByName: Record<string, unknown> = {};
+  for (const statement of insertStatements) {
+    for (const [, themeName, colorsJson] of statement.matchAll(APP_THEMES_TUPLE)) {
+      colorsByName[themeName] = JSON.parse(colorsJson);
+    }
+  }
+
+  return colorsByName;
+}
+
+describe("the base theme catalog is reproducible from the repo's own SQL", () => {
+  const seededColors = seededThemeColorsByName();
+  const presetNames = Object.keys(THEME_PRESETS);
+
+  it.each(presetNames)("seeds an ecommerce.app_themes row for the %s preset", (presetName) => {
+    expect(seededColors[presetName]).toBeDefined();
+  });
+
+  it.each(presetNames)(
+    "gives the %s preset's seeded row all 10 ThemeColors keys",
+    (presetName) => {
+      const colors = seededColors[presetName] as Record<string, unknown> | undefined;
+
+      for (const key of THEME_COLOR_KEYS) {
+        expect(typeof colors?.[key]).toBe("string");
+        expect((colors?.[key] as string | undefined)?.length).toBeGreaterThan(0);
+      }
+    },
+  );
+});


### PR DESCRIPTION
`ecommerce.app_themes` es el **catálogo de presets base**, pero se estaba usando como almacenamiento por tienda. Estado actual en producción:

```
 id |  theme_name   | is_active
----+---------------+-----------
  2 | Cumbre Dorada | f
  1 | default       | t
```

Dos filas, ninguna es un preset. El selector de temas no tenía nada real que ofrecer, y el catálogo iba a crecer una fila por cada tienda nueva.

## Qué cambia

**Migración `20260807000800`** — siembra los cinco presets base (Tech, Minimal, Suave, Bold, Boutique) con su paleta completa de 10 colores; reapunta la versión de tema de Cumbre Dorada al preset **Boutique** marcándola `is_custom = true`; y solo entonces borra las dos filas por tienda. El `delete` va detrás de una guarda que lanza excepción si alguna versión todavía las referencia, así que no puede dejar una versión huérfana.

**`scripts/seed-default-store.mjs`** — resuelve el preset base por nombre (`resolveBaseThemeId`) en vez de crear el suyo propio. Si la migración no está aplicada, falla con un mensaje que la nombra en vez de crear silenciosamente otra fila de catálogo.

**`supabase/seed.sql`** — deja de sembrar el tema `default`.

**`tests/quality/theme-base-catalog.test.ts`** — congela el contrato: cada preset de `THEME_PRESETS` tiene su fila sembrada en el SQL del repo, con las 10 claves de `ThemeColors`. Es lo que impide que el catálogo del código y el de la base se separen otra vez.

## La apariencia no cambia

Los colores que se renderizan viven en `app_theme_versions.variables` (`colorsLight` / `colorsDark`), que la migración no toca. Solo cambia a qué fila del catálogo apunta la versión y su marca `is_custom`.

## Verificación

`pnpm lint:full` 0 · `pnpm typecheck:full` 0 · `pnpm test` **304 archivos / 2561 tests** ✓ (rama medida contra `New-Features`, sin el lote de QA).

## Orden con el otro PR

Independiente de #79 — no comparten archivos. Las dos migraciones (`000800` aquí, `000900` allá) tampoco se tocan entre sí, pero por número esta va primero.
